### PR TITLE
Fix for #1014 assume current level i 0 for new devices.

### DIFF
--- a/bundles/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickController.java
+++ b/bundles/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickController.java
@@ -68,7 +68,10 @@ public class TellstickController {
 	private void increaseDecrease(TellstickDevice dev, IncreaseDecreaseType increaseDecreaseType)
 			throws TellstickException {
 		String strValue = dev.getData();
-		double value = Double.valueOf(strValue);
+		double value = 0;
+		if (strValue != null) {
+			 value = Double.valueOf(strValue);
+		}
 		int precent = (int) ((value / 255) * 100);
 		if (IncreaseDecreaseType.INCREASE == increaseDecreaseType) {
 			if (precent < 100) {


### PR DESCRIPTION
Assume that current dimLevel is 0 when we don't have any data from Telldus Center.
