### PR TITLE
RfxCom Lightning6 message added

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6Message.java
@@ -30,8 +30,8 @@ import org.openhab.core.types.UnDefType;
 /**
  * RFXCOM data class for lighting6 message. See Blyss.
  * 
- * @author Evert van Es, Cycling Engineer
- * @since 1.2.0
+ * @author Damien Servant
+ * @since 1.4.0
  */
 public class RFXComLighting6Message extends RFXComBaseMessage {
 


### PR DESCRIPTION
Hello,

I added support for the lightning6 messages (Blyss protocol) in the RFXCOM binding.
The syntax with Openhab is :
 Lighting6 format: `SensorId.GroupCode.UnitCode` e.g. 257.B.1, 64343.B.2 or 636602.H.5

It works with my Blyss Switch, but probably not with Blyss motors which use 2 extra internal Command Seq Number as it is described in the RFX documentation.
Can you integrate this code in the RFXCOM binding ?

Thanks,

Damien
