### PR TITLE
DateTimeType with timezone detection

### DIFF
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -20,7 +20,7 @@ import org.openhab.core.types.State;
 
 public class DateTimeType implements PrimitiveType, State {
 	
-	public final static SimpleDateFormat DATE_FORMATTER_WITHTZ = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz");
+	public final static SimpleDateFormat DATE_FORMATTER_WITH_TZ = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz");
 	public final static SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
 	protected Calendar calendar;
@@ -39,7 +39,7 @@ public class DateTimeType implements PrimitiveType, State {
 		
 		try {
 			try {
-				date = DATE_FORMATTER_WITHTZ.parse(calendarValue);
+				date = DATE_FORMATTER_WITH_TZ.parse(calendarValue);
 			}
 			catch (ParseException fpe2) {
 				date = DATE_FORMATTER.parse(calendarValue);


### PR DESCRIPTION
Hi, 

this patch enables correct reading in different-timezones (eg. in XML from weatherforcast), it falls back to the old parsing without timezone.
Example:
OpenWeather-XML

``` xml
<sun rise="2014-03-30T04:58:47" set="2014-03-30T17:48:03"/>
```

This times are in UTC (timezone is omitted)
The item would be converted to the the wrong time: 

```
DateTime ow_sunrise             "Sonnenaufgang [%1$tR]"   <weather_sunrise>  (Wetter) { http="<[openWeatherCache:1440000:XSLT(openweather_sunrise.xsl)]" }
```

see

``` groovy
groovy:000> import java.text.SimpleDateFormat;
===> [import java.text.SimpleDateFormat;]
groovy:000> DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
===> java.text.SimpleDateFormat@6b2ed43a
groovy:000> sunrise = '2014-03-30T04:58:47'
===> 2014-03-30T04:58:47
groovy:000> DATE_FORMATTER.parse(sunrise)
===> Sun Mar 30 04:58:47 CEST 2014
```

The Correct timestamp would be _Sun Mar 30 06:58:47 CEST 2014_

Via transform, i'm attaching the timezone:

``` XSL
<xsl:value-of select="concat(/current/city/sun/@rise, 'UTC')" />
```

now the time is correct:

``` groovy
groovy:000> DATE_FORMATTER_WITH_TZ = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz");
===> java.text.SimpleDateFormat@faabb380
groovy:000> sunrise = '2014-03-30T04:58:47' + 'UTC'
===> 2014-03-30T04:58:47UTC
groovy:000> DATE_FORMATTER_WITH_TZ.parse(sunrise)
===> Sun Mar 30 06:58:47 CEST 2014
```
