### PR TITLE
Fix errors with Everspring product naming

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/everspring/sf812.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/everspring/sf812.xml
@@ -2,7 +2,8 @@
 <Product>
 	<Model>ST814</Model>
 	<Endpoints>1</Endpoints>
-	<Label lang="en">Temperature and Humidity Sensor</Label>
+	<Label lang="en">Smoke Sensor</Label>
+	<Label lang="de">Rauchmelder</Label>
 	<CommandClasses>
 		<Class><id>0x20</id></Class>
 		<Class><id>0x71</id></Class>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -63,7 +63,7 @@
 				<Type>000D</Type>
 				<Id>0001</Id>
 			</Reference>
-			<Model>ST814</Model>
+			<Model>SF812</Model>
 			<Label lang="en">Smoke Sensor</Label>
 			<Label lang="de">Rauchmelder</Label>
 			<ConfigFile>everspring/sf812.xml</ConfigFile>


### PR DESCRIPTION
This just updates a couple of the XML files in the zwave product database.
