### PR TITLE
Changed multilevelswitch stopcommand

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSwitchCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSwitchCommandClass.java
@@ -161,7 +161,7 @@ public class ZWaveMultiLevelSwitchCommandClass extends ZWaveCommandClass impleme
 		logger.debug("Creating new message for application command SWITCH_MULTILEVEL_STOP_LEVEL_CHANGE for node {}", this.getNode().getNodeId());
 		SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessageClass.SendData, SerialMessageType.Request, SerialMessageClass.SendData, SerialMessagePriority.Set);
     	byte[] newPayload = { 	(byte) this.getNode().getNodeId(), 
-    							3, 
+    							2, 
 								(byte) getCommandClass().getKey(), 
 								(byte) SWITCH_MULTILEVEL_STOP_LEVEL_CHANGE };
     	result.setMessagePayload(newPayload);


### PR DESCRIPTION
This should fix #693
Compared stop level change message from open-zwave with the implementation in our zwave binding.
Changed the message payload according to open-zwave. Stopping and continue movement now works (for me).
The warning (see #693) has gone.
