### PR TITLE
Update class path to remove error indicator from Eclipse

### DIFF
--- a/bundles/binding/org.openhab.binding.heatmiser/.classpath
+++ b/bundles/binding/org.openhab.binding.heatmiser/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/bundles/binding/org.openhab.binding.heatmiser/build.properties
+++ b/bundles/binding/org.openhab.binding.heatmiser/build.properties
@@ -1,5 +1,4 @@
-source.. = src/main/java/,\
-           src/main/resources/
+source.. = src/main/java/
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/


### PR DESCRIPTION
This just removes the resource path from the classpath to stop the error in Eclipse.
