### PR TITLE
Mqttitude update - added support for upcoming 'region' feature in apps

### DIFF
--- a/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/MqttitudeBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/MqttitudeBindingProvider.java
@@ -1,30 +1,10 @@
 /**
- * openHAB, the open Home Automation Bus.
- * Copyright (C) 2010-2013, openHAB.org <admin@openhab.org>
+ * Copyright (c) 2010-2013, openHAB.org and others.
  *
- * See the contributors.txt file in the distribution for a
- * full listing of individual contributors.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Additional permission under GNU GPL version 3 section 7
- *
- * If you modify this Program, or any covered work, by linking or
- * combining it with Eclipse (or a modified version of that library),
- * containing parts covered by the terms of the Eclipse Public License
- * (EPL), the licensors of this Program grant you additional permission
- * to convey the resulting work.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.mqttitude;
 

--- a/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/Location.java
+++ b/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/Location.java
@@ -1,30 +1,10 @@
 /**
- * openHAB, the open Home Automation Bus.
- * Copyright (C) 2010-2013, openHAB.org <admin@openhab.org>
+ * Copyright (c) 2010-2013, openHAB.org and others.
  *
- * See the contributors.txt file in the distribution for a
- * full listing of individual contributors.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Additional permission under GNU GPL version 3 section 7
- *
- * If you modify this Program, or any covered work, by linking or
- * combining it with Eclipse (or a modified version of that library),
- * containing parts covered by the terms of the Eclipse Public License
- * (EPL), the licensors of this Program grant you additional permission
- * to convey the resulting work.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.mqttitude.internal;
 

--- a/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeActivator.java
+++ b/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeActivator.java
@@ -1,30 +1,10 @@
 /**
- * openHAB, the open Home Automation Bus.
- * Copyright (C) 2010-2013, openHAB.org <admin@openhab.org>
+ * Copyright (c) 2010-2013, openHAB.org and others.
  *
- * See the contributors.txt file in the distribution for a
- * full listing of individual contributors.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Additional permission under GNU GPL version 3 section 7
- *
- * If you modify this Program, or any covered work, by linking or
- * combining it with Eclipse (or a modified version of that library),
- * containing parts covered by the terms of the Eclipse Public License
- * (EPL), the licensors of this Program grant you additional permission
- * to convey the resulting work.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.mqttitude.internal;
 

--- a/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeBinding.java
+++ b/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeBinding.java
@@ -1,30 +1,10 @@
 /**
- * openHAB, the open Home Automation Bus.
- * Copyright (C) 2010-2013, openHAB.org <admin@openhab.org>
+ * Copyright (c) 2010-2013, openHAB.org and others.
  *
- * See the contributors.txt file in the distribution for a
- * full listing of individual contributors.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Additional permission under GNU GPL version 3 section 7
- *
- * If you modify this Program, or any covered work, by linking or
- * combining it with Eclipse (or a modified version of that library),
- * containing parts covered by the terms of the Eclipse Public License
- * (EPL), the licensors of this Program grant you additional permission
- * to convey the resulting work.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.mqttitude.internal;
 

--- a/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeConsumer.java
+++ b/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeConsumer.java
@@ -1,30 +1,10 @@
 /**
- * openHAB, the open Home Automation Bus.
- * Copyright (C) 2010-2013, openHAB.org <admin@openhab.org>
+ * Copyright (c) 2010-2013, openHAB.org and others.
  *
- * See the contributors.txt file in the distribution for a
- * full listing of individual contributors.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Additional permission under GNU GPL version 3 section 7
- *
- * If you modify this Program, or any covered work, by linking or
- * combining it with Eclipse (or a modified version of that library),
- * containing parts covered by the terms of the Eclipse Public License
- * (EPL), the licensors of this Program grant you additional permission
- * to convey the resulting work.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.mqttitude.internal;
 

--- a/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeGenericBindingProvider.java
@@ -1,30 +1,10 @@
 /**
- * openHAB, the open Home Automation Bus.
- * Copyright (C) 2010-2013, openHAB.org <admin@openhab.org>
+ * Copyright (c) 2010-2013, openHAB.org and others.
  *
- * See the contributors.txt file in the distribution for a
- * full listing of individual contributors.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Additional permission under GNU GPL version 3 section 7
- *
- * If you modify this Program, or any covered work, by linking or
- * combining it with Eclipse (or a modified version of that library),
- * containing parts covered by the terms of the Eclipse Public License
- * (EPL), the licensors of this Program grant you additional permission
- * to convey the resulting work.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.mqttitude.internal;
 
@@ -40,8 +20,8 @@ import org.openhab.model.item.binding.BindingConfigParseException;
  * items binding configuration file will look like the following:
  * 
  * <pre>
- * Switch Person_A	"Person A"	{ mqttitude="<broker>:<topic>" }
- * Switch Person_B  "Person B"	{ mqttitude="mosquitto:/mqttitude/personB" }
+ * Switch Person_A	"Person A"	{ mqttitude="<broker>:<topic>[:<region>]" }
+ * Switch Person_B  "Person B"	{ mqttitude="mosquitto:/mqttitude/personB:home" }
  * </pre>
  * 
  * @author Ben Jones

--- a/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeItemConfig.java
+++ b/bundles/binding/org.openhab.binding.mqttitude/src/main/java/org/openhab/binding/mqttitude/internal/MqttitudeItemConfig.java
@@ -1,30 +1,10 @@
 /**
- * openHAB, the open Home Automation Bus.
- * Copyright (C) 2010-2013, openHAB.org <admin@openhab.org>
+ * Copyright (c) 2010-2013, openHAB.org and others.
  *
- * See the contributors.txt file in the distribution for a
- * full listing of individual contributors.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Additional permission under GNU GPL version 3 section 7
- *
- * If you modify this Program, or any covered work, by linking or
- * combining it with Eclipse (or a modified version of that library),
- * containing parts covered by the terms of the Eclipse Public License
- * (EPL), the licensors of this Program grant you additional permission
- * to convey the resulting work.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.openhab.binding.mqttitude.internal;
 

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -885,12 +885,21 @@ tcp:refreshinterval=250
 
 ################################# Mqttitude Binding ###################################
 #
-# The latitude/longitude coordinates of 'home'
+# Mqttitude can track your presence in two ways;
+#
+#  1. Regions - by defining a region in your Mqttitude app (on your phone) you specify
+#               a set of lat/lon coordinates, a geofence, and a name - by using this name 
+# 				in your item binding openHAB will listen for enter/leave events for this 
+#               region and thus allow you to track your presence in multiple locations
+#  2. Home    - by defining the lat/lon of your home, along with a geofence radius (below), 
+#               the binding will listen for location publishes from the Mqttitude app and 
+#               manually calculate the distance from your 'home'
+#
+# Optional. The latitude/longitude coordinates of 'home'. 
 #mqttitude:home.lat=
 #mqttitude:home.lon=
 
-# Optional. Distance in metres a user must be from 'home' to be considered inside
-# the geofence
+# Optional. The geofence radius.
 #mqttitude:geofence=
 
 ############################### OpenPaths Binding #####################################


### PR DESCRIPTION
Means the binding will support multiple 'regions' on a given topic. So you can have a region/waypoint set for 'home', 'work', etc and openHAB can detect your presence in any of these.

Also a general tidy up of the code.
