### PR TITLE
added feature to urtsi binding to address multiple daisy-chained devices

### DIFF
--- a/bundles/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/UrtsiBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/UrtsiBindingProvider.java
@@ -21,4 +21,5 @@ public interface UrtsiBindingProvider extends AutoUpdateBindingProvider {
 	String getDeviceId(String itemName);
 	
 	int getChannel (String itemName);
+	int getAddress (String itemName);
 }

--- a/bundles/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/internal/UrtsiBinding.java
+++ b/bundles/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/internal/UrtsiBinding.java
@@ -92,6 +92,7 @@ public class UrtsiBinding extends AbstractBinding<UrtsiBindingProvider>
 		}
 		
 		int channel = provider.getChannel(itemName);
+		int address = provider.getAddress(itemName);
 		
 		if (urtsiDevice != null) {
 			if (logger.isDebugEnabled()) {
@@ -123,7 +124,8 @@ public class UrtsiBinding extends AbstractBinding<UrtsiBindingProvider>
 			}
 			if (actionKey != null) {
 				String channelString = String.format("%02d", channel);
-				String command = "01" + channelString + actionKey;
+				String addressString = String.format("%02d", address);
+				String command = addressString + channelString + actionKey;
 				boolean executedSuccessfully = urtsiDevice.writeString(command);
 				if (!executedSuccessfully) {
 					if (logger.isErrorEnabled()) {

--- a/bundles/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/internal/UrtsiItemConfiguration.xtend
+++ b/bundles/binding/org.openhab.binding.urtsi/src/main/java/org/openhab/binding/urtsi/internal/UrtsiItemConfiguration.xtend
@@ -20,4 +20,9 @@ class UrtsiItemConfiguration implements BindingConfig {
 	 * Channel of the urtsi device
 	 */
 	int channel
+
+	/**
+	 * Address of the urtsi device
+	 */
+	int address
 }


### PR DESCRIPTION
Added ability to address more than one Somfy URTSI device.

Background: when using RS 485, multiple URTSI devices can be daisy chained. The original URTSI binding implementation allowed only one device to be addressed, since the device address was hard coded to device "01". The present pull request fixes this by allowing both the address and channel to be specified in the binding config:

before: urtsi="dev<n>:<channel>"
now: urtsi="dev<n>:<address>:<channel>"

Note that if there is only one parameter specified it is interpreted as a channel, i.e. the proposed feature is backwards compatible such that existing item configurations will not need to be changed.
