### PR TITLE
Feature/squeeze default cfg

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -700,15 +700,19 @@ hue:secret=openHABRuntime
 
 ################################## Squeezebox Binding #################################
 #
-# Host of the first Squeezebox device to control 
-#squeeze:<boxId1>.host=
-# Port of cli interface of the first Squeezebox device to control 
+# Host address of your Logitech Media Server
+#squeeze:<serverId>.host=
+# Port of cli interface of your Logitech Media Server 
 # (optional, defaults to 9090)
-#squeeze:<boxId1>.cliport=
-# Webport interface of the first Squeezebox device to control (optional, 
-# defaults to 9000)
-#squeeze:<boxId1>.webport=
+#squeeze:<serverId>.cliport=
+# Webport interface of the your Logitech Media Server 
+# (optional, defaults to 9000)
+#squeeze:<serverId>.webport=
 
+# Id (MAC address) of your first Squeezebox
+#squeeze:<boxId1>.id=
+# Id (MAC address) of your nth Squeezebox
+#squeeze:<boxIdN>.id=
 
 ################################### Milight Binding ###################################
 #


### PR DESCRIPTION
The default config is missing the actual box id part. The server part is doubled, but there could be only one server at a time I think.
