### PR TITLE
MySQL persistence: use correct prefix in openhab_default.cfg

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -242,18 +242,14 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 #db4o:maxbackups=
 
 ############################ SQL Persistence Service ##################################
-#
-# the JDBC driver class like 'com.mysql.jdbc.Driver' or 'org.postgresql.Driver'
-#sql:driverClass=
-
 # the database url like 'jdbc:mysql://<host>:<port>/<user>'
-sql:url=
+#mysql:url=
 
 # the database user
-#sql:user=
+#mysql:user=
 
 # the database password
-#sql:password=
+#mysql:password=
 
 ############################ Cosm Persistence Service #################################
 #


### PR DESCRIPTION
I also fixed the MySQL Persistence documentation in the Wiki that mentioned a sql.persist file instead of the correct mysql.persist.
