### PR TITLE
Added a null check to prevent nullpointer in z-wave bundle

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSceneConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSceneConverter.java
@@ -65,6 +65,9 @@ public class ZWaveSceneConverter extends ZWaveCommandClassConverter<ZWaveBasicCo
 
 	@Override
 	void handleEvent(ZWaveCommandClassValueEvent event, Item item, Map<String, String> arguments) {
+		if(arguments.get("scene")==null)
+			return;
+		
 		int scene = Integer.parseInt(arguments.get("scene"));
 		if(scene != (Integer)event.getValue())
 			return;


### PR DESCRIPTION
When using the fibaro dimmer module, you can use scene's for the secondary button.
When using the scene's it gave a NPE - with this patch no longer.

You can now use scene activation like this:
Switch TestSwitch "Testswitch" { zwave="17:command=SCENE_ACTIVATION,scene=26,state=0" }
