### PR TITLE
Fix String Encoding for Intertechno Addresses

### DIFF
--- a/bundles/binding/org.openhab.binding.intertechno/src/main/java/org/openhab/binding/intertechno/internal/parser/AbstractIntertechnoParser.java
+++ b/bundles/binding/org.openhab.binding.intertechno/src/main/java/org/openhab/binding/intertechno/internal/parser/AbstractIntertechnoParser.java
@@ -45,7 +45,7 @@ public abstract class AbstractIntertechnoParser implements
 		for (int i = length - 1; i >= 0; i--) {
 			int currentBitValue = (int) Math.pow(2, i);
 			char bit = char0;
-			if (currentBitValue >= value) {
+			if (value >= currentBitValue) {
 				bit = char1;
 				value = value - currentBitValue;
 			}


### PR DESCRIPTION
The calculation of addresses to send command via the CUL transport binding is broken. This pull request fixes this.
