### PR TITLE
Fix potential null pointer exception if using incorrect interface

### DIFF
--- a/bundles/binding/org.openhab.binding.owserver/src/main/java/org/openhab/binding/owserver/internal/OWServerBinding.java
+++ b/bundles/binding/org.openhab.binding.owserver/src/main/java/org/openhab/binding/owserver/internal/OWServerBinding.java
@@ -212,6 +212,8 @@ public class OWServerBinding extends
 					if (server == null) {
 						needsUpdate = false;
 						logger.error("Unknown OW server referenced: "+unit);
+						
+						continue;
 					}
 					else {
 						age = System.currentTimeMillis() - server.lastUpdate;


### PR DESCRIPTION
Fixes a bug with a possible null pointer exception.
This simply adds a "continue" following a null pointer check to stop the pointer being used. It's only a problem if an unknown interface name is used, so it probably doesn't show up for most users.
