### PR TITLE
MySQL persistence: DimmerItem is a SwitchItem and needs to be checked prior to that

### DIFF
--- a/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
@@ -564,12 +564,12 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 
 				if (item instanceof NumberItem)
 					state = new DecimalType(rs.getDouble(2));
+				else if (item instanceof DimmerItem)
+					state = new PercentType(rs.getInt(2));
 				else if (item instanceof SwitchItem)
 					state = OnOffType.valueOf(rs.getString(2));
 				else if (item instanceof ContactItem)
 					state = OpenClosedType.valueOf(rs.getString(2));
-				else if (item instanceof DimmerItem)
-					state = new PercentType(rs.getInt(2));
 				else if (item instanceof RollershutterItem)
 					state = new PercentType(rs.getInt(2));
 				else if (item instanceof ColorItem)


### PR DESCRIPTION
This prevents the following exception:

java.lang.IllegalArgumentException: No enum constant org.openhab.core.library.types.OnOffType.9
        at java.lang.Enum.valueOf(Enum.java:236)
        at org.openhab.core.library.types.OnOffType.valueOf(OnOffType.java:1)
        at org.openhab.persistence.mysql.internal.MysqlPersistenceService.query(MysqlPersistenceService.java:568)
        at org.openhab.core.persistence.internal.PersistenceManager.initialize(PersistenceManager.java:369)
        at org.openhab.core.persistence.internal.PersistenceManager.itemAdded(PersistenceManager.java:342)
        at org.openhab.core.persistence.internal.PersistenceManager.allItemsChanged(PersistenceManager.java:337)
