### PR TITLE
Rest mapping fix

### DIFF
--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/resources/SitemapResource.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/resources/SitemapResource.java
@@ -333,7 +333,8 @@ public class SitemapResource {
 					}
 					else {
 						mappingBean.command = mapping.getCmd();
-					}				}
+					}				
+				}
 				else {
 					mappingBean.command = mapping.getCmd();
 				}


### PR DESCRIPTION
This corrects a bug that was introduced with the sitemap updates. An addition was made to remove quotes around commands, and this actually meant no command was provide in the REST interface if there were not quotes.
