### PR TITLE
Mysql error handling in event of failure to create table

### DIFF
--- a/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
@@ -222,7 +222,7 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 		// The item needs to be removed from the index table to avoid duplicates
 		if(sqlTables.containsKey(tableName) == false) {
 			logger.error("mySQL: Item '" + itemName + "' was not added to the table - removing index");
-			sqlCmd = new String("DELETE FROM Items WHERE ItemName=" + itemName);
+			sqlCmd = new String("DELETE FROM Items WHERE ItemName='" + itemName+"'");
 			logger.debug("SQL: " + sqlCmd);
 	
 			try {


### PR DESCRIPTION
This makes two changes to the mySQL persistence service -:
1) If there is a error creating a table, then the item is removed from the "Items" table to avoid duplication in the "Items" table.
2) DateTime types have the type defined as DATETIME(3) which allows millisecond support for versions of mySQL 5.6 and above.
