### PR TITLE
Fix NPE if no zwave stick in the machine.

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveActiveBinding.java
@@ -111,7 +111,7 @@ public class ZWaveActiveBinding extends AbstractActiveBinding<ZWaveBindingProvid
 		if (zProvider != null) {
 			ZWaveBindingConfig bindingConfig = zProvider.getZwaveBindingConfig(itemName);
 			
-			if (bindingConfig != null) {
+			if (bindingConfig != null && converterHandler != null) {
 					converterHandler.executeRefresh(zProvider, itemName, true);
 			}
 		}


### PR DESCRIPTION
If there is no zwave stick present, or the serial port doesn't open for some reason, then an exception is thrown and the converterHandler is not initialised. This then causes multiple null pointer exceptions at this point.
