### PR TITLE
InsteonPLM Binding Device Additions

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
@@ -782,7 +782,7 @@ public class DeviceFeature implements StatePublisher {
 			f.setMessageDispatcher(new PassThroughDispatcher(f));
 			f.setDefaultMsgHandler(new LastTimeHandler(f));
 			f.setDefaultCommandHandler(new NoOpCommandHandler(f));
-		} else	if ( (s.equals("2477Ddimmer") || s.equals("2472Ddimmer")) ) {
+		} else	if ( (s.equals("2477Ddimmer") || s.equals("2472Ddimmer") || s.equals("2486DWH8dimmer") ) ) {
 			f = new DeviceFeature(s);
 			f.setMessageDispatcher(new DefaultDispatcher(f));
 			f.addMessageHandler(new Integer(0x06), new NoOpMsgHandler(f));
@@ -794,7 +794,7 @@ public class DeviceFeature implements StatePublisher {
 			f.addCommandHandler(PercentType.class, new PercentHandler(f));
 			f.addCommandHandler(OnOffType.class, new LightOnOffCommandHandler(f));
 			f.setPollHandler(new DefaultPollHandler(f));
-		} else	if ( (s.equals("2477Dlasttime") || s.equals("2472Dlasttime")) ) {
+		} else	if ( (s.equals("2477Dlasttime") || s.equals("2472Dlasttime") || s.equals("2486DWH8lasttime") ) ) {
 			f = new DeviceFeature(s);
 			f.setStatusFeature(true);
 			f.setMessageDispatcher(new PassThroughDispatcher(f));

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/categories.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/categories.xml
@@ -36,6 +36,15 @@ Example:
     	<feature name="lastheardfrom">2472Dlasttime</feature>
     </productKey>
   </subcategory>
+  <subcategory>
+    <name>KeypadLinc Dimmer</name>
+    <description>2486DWH8</description>
+    <subCat>0x1C</subCat>
+    <productKey name="0x000051">
+    	<feature name="dimmer">2486DWH8dimmer</feature>
+    	<feature name="lastheardfrom">2486DWH8lasttime</feature>
+    </productKey>
+  </subcategory>
 </category>
 <category>
   <name>Switch</name>


### PR DESCRIPTION
Added support to the Insteon PLM binding for the OutletLinc Dimmer (2472D) and KeypadLinc Dimmer (2486DWH8) devices.
