### PR TITLE
Fix typos and javadoc errors

### DIFF
--- a/bundles/binding/org.openhab.binding.intertechno/src/main/java/org/openhab/binding/intertechno/internal/CULIntertechnoBinding.java
+++ b/bundles/binding/org.openhab.binding.intertechno/src/main/java/org/openhab/binding/intertechno/internal/CULIntertechnoBinding.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Implements the communcation with Intertechno devices via CUL devices.
+ * Implements the communication with Intertechno devices via CUL devices.
  * Currently it is only possible to send commands.
  * 
  * @author Till Klocke
@@ -75,7 +75,7 @@ public class CULIntertechnoBinding extends
 	}
 
 	public void activate() {
-		bindCULHanlder();
+		bindCULHandler();
 	}
 
 	public void deactivate() {
@@ -91,11 +91,11 @@ public class CULIntertechnoBinding extends
 				CULManager.close(cul);
 			}
 			deviceName = newDeviceName;
-			bindCULHanlder();
+			bindCULHandler();
 		}
 	}
 
-	private void bindCULHanlder() {
+	private void bindCULHandler() {
 		if (!StringUtils.isEmpty(deviceName)) {
 			try {
 				cul = CULManager.getOpenCULHandler(deviceName, CULMode.SLOW_RF);

--- a/bundles/binding/org.openhab.binding.intertechno/src/main/java/org/openhab/binding/intertechno/internal/CULIntertechnoGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.intertechno/src/main/java/org/openhab/binding/intertechno/internal/CULIntertechnoGenericBindingProvider.java
@@ -54,7 +54,8 @@ public class CULIntertechnoGenericBindingProvider extends
 
 	/**
 	 * config of style
-	 * {intertechno="type=<classic|fls|rev>;group=<group>;address=<address>"}
+	 * <code>{{@literal intertechno="type=<classic|fls|rev>;group=<group>;address=<address>"}}</code><br>
+	 * 
 	 * {@inheritDoc}
 	 */
 	@Override

--- a/bundles/binding/org.openhab.binding.intertechno/src/main/java/org/openhab/binding/intertechno/internal/parser/AbstractIntertechnoParser.java
+++ b/bundles/binding/org.openhab.binding.intertechno/src/main/java/org/openhab/binding/intertechno/internal/parser/AbstractIntertechnoParser.java
@@ -19,7 +19,7 @@ public abstract class AbstractIntertechnoParser implements
 
 	/**
 	 * Encode an integer as String for sending it via Intertechno. Numbers are
-	 * repesented as "binary" Strings where each letter represents a byte. It si
+	 * represented as "binary" Strings where each letter represents a byte. It is
 	 * configurable which letters represents 0 and which represents 1.
 	 * 
 	 * @param length


### PR DESCRIPTION
I just fixed some typos in comments and functions names as well as an javadoc specific error.
