### PR TITLE
issue 992

### DIFF
--- a/bundles/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/OmniLinkBinding.java
+++ b/bundles/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/OmniLinkBinding.java
@@ -20,7 +20,7 @@ import org.openhab.binding.omnilink.OmniLinkBindingProvider;
 import org.openhab.binding.omnilink.internal.model.Area;
 import org.openhab.binding.omnilink.internal.model.AudioSource;
 import org.openhab.binding.omnilink.internal.model.AudioZone;
-import org.openhab.binding.omnilink.internal.model.Aux;
+import org.openhab.binding.omnilink.internal.model.Auxiliary;
 import org.openhab.binding.omnilink.internal.model.Button;
 import org.openhab.binding.omnilink.internal.model.OmnilinkDevice;
 import org.openhab.binding.omnilink.internal.model.Thermostat;
@@ -94,7 +94,7 @@ public class OmniLinkBinding extends AbstractBinding<OmniLinkBindingProvider>
 	private Map<Integer, Area> areaMap = Collections.synchronizedMap(new HashMap<Integer, Area>());
 	private Map<Integer, AudioSource> audioSourceMap = Collections.synchronizedMap(new HashMap<Integer, AudioSource>());
 	private Map<Integer, AudioZone> audioZoneMap = Collections.synchronizedMap(new HashMap<Integer, AudioZone>());
-	private Map<Integer, Aux> auxMap = Collections.synchronizedMap(new HashMap<Integer, Aux>());
+	private Map<Integer, Auxiliary> auxMap = Collections.synchronizedMap(new HashMap<Integer, Auxiliary>());
 	private Map<Integer, Thermostat> thermostatMap = Collections.synchronizedMap(new HashMap<Integer, Thermostat>());
 	private Map<Integer, Unit> unitMap = Collections.synchronizedMap(new HashMap<Integer, Unit>());
 	private Map<Integer, Zone> zoneMap = Collections.synchronizedMap(new HashMap<Integer, Zone>());
@@ -569,14 +569,14 @@ public class OmniLinkBinding extends AbstractBinding<OmniLinkBindingProvider>
 						case AUX_LOW:
 						case AUX_STATUS: {
 							AuxSensorProperties p = readAuxProperties(config.getNumber());
-							Aux aux = auxMap.get(number);
-							if (aux == null) {
-								aux = new Aux(p, celius);
-								auxMap.put(number, aux);
+							Auxiliary auxiliary = auxMap.get(number);
+							if (auxiliary == null) {
+								auxiliary = new Auxiliary(p, celius);
+								auxMap.put(number, auxiliary);
 							}
-							config.setDevice(aux);
-							aux.setProperties(p);
-							aux.updateItem(provider.getItem(itemName), config,
+							config.setDevice(auxiliary);
+							auxiliary.setProperties(p);
+							auxiliary.updateItem(provider.getItem(itemName), config,
 									eventPublisher);
 						}
 							break;
@@ -661,9 +661,9 @@ public class OmniLinkBinding extends AbstractBinding<OmniLinkBindingProvider>
 		}
 
 		/**
-		 * Read the properties of a aux sensor
-		 * @param number of aux sensor
-		 * @return AuxSensorProperties of aux sensor or null if not found
+		 * Read the properties of a Auxiliary sensor
+		 * @param number of Auxiliary sensor
+		 * @return AuxSensorProperties of Auxiliary sensor or null if not found
 		 * @throws IOException
 		 * @throws OmniNotConnectedException
 		 * @throws OmniInvalidResponseException

--- a/bundles/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/model/Area.java
+++ b/bundles/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/model/Area.java
@@ -27,7 +27,7 @@ import com.digitaldan.jomnilinkII.MessageTypes.properties.AreaProperties;
  * @since 1.5.0
  */
 public class Area extends OmnilinkDevice {
-	private static final Logger logger = LoggerFactory.getLogger(Aux.class);
+	private static final Logger logger = LoggerFactory.getLogger(Area.class);
 
 	public static final String[] omniText = { "Off", "Day", "Night", "Away",
 			"Vacation", "Day-Instant", "Night-Delayed" };

--- a/bundles/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/model/Auxiliary.java
+++ b/bundles/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/model/Auxiliary.java
@@ -20,18 +20,18 @@ import com.digitaldan.jomnilinkII.MessageUtils;
 import com.digitaldan.jomnilinkII.MessageTypes.properties.AuxSensorProperties;
 
 /**
- * Aux are temperature and/or humidity sensors
+ * An Auxiliary is a temperature and/or humidity sensors
  * 
  * @author Dan Cunningham
  * @since 1.5.0
  */
-public class Aux extends OmnilinkDevice {
-	private static final Logger logger = LoggerFactory.getLogger(Aux.class);
+public class Auxiliary extends OmnilinkDevice {
+	private static final Logger logger = LoggerFactory.getLogger(Auxiliary.class);
 
 	private AuxSensorProperties properties;
 	private boolean celsius;
 
-	public Aux(AuxSensorProperties properties, boolean celius) {
+	public Auxiliary(AuxSensorProperties properties, boolean celius) {
 		this.properties = properties;
 		this.celsius = celius;
 	}


### PR DESCRIPTION
Acording to http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx the following are reserved names and cannot be used as a filename (even with a extension)
CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
