### PR TITLE
Add mySQL timeout parameter and update cfg defaults

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -266,6 +266,12 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # the database password
 #mysql:password=
 
+# the reconnection counter
+#mysql:reconnectCnt=
+
+# the connection timeout (in seconds)
+#mysql:waitTimeout=
+
 ############################ Cosm Persistence Service #################################
 #
 # the url of the Cosm feed (optional, defaults to 'http://api.cosm.com/v2/feeds/') 


### PR DESCRIPTION
This adds the ability to override the session timeout parameter. It seems that in some cases this could be as low  as 60 seconds, which would make the mysql connection time out almost every transaction.
