### PR TITLE
Fix for HTTP binding startup sequence bug

### DIFF
--- a/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpBinding.java
+++ b/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpBinding.java
@@ -333,9 +333,9 @@ public class HttpBinding extends AbstractActiveBinding<HttpBindingProvider> impl
 	 * @return true if a valid HTTP request, false otherwise
 	 */
 	private boolean isValidUrl(String url) {
-		if (StringUtils.startsWith(url, "http://"))
+		if (StringUtils.startsWithIgnoreCase(url, "http://"))
 			return true;
-		if (StringUtils.startsWith(url, "https://"))
+		if (StringUtils.startsWithIgnoreCase(url, "https://"))
 			return true;
 		
 		return false;


### PR DESCRIPTION
Was seeing exceptions in my openHAB log on startup after adding some 'cached' HTTP item bindings. The reason being the binding was being marked 'configured' before the config had been loaded and thus the cache ids were being treated as URLs.
