### PR TITLE
added "synchronized" keyword to prevent race condition in RRD4JService

### DIFF
--- a/bundles/persistence/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jService.java
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jService.java
@@ -84,7 +84,7 @@ public class RRD4jService implements QueryablePersistenceService {
 	/**
 	 * @{inheritDoc}
 	 */
-	public void store(final Item item, final String alias) {
+	public synchronized void store(final Item item, final String alias) {
 		final String name = alias==null ? item.getName() : alias;
 		ConsolFun function = getConsolidationFunction(item);
 		RrdDb db = getDB(name, function);


### PR DESCRIPTION
When multiple persistence strategies update the same rrd4j database file at the same time, a race condition can lead to corrupt data being written to the file, resulting in spikes in the data.
This bug was fixed by adding the "synchronized" keyword before the store() function in the RRD4JService class.
