### PR TITLE
Wrong parameters for RPC function init

### DIFF
--- a/bundles/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/bus/HomematicBinding.java
+++ b/bundles/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/bus/HomematicBinding.java
@@ -467,7 +467,7 @@ public class HomematicBinding extends AbstractActiveBinding<HomematicBindingProv
         }
         logger.debug("Removing callback handler.");
         try {
-            ccu.getConnection().init("", createHomematicId());
+            ccu.getConnection().init("http://" + callbackHost + ":" + callbackPort + "/xmlrpc", "");
             cbServer.stop();
         } catch (Exception e) {
             logger.debug("Error while unregistering callback server. Will be ignored.");


### PR DESCRIPTION
According to the HomeMatic XML RPC specification, to unregister a server, "interface_id" needs to be an empty string, not "url". I currently don't have a CCU to test this. So please check, if the change works. Also see: https://forum.homegear.eu/viewtopic.php?f=6&t=2&p=114#p105 and http://www.eq-3.de/Downloads/Software/HM-CCU2-Firmware_Updates/HM-CCU2-2.7.14/HM_XmlRpc_API-V2.100.pdf page 11.
