### PR TITLE
Modified "historicState" to return HistoricItem as per other extensions

### DIFF
--- a/bundles/core/org.openhab.core.persistence.test/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/core/org.openhab.core.persistence.test/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -24,10 +24,10 @@ import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.test.TestPersistenceService;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
-import org.openhab.core.types.UnDefType;
 
 /**
  * @author Kai Kreuzer
+ * @author Chris Jackson
  * @since 1.1.0
  */
 public class PersistenceExtensionsTest {
@@ -60,17 +60,17 @@ public class PersistenceExtensionsTest {
 	
 	@Test
 	public void testHistoricState() {
-		State state = PersistenceExtensions.historicState(item, new DateMidnight(2012, 1, 1), "test");
-		assertEquals("2012", state.toString());
+		HistoricItem historicItem = PersistenceExtensions.historicState(item, new DateMidnight(2012, 1, 1), "test");
+		assertEquals("2012", historicItem.getState().toString());
 
-		state = PersistenceExtensions.historicState(item, new DateMidnight(2011, 12, 31), "test");
-		assertEquals("2011", state.toString());
+		historicItem = PersistenceExtensions.historicState(item, new DateMidnight(2011, 12, 31), "test");
+		assertEquals("2011", historicItem.getState().toString());
 
-		state = PersistenceExtensions.historicState(item, new DateMidnight(2011, 1, 1), "test");
-		assertEquals("2011", state.toString());
+		historicItem = PersistenceExtensions.historicState(item, new DateMidnight(2011, 1, 1), "test");
+		assertEquals("2011", historicItem.getState().toString());
 
-		state = PersistenceExtensions.historicState(item, new DateMidnight(2000, 1, 1), "test");
-		assertEquals("2000", state.toString());
+		historicItem = PersistenceExtensions.historicState(item, new DateMidnight(2000, 1, 1), "test");
+		assertEquals("2000", historicItem.getState().toString());
 	}
 
 	@Test


### PR DESCRIPTION
As mentioned in the other request, whenever I upload the persistence extension file to github, it shows all lines changed - locally I don't see this. Maybe there's something "hidden" in the file (line terminations or something) that github doesn't like?

This is a new branch taken from the latest openhab master (with the latest license information) and GitHub does say it is able to merge automatically so hopefully it's ok. 
