### PR TITLE
Zwave wake-up - make wakeup target node class member

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
@@ -393,6 +393,10 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass implements ZWaveC
 		return wakeUpQueue.size();
 	}
 	
+	/**
+	 * Gets the target node for the Wakeup command class
+	 * @return wakeup target node id
+	 */
 	public int getTargetNodeId() {
 		return targetNodeId;
 	}


### PR DESCRIPTION
Makes the wakeup target node a class member so that it can be read along with the other class configuration information (intervals etc).
