### PR TITLE
Update wakup class

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
@@ -143,7 +143,6 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass implements ZWaveC
 				
 				this.initializationComplete = true;
 				
-				
 				this.getNode().advanceNodeStage(NodeStage.DYNAMIC);
 				break;
 			case WAKE_UP_INTERVAL_CAPABILITIES_REPORT:
@@ -167,7 +166,6 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass implements ZWaveC
 				logger.trace("Process Wake Up Notification");
 				
 				logger.debug("Node {} is awake", this.getNode().getNodeId());
-				this.setAwake(true);
 				serialMessage.setTransActionCanceled(true);
 
 				// if this node has not gone through it's query stages yet, and there
@@ -177,11 +175,10 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass implements ZWaveC
 					
 					this.getNode().setNodeStage(NodeStage.WAKEUP);
 					this.getNode().advanceNodeStage(NodeStage.DETAILS);
-					return;
 				}
 
-				// Empty the pending queue
-				sendPending();
+				// Set the awake flag. This will also empty the queue
+				this.setAwake(true);
 				break;
 			default:
 				logger.warn(String.format("Unsupported Command 0x%02X for command class %s (0x%02X).", 
@@ -349,8 +346,20 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass implements ZWaveC
 	public void setAwake(boolean isAwake) {
 		this.isAwake = isAwake;
 		
-		if(isAwake)
-			sendPending();
+		if(isAwake) {
+			SerialMessage serialMessage;
+			logger.debug("Sending {} messages from the wake-up queue of node {}", this.wakeUpQueue.size(), this.getNode().getNodeId());
+
+			// Handle all messages in the wake-up queue for this node.
+			while (!this.wakeUpQueue.isEmpty()) {
+				serialMessage = this.wakeUpQueue.poll();
+				this.getController().sendData(serialMessage);
+			}
+
+			// No more information. Go back to sleep.
+			logger.trace("No more messages, go back to sleep node {}", this.getNode().getNodeId());
+			this.getController().sendData(this.getNoMoreInformationMessage());
+		}
 	}
 
 	/**
@@ -373,21 +382,6 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass implements ZWaveC
 				                (byte) getController().getOwnNodeId()};
     	result.setMessagePayload(newPayload);
     	return result;		
-	}
-	
-	private void sendPending() {
-		SerialMessage serialMessage;
-		logger.debug("Sending {} messages from the wake-up queue of node {}", this.wakeUpQueue.size(), this.getNode().getNodeId());
-
-		// Handle all messages in the wake-up queue for this node.
-		while (!this.wakeUpQueue.isEmpty()) {
-			serialMessage = this.wakeUpQueue.poll();
-			this.getController().sendData(serialMessage);
-		}
-		
-		// No more information. Go back to sleep.
-		logger.trace("No more messages, go back to sleep node {}", this.getNode().getNodeId());
-		this.getController().sendData(this.getNoMoreInformationMessage());
 	}
 
 	/**


### PR DESCRIPTION
Moves the 'empty queue' to after the startup check.
As discussed in PR 718 (https://github.com/openhab/openhab/pull/718)
