### PR TITLE
Maxcube: Support On/Off commands

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
@@ -34,6 +34,7 @@ import org.openhab.binding.maxcube.internal.message.ShutterContact;
 import org.openhab.binding.maxcube.internal.message.WallMountedThermostat;
 import org.openhab.core.binding.AbstractActiveBinding;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.Command;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
@@ -280,8 +281,11 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 
 			String rfAddress = device.getRFAddress();
 
-			if (command instanceof DecimalType) {
-				DecimalType decimalType = (DecimalType) command;
+			if (command instanceof DecimalType || command instanceof OnOffType) {
+				DecimalType decimalType = new DecimalType(4.5); /* default to 'off' */
+				if (command instanceof DecimalType)	decimalType = (DecimalType) command;
+				else if (command instanceof OnOffType) decimalType = ((OnOffType)command == OnOffType.ON)?new DecimalType(30.5):new DecimalType(4.5);
+
 				S_Command cmd = new S_Command(rfAddress, device.getRoomId(), decimalType.doubleValue());
 				String commandString = cmd.getCommandString();
 

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/S_Command.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/S_Command.java
@@ -47,7 +47,7 @@ public class S_Command {
 		// bit 0,1 = 00 = Auto weekprog (no temp is needed, just make the whole
 		// byte 00
 
-		int setpointValue = (int) setpointTemperature * 2;
+		int setpointValue = (int) (setpointTemperature * 2);
 		bits = Utils.getBits(setpointValue);
 		
 		// default to perm setting


### PR DESCRIPTION
 Maxcube: Support on off commands for radiator thermostats and correctly support 0.5 deg increments.

ON command will set radiator thermostat to full 'On' (i.e. 30.5 deg). 'On' is displayed on unit
OFF command will set radiator thermostat to full 'Off' (i.e. 4.5 deg). 'Off' is displayed on unit

Also fixes issue where we were casting double to int then multiplying by 2, resulting in losing the .5 values. This was stopping On/Off setting as they are 30.5 and 4.5 respectively
