### PR TITLE
Add a standard set of colours to sitemaps

### DIFF
--- a/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/items/ItemUIRegistryImpl.java
@@ -782,6 +782,11 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
 		if(colorString.startsWith("\"") && colorString.endsWith("\""))
 			colorString = colorString.substring(1, colorString.length()-1);
+		
+		// Check if the color is a "standard" color - if so, we convert to the CSS ("#xxxxxx") format
+		OpenhabColors stdColor = OpenhabColors.fromString(colorString);
+		if(stdColor != null)
+			colorString = stdColor.toString();
 
 		return colorString;
 	}
@@ -872,6 +877,34 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 			    }
 			    return null;
 			  }
+
+		public String toString() {
+			return this.value;
+		}
+	}
+
+	enum OpenhabColors {
+		MAROON("#800000"),RED("#ff0000"),ORANGE("#ffa500"),YELLOW("#ffff00"),OLIVE("#808000"),
+		PURPLE("#800080"),FUCHSIA("#ff00ff"),WHITE("#ffffff"),LIME("#00ff00"),GREEN("#008000"),
+		NAVY("#000080"),BLUE("#0000ff"),AQUA("#00ffff"),TEAL("#008080"),BLACK("#000000"),
+		SILVER("#c0c0c0"),GRAY("#808080");
+
+		private String value;
+
+		private OpenhabColors(String value) {
+			this.value = value;
+		}
+
+		public static OpenhabColors fromString(String text) {
+			if (text != null) {
+				for (OpenhabColors c : OpenhabColors.values()) {
+					if (text.equalsIgnoreCase(c.name())) {
+						return c;
+					}
+				}
+			}
+			return null;
+		}
 
 		public String toString() {
 			return this.value;


### PR DESCRIPTION
This adds a standard set of colors to sitemaps, and translates these colors within the openhab UI to the CSS format. Any other color/name/definition that someone may want to use as a color will be passed straight through without modification.

The text below is proposed for the wiki...

openHAB supports a standard set of colors, based on the CSS definitions. This is a set of 17 colors that should be supported by any UI. The colors are defined by name, and within openHAB they are translated to the CSS color format (ie "#xxxxxx"). This should ensure a standard interface for these colors.

Below is a list of the standard colors and their respective CSS definitions. Note that case is not important.

| Name used in sitemap | Color provided in REST interface |
| --- | --- |
| MAROON | #800000 |
| RED | #ff0000 |
| ORANGE | #ffa500 |
| YELLOW | #ffff00 |
| OLIVE | #808000 |
| PURPLE | #800080 |
| FUCHSIA | #ff00ff |
| WHITE | #ffffff |
| LIME | #00ff00 |
| GREEN | #008000 |
| NAVY | #000080 |
| BLUE | #0000ff |
| AQUA | #00ffff |
| TEAL | #008080 |
| BLACK | #000000 |
| SILVER | #c0c0c0 |
| GRAY | #808080 |

For any color other than those defined above, _"color"_ is passed directly through to the UI, so its exact implementation is up to the UI. It is generally expected that valid HTML colors can be used (eg "green", "red", "#334455") but a UI could for example define abstract colors that are defined internally depending on the theme. For example, "warning" could be defined and used in a UI dependant way, but there is currently no standardisation of these terms.
