### PR TITLE
ZWAVE Update serialisation folder to only use the major/minor part of the version

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
@@ -50,7 +50,8 @@ public class ZWaveNodeSerializer {
 	 */
 	public ZWaveNodeSerializer() {
 		logger.trace("Initializing ZWaveNodeSerializer.");
-		this.versionedFolderName = String.format("%s/%s/", FOLDER_NAME, ZWaveActivator.getVersion());
+		this.versionedFolderName = String.format("%s/%d.%d/", FOLDER_NAME, 
+				ZWaveActivator.getVersion().getMajor(), ZWaveActivator.getVersion().getMinor());
 
 		File folder = new File(versionedFolderName);
 		// create path for serialization.


### PR DESCRIPTION
This changes the serialise folder from etc/zwave/full-version to etc/zwave/major.minor

The problem with the current system is during development, every compilation of the binding gets a new version number, and it means that saved data is never used since it's saved in a folder in the previous version.

Jan - one for you :)
