### PR TITLE
ZWave XML - add delete method to NodeSerialiser to allow the file for a deleted node to be removed.

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
@@ -143,4 +143,18 @@ public class ZWaveNodeSerializer {
 			return null;
 		}
 	}
+	
+	/**
+	 * Deletes the persistence store for the specified node.
+	 * 
+	 * @param nodeId The node ID to remove
+	 * @return true if the file was deleted
+	 */
+	public boolean DeleteNode(int nodeId) {
+		synchronized (stream) {
+			File file = new File(this.versionedFolderName, String.format("node%d.xml", nodeId));
+
+			return file.delete();
+		}
+	}
 }


### PR DESCRIPTION
This adds a simple method to delete an existing XML file used in the zWave XML serialisation.
