### PR TITLE
More verbose output on NoSuchPortException

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -639,7 +639,7 @@ public class ZWaveController {
 
 			logger.info("Serial port is initialized");
 		} catch (NoSuchPortException e) {
-			logger.error(e.getLocalizedMessage());
+			logger.error(String.format("Port %s does not exist", serialPortName));
 			throw new SerialInterfaceException(e.getLocalizedMessage(), e);
 		} catch (PortInUseException e) {
 			logger.error(e.getLocalizedMessage());


### PR DESCRIPTION
Made output more verbose according to the JavaDoc of CommPortIdentifier.getPortIdentifier why a NoSuchPortException could be thrown.
