### PR TITLE
Add null pointer checks to cope with initialisation errors

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterBase.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterBase.java
@@ -97,7 +97,9 @@ public abstract class ZWaveConverterBase {
 	 * @return a converter object that converts between the value and the state;
 	 */
 	protected ZWaveStateConverter<?,?> getStateConverter(Item item, Object value) {
-		
+		if(item == null)
+			return null;
+
 		List<Class<? extends State>> list = new ArrayList<Class<? extends State>>(item.getAcceptedDataTypes());
 		Collections.sort(list, new StateComparator());
 

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
@@ -101,6 +101,9 @@ public class ZWaveConverterHandler {
 	 * @return the {@link ZWaveCommandClass} that can be used to get a converter suitable to do the conversion.
 	 */
 	private ZWaveCommandClass resolveConverter(Item item, ZWaveNode node, int endpointId) {
+		if(item == null)
+			return null;
+
 		ZWaveMultiInstanceCommandClass multiInstanceCommandClass = null;
 		ZWaveCommandClass result = null;
 		

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveInfoConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveInfoConverter.java
@@ -65,6 +65,9 @@ public class ZWaveInfoConverter extends ZWaveConverterBase {
 	 * @param arguments the arguments for the converter.
 	 */
 	public void executeRefresh(Item item, ZWaveNode node, int endpointId, Map<String,String> arguments) {
+		if(item == null)
+			return;
+
 		// not bound to an item.
 		if (!arguments.containsKey("item"))
 			return;


### PR DESCRIPTION
NPE can occur on startup depending on the order files are read.
