### PR TITLE
Allow configuration parameter 0.

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ConfigurationParameter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ConfigurationParameter.java
@@ -36,7 +36,7 @@ public class ConfigurationParameter {
 			throw new IllegalArgumentException("illegal parameter size");
 		}
 		
-		if (index < 1 || index > 0xFF) {
+		if (index < 0 || index > 0xFF) {
 			throw new IllegalArgumentException("illegal parameter index");
 		}
 		


### PR DESCRIPTION
When I originally wrote this I thought parameter numbers started at 1 - they don't - they start at 0...
