### PR TITLE
Added ‘disabled’ to rules. This allows a rule to be simply disabled without removing it from the rule file.

### DIFF
--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/Rules.xtext
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/Rules.xtext
@@ -17,7 +17,7 @@ Import:
 ;
 		
 Rule:
-	'rule' name=(ID|STRING)
+	'rule' name=(ID|STRING) (disabled?='disabled')?
 	'when' eventtrigger+=EventTrigger ('or' eventtrigger+=EventTrigger)*
 	'then' script=Script
 	'end'

--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleTriggerManager.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleTriggerManager.java
@@ -349,7 +349,8 @@ public class RuleTriggerManager {
 	 */
 	public void addRuleModel(RuleModel model) {
 		for(Rule rule : model.getRules()) {
-			addRule(rule);
+			if(!rule.isDisabled())
+				addRule(rule);
 		}
 	}
 


### PR DESCRIPTION
I know this is core functionality, so you probably don't want to include it in 1.4, but I'll raise it here anyway... Currently, unless I'm wrong, the only way not to run a rule is to remove it from the .rule file, which is a pain from a maintenance perspective.
This modification allows you to add "disabled" to the end of the rule definition - after the rule name. Adding this will stop the rule being registered, so it's the same as if it's removed from the .rule file.
