### PR TITLE
Column name in ORDER BY clause has to be defined without quotes

### DIFF
--- a/distribution/openhabhome/start.sh
+++ b/distribution/openhabhome/start.sh
@@ -8,19 +8,9 @@ eclipsehome="server";
 # set ports for HTTP(S) server
 HTTP_PORT=8080
 HTTPS_PORT=8443
-DEBUG_PORT=8001
-CONSOLE_PORT=
-
-if [ -z "$OH_HTTP_PORT" ]; then OH_HTTP_PORT=$HTTP_PORT; fi
-if [ -z "$OH_HTTPS_PORT" ]; then OH_HTTPS_PORT=$HTTPS_PORT; fi
-if [ -z "$OH_DEBUG_PORT" ]; then OH_DEBUG_PORT=$DEBUG_PORT; fi
-if [ -z "$OH_CONSOLE_PORT" ]; then OH_CONSOLE_PORT=$CONSOLE_PORT; fi
 
 # get path to equinox jar inside $eclipsehome folder
 cp=$(find $eclipsehome -name "org.eclipse.equinox.launcher_*.jar" | sort | tail -1);
 
-# debug options
-debug_opts="-agentlib:jdwp=transport=dt_socket,address=$OH_DEBUG_PORT,server=y,suspend=n"
-
-echo Launching the openHAB runtime in debug mode...
-java $debug_opts -Dosgi.clean=true -Declipse.ignoreApp=true -Dosgi.noShutdown=true -Djetty.port=$OH_HTTP_PORT -Djetty.port.ssl=$OH_HTTPS_PORT -Djetty.home=. -Dlogback.configurationFile=configurations/logback_debug.xml -Dfelix.fileinstall.dir=addons -Djava.library.path=lib -Dorg.quartz.properties=./etc/quartz.properties -Djava.security.auth.login.config=./etc/login.conf -Dequinox.ds.block_timeout=240000 -Dequinox.scr.waitTimeOnBlock=60000 -Dfelix.fileinstall.active.level=4 -Djava.awt.headless=true -jar $cp $* -console $OH_CONSOLE_PORT
+echo Launching the openHAB runtime...
+java -Dosgi.clean=true -Declipse.ignoreApp=true -Dosgi.noShutdown=true -Djetty.port=$HTTP_PORT -Djetty.port.ssl=$HTTPS_PORT -Djetty.home=. -Dlogback.configurationFile=configurations/logback.xml -Dfelix.fileinstall.dir=addons -Djava.library.path=lib -Djava.security.auth.login.config=./etc/login.conf -Dorg.quartz.properties=./etc/quartz.properties -Dequinox.ds.block_timeout=240000 -Dequinox.scr.waitTimeOnBlock=60000 -Dfelix.fileinstall.active.level=4 -Djava.awt.headless=true -jar $cp $* -console 

--- a/distribution/openhabhome/start_debug.sh
+++ b/distribution/openhabhome/start_debug.sh
@@ -8,19 +8,12 @@ eclipsehome="server";
 # set ports for HTTP(S) server
 HTTP_PORT=8080
 HTTPS_PORT=8443
-DEBUG_PORT=8001
-CONSOLE_PORT=
-
-if [ -z "$OH_HTTP_PORT" ]; then OH_HTTP_PORT=$HTTP_PORT; fi
-if [ -z "$OH_HTTPS_PORT" ]; then OH_HTTPS_PORT=$HTTPS_PORT; fi
-if [ -z "$OH_DEBUG_PORT" ]; then OH_DEBUG_PORT=$DEBUG_PORT; fi
-if [ -z "$OH_CONSOLE_PORT" ]; then OH_CONSOLE_PORT=$CONSOLE_PORT; fi
 
 # get path to equinox jar inside $eclipsehome folder
 cp=$(find $eclipsehome -name "org.eclipse.equinox.launcher_*.jar" | sort | tail -1);
 
 # debug options
-debug_opts="-agentlib:jdwp=transport=dt_socket,address=$OH_DEBUG_PORT,server=y,suspend=n"
+debug_opts="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=n"
 
 echo Launching the openHAB runtime in debug mode...
-java $debug_opts -Dosgi.clean=true -Declipse.ignoreApp=true -Dosgi.noShutdown=true -Djetty.port=$OH_HTTP_PORT -Djetty.port.ssl=$OH_HTTPS_PORT -Djetty.home=. -Dlogback.configurationFile=configurations/logback_debug.xml -Dfelix.fileinstall.dir=addons -Djava.library.path=lib -Dorg.quartz.properties=./etc/quartz.properties -Djava.security.auth.login.config=./etc/login.conf -Dequinox.ds.block_timeout=240000 -Dequinox.scr.waitTimeOnBlock=60000 -Dfelix.fileinstall.active.level=4 -Djava.awt.headless=true -jar $cp $* -console $OH_CONSOLE_PORT
+java $debug_opts -Dosgi.clean=true -Declipse.ignoreApp=true -Dosgi.noShutdown=true -Djetty.port=$HTTP_PORT -Djetty.port.ssl=$HTTPS_PORT -Djetty.home=. -Dlogback.configurationFile=configurations/logback_debug.xml -Dfelix.fileinstall.dir=addons -Djava.library.path=lib -Dorg.quartz.properties=./etc/quartz.properties -Djava.security.auth.login.config=./etc/login.conf -Dequinox.ds.block_timeout=240000 -Dequinox.scr.waitTimeOnBlock=60000 -Dfelix.fileinstall.active.level=4 -Djava.awt.headless=true -jar $cp $* -console 


### PR DESCRIPTION
Column name in ORDER BY clause has to be defined without quotes, else ORDEY BY does not work as expected
