### PR TITLE
Added lastUpdated/lastChanged tracking to core item framework

### DIFF
--- a/bundles/core/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/core/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -30,6 +30,7 @@ package org.openhab.core.items;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -61,6 +62,9 @@ abstract public class GenericItem implements Item {
 	
 	protected State state = UnDefType.NULL;
 	
+	protected Date lastUpdated;
+	protected Date lastChanged;
+	
 	public GenericItem(String name) {
 		this.name = name;
 	}
@@ -83,6 +87,20 @@ abstract public class GenericItem implements Item {
 		}
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
+	public Date getLastUpdated() {
+		return lastUpdated;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public Date getLastChanged() {
+		return lastChanged;
+	}
+
 	public void initialize() {}
 	
 	public void dispose() {
@@ -115,8 +133,17 @@ abstract public class GenericItem implements Item {
 	}
 	
 	public void setState(State state) {
+		// update the internal state variable
 		State oldState = this.state;
 		this.state = state;
+		
+		// update the internal updated/changed variables
+		lastUpdated = new Date();
+		if (!oldState.equals(state)) {
+			lastChanged = lastUpdated;
+		}
+
+		// notify any listeners of this event
 		notifyListeners(oldState, state);
 	}
 

--- a/bundles/core/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
+++ b/bundles/core/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
@@ -28,6 +28,7 @@
  */
 package org.openhab.core.items;
 
+import java.util.Date;
 import java.util.List;
 
 import org.openhab.core.types.Command;
@@ -49,7 +50,7 @@ public interface Item {
 	 * @return the current state
 	 */
 	public State getState();
-
+	
 	/**
 	 * returns the current state of the item as a specific type
 	 * 
@@ -57,6 +58,20 @@ public interface Item {
 	 * null, if state cannot be provided as the requested type 
 	 */
 	public State getStateAs(Class<? extends State> typeClass);
+
+	/**
+	 * returns the date this item was last updated
+	 * 
+	 * @return the date this item was last updated
+	 */
+	public Date getLastUpdated();
+	
+	/**
+	 * returns the date this item was last changed
+	 * 
+	 * @return the date this item was last changed
+	 */
+	public Date getLastChanged();
 
 	/**
 	 * returns the name of the item
@@ -74,7 +89,6 @@ public interface Item {
 	 * @return a list of data types that can be used to update the item state
 	 */
 	public List<Class<? extends State>> getAcceptedDataTypes();
-	
 	
 	/**
 	 * <p>This method provides a list of all command types that can be used for this item</p>


### PR DESCRIPTION
Kai/Thomas - this is a change to some core code so will need close inspection! It is a simple addition to the Item framework which should allow much easier tracking of when an item was last updated/changed. This can be partly achieved already using the persistence framework, but for things like temp sensors which are updated very frequently persistence would mean a large data store, whereas this simple change allows you to check if a sensor has been active recently. Also - not even sure if the persistence stuff currently supports persisting 'updates only'? Feel free to reject if you feel this isn't in line with your design, but it would be useful to a few of us to include this simple change.
