### PR TITLE
[ESH] Move the Apple TTS Engine (Macintalk) to a seperate add-on bundle

### DIFF
--- a/bundles/io/.classpath
+++ b/bundles/io/.classpath
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="lib" path="lib/cmu_us_kal.jar"/>
+	<classpathentry kind="lib" path="lib/freetts.jar"/>
+	<classpathentry kind="lib" path="lib/cmu_time_awb.jar"/>
+	<classpathentry kind="lib" path="lib/cmudict04.jar"/>
+	<classpathentry kind="lib" path="lib/cmulex.jar"/>
+	<classpathentry kind="lib" path="lib/cmutimelex.jar"/>
+	<classpathentry kind="lib" path="lib/en_us.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/io/.project
+++ b/bundles/io/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.io.multimedia.tts.macintalktts</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/io/.settings/org.eclipse.pde.core.prefs
+++ b/bundles/io/.settings/org.eclipse.pde.core.prefs
@@ -1,0 +1,4 @@
+#Mon Oct 11 21:08:09 CEST 2010
+eclipse.preferences.version=1
+pluginProject.extensions=false
+resolve.requirebundle=false

--- a/bundles/io/build.properties
+++ b/bundles/io/build.properties
@@ -1,0 +1,12 @@
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               lib/cmu_time_awb.jar,\
+               lib/cmu_us_kal.jar,\
+               lib/freetts.jar,\
+               lib/cmudict04.jar,\
+               lib/cmulex.jar,\
+               lib/cmutimelex.jar,\
+               lib/en_us.jar
+source.. = src/main/java/

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/.classpath
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/.project
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.io.multimedia.tts.macintalk</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/.settings/org.eclipse.pde.core.prefs
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/.settings/org.eclipse.pde.core.prefs
@@ -1,0 +1,4 @@
+#Mon Oct 11 21:08:09 CEST 2010
+eclipse.preferences.version=1
+pluginProject.extensions=false
+resolve.requirebundle=false

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: openHAB Multimedia MacinTalk
+Bundle-SymbolicName: org.openhab.io.multimedia.tts.macintalk
+Bundle-Version: 1.5.0.qualifier
+Bundle-Vendor: openHAB.org
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-ClassPath: .
+Import-Package: org.openhab.io.multimedia.tts,
+ org.osgi.framework,
+ org.slf4j
+Service-Component: OSGI-INF/tts_mac.xml
+Bundle-ActivationPolicy: lazy

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/OSGI-INF/tts_mac.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/OSGI-INF/tts_mac.xml
@@ -9,7 +9,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.io.multimedia.tts.mac">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.openhab.io.multimedia.tts.macintalk">
    <implementation class="org.openhab.io.multimedia.internal.tts.TTSServiceMacOS"/>
    <service>
       <provide interface="org.openhab.io.multimedia.tts.TTSService"/>

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/build.properties
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/build.properties
@@ -1,0 +1,6 @@
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               OSGI-INF/tts_mac.xml
+source.. = src/main/java/

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.openhab.bundles</groupId>
+		<artifactId>io</artifactId>
+		<version>1.5.0-SNAPSHOT</version>
+	</parent>
+
+	<name>openHAB Multimedia MacinTalk</name>
+
+	<properties>
+		<bundle.symbolicName>org.openhab.io.multimedia.tts.macintalk</bundle.symbolicName>
+		<bundle.namespace>org.openhab.io.multimedia.tts.macintalk</bundle.namespace>
+		<deb.name>openhab-addon-io-multimedia-macintalk</deb.name>
+		<deb.description>${name}</deb.description>
+	</properties>
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openhab.io</groupId>
+	<artifactId>org.openhab.io.multimedia.tts.macintalk</artifactId>
+
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.vafer</groupId>
+				<artifactId>jdeb</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/src/main/java/org/openhab/io/multimedia/internal/tts/TTSServiceMacOS.java
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/src/main/java/org/openhab/io/multimedia/internal/tts/TTSServiceMacOS.java
@@ -10,7 +10,6 @@ package org.openhab.io.multimedia.internal.tts;
 
 import java.io.IOException;
 import java.util.ArrayList;
-
 import org.openhab.io.multimedia.tts.TTSService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +25,12 @@ import org.slf4j.LoggerFactory;
 public class TTSServiceMacOS implements TTSService {
 
 	private static final Logger logger = LoggerFactory.getLogger(TTSServiceMacOS.class);
+	
+	public void activate() {
+	}
+	
+	public void deactive() {
+	}
 	
 	/**
 	 * {@inheritDoc}

--- a/bundles/io/org.openhab.io.multimedia/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.multimedia/META-INF/MANIFEST.MF
@@ -18,7 +18,6 @@ Import-Package: org.apache.commons.collections,
  org.slf4j
 Export-Package: org.openhab.io.multimedia.actions,org.openhab.io.multi
  media.tts
-Service-Component: OSGI-INF/tts_mac.xml,
- OSGI-INF/audioaction.xml
+Service-Component: OSGI-INF/audioaction.xml
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.openhab.io.multimedia.internal.MultimediaActivator

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -755,6 +755,12 @@
         </dependency>
         <dependency>
             <groupId>org.openhab.io</groupId>
+            <artifactId>org.openhab.io.multimedia.tts.macintalk</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.io</groupId>
             <artifactId>org.openhab.io.multimedia.tts.marytts</artifactId>
             <version>${project.version}</version>
             <type>jar</type>

--- a/distribution/src/assemble/addons.xml
+++ b/distribution/src/assemble/addons.xml
@@ -27,6 +27,7 @@
       	<include>org.openhab.binding:*:jar:*</include>
       	<include>org.openhab.persistence:*:jar:*</include>
       	<include>org.openhab.io:org.openhab.io.multimedia.tts.freetts:jar:*</include>
+      	<include>org.openhab.io:org.openhab.io.multimedia.tts.macintalk:jar:*</include>
         <include>org.openhab.io:org.openhab.io.multimedia.tts.marytts:jar:*</include>
       	<include>org.openhab.io:org.openhab.io.dropbox:jar:*</include>
 		<include>org.openhab.io:org.openhab.io.cv:jar:*</include>

--- a/distribution/src/assemble/demo.xml
+++ b/distribution/src/assemble/demo.xml
@@ -39,6 +39,7 @@
       	<include>org.openhab.persistence:org.openhab.persistence.logging:jar:*</include>
       	<include>org.openhab.persistence:org.openhab.persistence.exec:jar:*</include>
       	<include>org.openhab.io:org.openhab.io.multimedia.tts.freetts:jar:*</include>
+      	<include>org.openhab.io:org.openhab.io.multimedia.tts.macintalk:jar:*</include>
       </includes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
Thomas, couldn't alter the "product" bundle to have this add-on included. All other distribution .xml and pom.xml should be ok. 
