### PR TITLE
InsteonPLM binding: simplified  addition of new devices

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.insteonplm.internal.device;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -19,6 +20,7 @@ import org.openhab.binding.insteonplm.internal.driver.Driver;
 import org.openhab.binding.insteonplm.internal.message.FieldException;
 import org.openhab.binding.insteonplm.internal.message.Msg;
 import org.openhab.binding.insteonplm.internal.utils.Utils;
+import org.openhab.binding.insteonplm.internal.utils.Utils.ParsingException;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
@@ -47,12 +49,11 @@ import org.slf4j.LoggerFactory;
  * Lastly, StateListeners can register with the DeviceFeature to get notifications when
  * the state of a feature has changed.
  * 
- * The character of a DeviceFeature is thus given by its message and command handlers. The long
- * term goal is to abstract the logic into an xml file, such that new DeviceFeatures (for new devices)
- * can be plugged together from existing Handlers without touching the source code. Right now the
- * DeviceFeatures are hard coded in a factory method.
- * We decided to wait with going to xml until the problem domain (the quirks of the Insteon bus)
- * are better understood, and more devices are available for testing.
+ * The character of a DeviceFeature is thus given by a set of message and command handlers.
+ * A FeatureTemplate captures exactly that: it says what set of handlers make up a DeviceFeature.
+ * 
+ * DeviceFeatures are added to a new device by referencing a FeatureTemplate (defined in device_features.xml)
+ * from the Device definition file (categories.xml).
  * 
  * @author Daniel Pfrommer
  * @author Bernd Pfrommer
@@ -67,15 +68,17 @@ public class DeviceFeature implements StatePublisher {
 
 	private static final Logger logger = LoggerFactory.getLogger(DeviceFeature.class);
 	
+	private static HashMap<String, FeatureTemplate> s_features = new HashMap<String, FeatureTemplate>();
+	
 	private InsteonDevice				m_device = null;
 	private String						m_name	 = "INVALID_FEATURE_NAME";
-	private boolean						m_isStatus = false;
+	private boolean					m_isStatus = false;
 	private QueryStatus	                m_queryStatus = QueryStatus.NEVER_QUERIED;
 	
 	private MessageHandler				m_defaultMsgHandler = new DefaultMsgHandler(this);
 	private CommandHandler				m_defaultCommandHandler = new WarnCommandHandler(this);
 	private PollHandler					m_pollHandler = null;
-	private	MessageDispatcher			m_dispatcher = null;
+	private	 MessageDispatcher			m_dispatcher = null;
 	private HashMap<String, String>		m_parameters = new HashMap<String, String>();
 
 	private HashMap<Integer, MessageHandler> m_msgHandlers =
@@ -83,6 +86,20 @@ public class DeviceFeature implements StatePublisher {
 	private HashMap<Class<? extends Command>, CommandHandler> m_commandHandlers =
 				new HashMap<Class<? extends Command>, CommandHandler>();
 	private ArrayList<StateListener> m_listeners = new ArrayList<StateListener>();
+	
+	static {
+		try {
+			InputStream input = DeviceFeature.class.getResourceAsStream("/device_features.xml");
+			ArrayList<FeatureTemplate> features = XMLDeviceFeatureReader.s_readTemplates(input);
+			for (FeatureTemplate f : features) {
+				s_features.put(f.getName(), f);
+			}
+		} catch (IOException e) {
+			logger.error("IOException while reading device features", e);
+		} catch (ParsingException e) {
+			logger.error("Parsing exception while reading device features", e);
+		}
+	}
 	
 	/**
 	 * Constructor
@@ -102,27 +119,26 @@ public class DeviceFeature implements StatePublisher {
 		m_name = name;
 	}
 	
-	public String	 	 getName()			{ return m_name; }
-	public QueryStatus	 getQueryStatus()	{ return m_queryStatus; }
-	public String		 getParameter(String p)	{ return m_parameters.get(p); }
+	public String	 	getName()			{ return m_name; }
+	public QueryStatus	getQueryStatus()	{ return m_queryStatus; }
+	public String		getParameter(String p)	{ return m_parameters.get(p); }
 	public InsteonDevice getDevice() 		{ return m_device; }
-	public boolean 	hasListeners() 			{ return !m_listeners.isEmpty(); }
-	public boolean	isStatusFeature()		{ return m_isStatus; }
+	public boolean 	hasListeners() 		{ return !m_listeners.isEmpty(); }
+	public boolean		isStatusFeature()	{ return m_isStatus; }
 	
 	
-	public void	setStatusFeature(boolean f)		{ m_isStatus = f; }
-	public void	setPollHandler(PollHandler h)	{ m_pollHandler = h; }
-	public void	setDevice(InsteonDevice d)		{ m_device = d; }
+	public void setStatusFeature(boolean f)	{ m_isStatus = f; }
+	public void setPollHandler(PollHandler h)	{ m_pollHandler = h; }
+	public void setDevice(InsteonDevice d)		{ m_device = d; }
 	public void setMessageDispatcher(MessageDispatcher md) { m_dispatcher = md; }
 	public void setDefaultCommandHandler(CommandHandler ch) { m_defaultCommandHandler = ch; }
 	public void setDefaultMsgHandler(MessageHandler mh) { m_defaultMsgHandler = mh; }
 	public void setParameters(HashMap<String,String> p) { m_parameters = p;	}
 	
-	public void	 setQueryStatus(QueryStatus status)	{
+	public void setQueryStatus(QueryStatus status)	{
 		logger.trace("{} set query status to: {}", m_name, status);
 		m_queryStatus = status;
 	}
-	
 
 	public void addListener(StateListener l) {
 		synchronized(m_listeners) {
@@ -185,13 +201,11 @@ public class DeviceFeature implements StatePublisher {
 		return m_name + "(" + m_listeners.size()  +":" +m_commandHandlers.size() + ":" + m_msgHandlers.size() + ")";
 	}
 	
-	//
-	// --- handlers for various incoming Insteon messages --------
-	//
 	/**
 	 * Base class for all message handlers. A message handler processes incoming
 	 * Insteon messages and reacts by publishing corresponding messages on the openhab
 	 * bus, updates device state etc.
+	 * @author Daniel Pfrommer
 	 */
 	public static abstract class MessageHandler {
 		StatePublisher m_pub = null;
@@ -199,7 +213,7 @@ public class DeviceFeature implements StatePublisher {
 		 * Constructor
 		 * @param p state publishing object for dissemination of state changes
 		 */
-		MessageHandler(StatePublisher p) {
+		MessageHandler(DeviceFeature p) {
 				m_pub = p;
 		}
 		/**
@@ -213,10 +227,11 @@ public class DeviceFeature implements StatePublisher {
 		 */
 		public abstract void handleMessage(byte cmd1, Msg msg, DeviceFeature feature,
 									String fromPort);
+		
 	}
 	
 	public static class DefaultMsgHandler extends MessageHandler {
-		DefaultMsgHandler(StatePublisher p) { super(p); }
+		DefaultMsgHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
@@ -225,7 +240,7 @@ public class DeviceFeature implements StatePublisher {
 	}
 
 	public static class NoOpMsgHandler extends MessageHandler {
-		NoOpMsgHandler(StatePublisher p) { super(p); }
+		NoOpMsgHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
@@ -234,7 +249,7 @@ public class DeviceFeature implements StatePublisher {
 	}
 
 	public static class LightOnDimmerHandler extends MessageHandler {
-		LightOnDimmerHandler(StatePublisher p) { super(p); }
+		LightOnDimmerHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
@@ -273,7 +288,7 @@ public class DeviceFeature implements StatePublisher {
 		}
 	}
 	public static class LightOnSwitchHandler extends MessageHandler {
-		LightOnSwitchHandler(StatePublisher p) { super(p); }
+		LightOnSwitchHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
@@ -282,16 +297,22 @@ public class DeviceFeature implements StatePublisher {
 	}
 	
 	public static class LightOffHandler extends MessageHandler {
-		LightOffHandler(StatePublisher p) { super(p); }
+		LightOffHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
 			m_pub.publish(OnOffType.OFF);
 		}
 	}
-	
+	/**
+	 * A message handler which reads the command2 field
+	 * if command2 == 0xFF then the light has been turned on
+	 * else if command2 == 0x00 then the light has been turned off
+	 * it should ideally be mapped to the 0x19 command byte so that it reads
+	 * the status request acks sent back by the switch
+	 */
 	public static class LightStateSwitchHandler extends  MessageHandler {
-		LightStateSwitchHandler(StatePublisher p) { super(p); }
+		LightStateSwitchHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
@@ -313,8 +334,13 @@ public class DeviceFeature implements StatePublisher {
 			}
 		}
 	}
+	/**
+	 * Similar to the LightStateSwitchHandler, but for a dimmer
+	 * In the dimmers case the command2 byte represents the light level from 0-255
+	 * @see LightStateSwitchHandler
+	 */
 	public static class LightStateDimmerHandler extends  MessageHandler {
-		LightStateDimmerHandler(StatePublisher p) { super(p); }
+		LightStateDimmerHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
@@ -344,7 +370,7 @@ public class DeviceFeature implements StatePublisher {
 	}
 	
 	public static class StopManualChangeHandler extends MessageHandler {
-		StopManualChangeHandler(StatePublisher p) { super(p); }
+		StopManualChangeHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
@@ -354,7 +380,7 @@ public class DeviceFeature implements StatePublisher {
 	}
 	
 	public static class InfoRequestReplyHandler extends MessageHandler {
-		InfoRequestReplyHandler(StatePublisher p) { super(p); }
+		InfoRequestReplyHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
@@ -387,7 +413,7 @@ public class DeviceFeature implements StatePublisher {
 	}
 
 	public static class LastTimeHandler extends MessageHandler {
-		LastTimeHandler(StatePublisher p) { super(p); }
+		LastTimeHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1a, Msg msg, DeviceFeature f,
 					String fromPort) {
@@ -400,7 +426,7 @@ public class DeviceFeature implements StatePublisher {
 
 	
 	public static class StateContactHandler extends MessageHandler {
-		StateContactHandler(StatePublisher p) { super(p); }
+		StateContactHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1a, Msg msg, DeviceFeature f,
 					String fromPort) {
@@ -423,7 +449,7 @@ public class DeviceFeature implements StatePublisher {
 	}
 	
 	public static class ClosedContactHandler extends MessageHandler {
-		ClosedContactHandler(StatePublisher p) { super(p); }
+		ClosedContactHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
@@ -432,17 +458,13 @@ public class DeviceFeature implements StatePublisher {
 	}
 
 	public static class OpenedContactHandler extends MessageHandler {
-		OpenedContactHandler(StatePublisher p) { super(p); }
+		OpenedContactHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
 				String fromPort) {
 			m_pub.publish(OpenClosedType.OPEN);
 		}
 	}
-
-	//
-	// --- poll handlers create the appropriate polling messages
-	//
 
 	/**
 	 * A PollHandler creates an Insteon message to query a particular
@@ -452,11 +474,11 @@ public class DeviceFeature implements StatePublisher {
 		DeviceFeature m_feature = null;
 		/**
 		 * Constructor
-		 * @param feature The device feature to be polled
+		 * @param feature The device feature being polled
 		 */
 		PollHandler(DeviceFeature feature) {
 			m_feature = feature;
-		}
+		}		
 		/**
 		 * Creates Insteon message that can be used to poll a feature
 		 * via the Insteon network.
@@ -509,9 +531,6 @@ public class DeviceFeature implements StatePublisher {
 			return null;
 		}
 	}
-	//
-	// --- command handlers to translate OpenHAB commands into insteon messages
-	//
 	/**
 	 * A command handler translates an openHAB command into a insteon message
 	 *
@@ -526,7 +545,7 @@ public class DeviceFeature implements StatePublisher {
 		 */
 		CommandHandler(DeviceFeature feature) {
 			m_feature = feature;
-		}
+		}	
 		/**
 		 * Implements what to do when an openHAB command is received
 		 * @param cmd the openhab command issued
@@ -674,13 +693,12 @@ public class DeviceFeature implements StatePublisher {
 				}
 			}
 		}
-
 	}
 	/**
 	 * Does preprocessing of messages to decide which handler should be called
 	 *
 	 */
-	private static abstract class MessageDispatcher {
+	public static abstract class MessageDispatcher {
 		DeviceFeature m_feature = null;
 		/**
 		 * Constructor
@@ -695,7 +713,7 @@ public class DeviceFeature implements StatePublisher {
 		 * @param port Insteon device ('/dev/usb') from which the message came
 		 * @return true if dispatch was successful, false otherwise
 		 */
-		abstract boolean dispatch(Msg msg, String port);
+		public abstract boolean dispatch(Msg msg, String port);
 	}
 
 	private static class DefaultDispatcher extends MessageDispatcher {
@@ -758,8 +776,7 @@ public class DeviceFeature implements StatePublisher {
 	}
 	
 	/**
-	 * Factory method for creating DeviceFeatures. Once the problem domain is better understood
-	 * and there are more devices, this should be done with an xml file.
+	 * Factory method for creating DeviceFeatures.
 	 * @param s The name of the device feature to create.
 	 * @return The newly created DeviceFeature, or null if requested DeviceFeature does not exist.
 	 */
@@ -768,87 +785,45 @@ public class DeviceFeature implements StatePublisher {
 		DeviceFeature f = null;
 		if (s.equals("PLACEHOLDER")) {
 			f = new DeviceFeature("PLACEHOLDER");
-		} else	if (s.equals("2477Sswitch")) {
-			f = new DeviceFeature("2477Sswitch");
-			f.setMessageDispatcher(new DefaultDispatcher(f));
-			f.addMessageHandler(new Integer(0x11), new LightOnSwitchHandler(f));
-			f.addMessageHandler(new Integer(0x13), new LightOffHandler(f));
-			f.addMessageHandler(new Integer(0x19), new LightStateSwitchHandler(f));
-			f.addCommandHandler(OnOffType.class, new LightOnOffCommandHandler(f));
-			f.setPollHandler(new DefaultPollHandler(f));
-		} else	if (s.equals("2477Slasttime")) {
-			f = new DeviceFeature("2477Slasttime");
-			f.setStatusFeature(true);
-			f.setMessageDispatcher(new PassThroughDispatcher(f));
-			f.setDefaultMsgHandler(new LastTimeHandler(f));
-			f.setDefaultCommandHandler(new NoOpCommandHandler(f));
-		} else	if ( (s.equals("2477Ddimmer") || s.equals("2472Ddimmer") || s.equals("2486DWH8dimmer") ) ) {
-			f = new DeviceFeature(s);
-			f.setMessageDispatcher(new DefaultDispatcher(f));
-			f.addMessageHandler(new Integer(0x06), new NoOpMsgHandler(f));
-			f.addMessageHandler(new Integer(0x11), new LightOnDimmerHandler(f));
-			f.addMessageHandler(new Integer(0x13), new LightOffHandler(f));
-			f.addMessageHandler(new Integer(0x17), new NoOpMsgHandler(f));
-			f.addMessageHandler(new Integer(0x18), new StopManualChangeHandler(f));
-			f.addMessageHandler(new Integer(0x19), new LightStateDimmerHandler(f));
-			f.addCommandHandler(PercentType.class, new PercentHandler(f));
-			f.addCommandHandler(OnOffType.class, new LightOnOffCommandHandler(f));
-			f.setPollHandler(new DefaultPollHandler(f));
-		} else	if ( (s.equals("2477Dlasttime") || s.equals("2472Dlasttime") || s.equals("2486DWH8lasttime") ) ) {
-			f = new DeviceFeature(s);
-			f.setStatusFeature(true);
-			f.setMessageDispatcher(new PassThroughDispatcher(f));
-			f.setDefaultMsgHandler(new LastTimeHandler(f));
-			f.setDefaultCommandHandler(new NoOpCommandHandler(f));
-		} else	if (s.equals("2450IOLincContact")) {
-			f = new DeviceFeature("2450IOLincContact");
-			f.setMessageDispatcher(new DefaultDispatcher(f));
-			f.addMessageHandler(new Integer(0x06), new NoOpMsgHandler(f));
-			f.addMessageHandler(new Integer(0x11), new OpenedContactHandler(f));
-			f.addMessageHandler(new Integer(0x13), new ClosedContactHandler(f));
-			f.addMessageHandler(new Integer(0x19), new StateContactHandler(f));
-			f.addCommandHandler(OnOffType.class, new NoOpCommandHandler(f));
-			f.setPollHandler(new ContactPollHandler(f));
-		} else	if (s.equals("2842contact")) {
-			f = new DeviceFeature("2842contact");
-			f.setMessageDispatcher(new DefaultDispatcher(f));
-			f.addMessageHandler(new Integer(0x06), new NoOpMsgHandler(f));
-			f.addMessageHandler(new Integer(0x11), new OpenedContactHandler(f));
-			f.addMessageHandler(new Integer(0x13), new ClosedContactHandler(f));
-			f.addCommandHandler(OnOffType.class, new NoOpCommandHandler(f));
-			f.setPollHandler(new NoPollHandler(f));
-		} else	if (s.equals("2450IOLincSwitch")) {
-			f = new DeviceFeature("2450IOLincSwitch");
-			f.setMessageDispatcher(new DefaultDispatcher(f));
-			f.addMessageHandler(new Integer(0x06), new NoOpMsgHandler(f));
-			f.addMessageHandler(new Integer(0x11), new NoOpMsgHandler(f));
-			f.addMessageHandler(new Integer(0x13), new NoOpMsgHandler(f));
-			f.addMessageHandler(new Integer(0x19), new LightStateSwitchHandler(f));
-			f.addCommandHandler(OnOffType.class, new IOLincOnOffCommandHandler(f));
-			f.setPollHandler(new DefaultPollHandler(f));
-		} else	if (s.equals("2450IOLinclasttime")) {
-			f = new DeviceFeature("2450IOLinclasttime");
-			f.setStatusFeature(true);
-			f.setMessageDispatcher(new PassThroughDispatcher(f));
-			f.setDefaultMsgHandler(new LastTimeHandler(f));
-			f.setDefaultCommandHandler(new NoOpCommandHandler(f));
-		} else	if (s.equals("2842lasttime")) {
-			f = new DeviceFeature("2842lasttime");
-			f.setStatusFeature(true);
-			f.setMessageDispatcher(new PassThroughDispatcher(f));
-			f.setDefaultMsgHandler(new LastTimeHandler(f));
-			f.setDefaultCommandHandler(new NoOpCommandHandler(f));
-		} else	if (s.equals("2413Ucontrol")) {
-			f = new DeviceFeature("2413Ucontrol");
-			f.setStatusFeature(false);
-			f.setMessageDispatcher(new PassThroughDispatcher(f));
-			f.setDefaultMsgHandler(new NoOpMsgHandler(f));
-			f.addCommandHandler(DecimalType.class, new ModemCommandHandler(f));
+		} else if (s_features.containsKey(s)) {
+			f = s_features.get(s).build();
 		} else {
 			logger.error("unimplemented feature requested: {}", s);
 		}
 		return f;
 	}
-	
-}
 
+	/**
+	 * Factory method for creating device dispatchers given a name.
+	 * The name is usually the class name.
+	 * @param name the name of the dispatcher to create
+	 * @param f the feature for which to create the dispatcher
+	 * @return the dispatcher which was created
+	 */
+	public static MessageDispatcher s_makeMessageDispatcher(String name, DeviceFeature f) {
+		if (name.equals("PassThroughDispatcher")) return new PassThroughDispatcher(f);
+		else if (name.equals("DefaultDispatcher")) return new DefaultDispatcher(f);
+		else {
+			logger.error("unimplemented message dispatcher requested: {}", name);
+			return null;
+		}
+	}
+	/**
+	 * Factory method for creating handlers of a given name using java reflection
+	 * @param name the name of the handler to create
+	 * @param f the feature for which to create the handler
+	 * @return the handler which was created
+	 */
+	public static <T> T s_makeHandler(String name, DeviceFeature f) {
+		String cname = DeviceFeature.class.getName() + "$" + name;
+		try {
+			Class<?> c = Class.forName(cname);
+			@SuppressWarnings("unchecked")
+			Class<? extends T> dc = (Class <? extends T>) c;
+			return dc.getDeclaredConstructor(DeviceFeature.class).newInstance(f);
+		} catch (Exception e) {
+			logger.error("error trying to create message handler: {}", name, e);
+		}
+		return null;
+	}
+}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/FeatureTemplate.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/FeatureTemplate.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2010-2013, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.insteonplm.internal.device;
+
+import java.util.HashMap;
+import java.util.Map.Entry;
+
+import org.openhab.core.types.Command;
+
+/**
+ * A simple class which contains the basic info needed to create a device feature.
+ * Here, all handlers are represented as strings. The actual device feature
+ * is then instantiated from the template by calling the build() function.
+ * 
+ * @author Daniel Pfrommer
+ * @since 1.5.0
+ */
+public class FeatureTemplate {
+	private String m_name;
+	private boolean m_isStatus;
+	
+	private String m_dispatcher = null;
+	private String m_pollHandler = null;
+	private String m_defaultMsgHandler = null;
+	private String m_defaultCmdHandler = null;
+	private HashMap<Integer, String> m_messageHandlers = new HashMap<Integer, String>();
+	private HashMap<Class<? extends Command>, String> m_commandHandlers = new HashMap<Class<? extends Command>, String>();
+	
+	public String getName() { return m_name; }
+	public boolean isStatusFeature() { return m_isStatus; }
+	public String getPollHandler() { return m_pollHandler; }
+	public String getDispatcher() { return m_dispatcher; }
+	public String getDefaultCommandHandler() { return m_defaultCmdHandler; }
+	public String getDefaultMessageHandler() { return m_defaultMsgHandler; }
+	
+	/**
+	 * Retrieves a hashmap of message command code to command handler name
+	 * @return a Hashmap from Integer to String representing the command codes and the associated message handlers
+	 */
+	public HashMap<Integer, String> getMessageHandlers() { return m_messageHandlers; }
+	/**
+	 * Similar to getMessageHandlers(), but for command handlers
+	 * Instead of Integers it uses the class of the Command as a key
+	 * @see #getMessageHandlers()
+	 * @return a HashMap from Command Classes to CommandHandler names
+	 */
+	public HashMap<Class<? extends Command>, String> getCommandHandlers() { return m_commandHandlers; }
+	
+	public void setName(String name) { m_name = name; }
+	
+	public void setStatusFeature(boolean status) { m_isStatus = status; }
+	
+	public void setMessageDispatcher(String dispatcher) { m_dispatcher = dispatcher; }
+	public void setPollHandler(String poll) { m_pollHandler = poll; }
+	public void setDefaultCommandHandler(String cmd) { m_defaultCmdHandler = cmd; }
+	public void setDefaultMessageHandler(String msg) { m_defaultMsgHandler = msg; }
+	/**
+	 * Adds a message handler mapped from the command which this handler should be invoked for
+	 * to the name of the handler to be created
+	 */
+	public void addMessageHandler(int cmd, String handler) {
+		m_messageHandlers.put(cmd, handler);
+	}
+	/**
+	 * Adds a command handler mapped from the command class which this handler should be invoke for
+	 * to the name of the handler to be created
+	 */
+	public void addCommandHandler(Class<? extends Command> command, String handler) {
+		m_commandHandlers.put(command, handler);
+	}
+	/**
+	 * Builds the actual feature
+	 * @return the feature which this template describes
+	 */
+	public DeviceFeature build() {
+		DeviceFeature f = new DeviceFeature(m_name);
+		f.setStatusFeature(m_isStatus);
+		
+		if (m_dispatcher != null) f.setMessageDispatcher((DeviceFeature.MessageDispatcher)
+													DeviceFeature.s_makeHandler(m_dispatcher, f));
+		if (m_pollHandler != null) f.setPollHandler((DeviceFeature.PollHandler)DeviceFeature.s_makeHandler(m_pollHandler, f));
+		if (m_defaultCmdHandler != null) f.setDefaultCommandHandler((DeviceFeature.CommandHandler)
+													DeviceFeature.s_makeHandler(m_defaultCmdHandler, f));
+		if (m_defaultMsgHandler != null) f.setDefaultMsgHandler((DeviceFeature.MessageHandler)
+													DeviceFeature.s_makeHandler(m_defaultMsgHandler, f));
+		for (Entry<Integer, String> mH : m_messageHandlers.entrySet()) {
+			f.addMessageHandler(mH.getKey(), (DeviceFeature.MessageHandler)DeviceFeature.s_makeHandler(mH.getValue(), f));
+		}
+		for (Entry<Class<? extends Command>, String> cH : m_commandHandlers.entrySet()) {
+			f.addCommandHandler(cH.getKey(), (DeviceFeature.CommandHandler)DeviceFeature.s_makeHandler(cH.getValue(), f));
+		}
+		return f;
+	}
+	
+	public String toString() {
+		return getName() + "(" + isStatusFeature() + ")";
+	}
+}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/XMLDeviceFeatureReader.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/XMLDeviceFeatureReader.java
@@ -1,0 +1,133 @@
+package org.openhab.binding.insteonplm.internal.device;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.openhab.binding.insteonplm.internal.utils.Utils;
+import org.openhab.binding.insteonplm.internal.utils.Utils.ParsingException;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.types.Command;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+public class XMLDeviceFeatureReader {
+	public static ArrayList<FeatureTemplate> s_readTemplates(InputStream input)
+			throws IOException, ParsingException {
+		ArrayList<FeatureTemplate> features = new ArrayList<FeatureTemplate>();
+		try {
+			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+			//Parse it!
+			Document doc = dBuilder.parse(input);
+			doc.getDocumentElement().normalize();
+
+			Element root = doc.getDocumentElement();
+
+			NodeList nodes = root.getChildNodes();
+
+			for (int i = 0; i < nodes.getLength(); i++) {
+				Node node  = nodes.item(i);
+				if (node.getNodeType() == Node.ELEMENT_NODE) {
+					Element e = (Element) node;
+					if (e.getTagName().equals("feature")) features.add(s_parseFeature(e));
+				}
+			}
+		} catch (SAXException e) {
+			throw new ParsingException("Failed to parse XML!", e);
+		} catch (ParserConfigurationException e) {
+			throw new ParsingException("Got parser config exception! ", e);
+		}
+		return features;
+	}
+	private static FeatureTemplate s_parseFeature(Element e) throws ParsingException {
+		String name = e.getAttribute("name");
+		boolean statusFeature = e.getAttribute("statusFeature").equals("true");
+		FeatureTemplate feature = new FeatureTemplate();
+		feature.setName(name);
+		feature.setStatusFeature(statusFeature);
+		
+		NodeList nodes = e.getChildNodes();
+		
+		for (int i = 0; i < nodes.getLength(); i++) {
+			Node node  = nodes.item(i);
+			if (node.getNodeType() == Node.ELEMENT_NODE) {
+				Element child = (Element) node;
+				if (child.getTagName().equals("message-handler")) {
+					s_parseMessageHandler(child, feature);
+				} else if (child.getTagName().equals("command-handler")) {
+					s_parseCommandHandler(child, feature);
+				} else if (child.getTagName().equals("message-dispatcher")) {
+					s_parseMessageDispatcher(child, feature);
+				} else if (child.getTagName().equals("poll-handler")) {
+					s_parsePollHandler(child, feature);
+				}
+			}
+		}
+		
+		return feature;
+	}
+	private static void s_parseMessageHandler(Element e, FeatureTemplate f) throws DOMException, ParsingException {
+		String handler = e.getTextContent();
+		if (handler == null) throw new ParsingException("Could not find MessageHandler for: " + e.getTextContent());
+		if (e.getAttribute("default").equals("true")) {
+			f.setDefaultMessageHandler(handler);
+		} else {
+			int command = Utils.from0xHexString(e.getAttribute("cmd"));
+			f.addMessageHandler(command, handler);
+		}
+	}
+	private static void s_parseCommandHandler(Element e, FeatureTemplate f) throws ParsingException {
+		String handler = e.getTextContent();
+		if (handler == null) throw new ParsingException("Could not find CommandHandler for: " + e.getTextContent());
+		if (e.getAttribute("default").equals("true")) {
+			f.setDefaultCommandHandler(handler);
+		} else {
+			Class<? extends Command> command = s_parseCommandClass(e.getAttribute("command"));
+			f.addCommandHandler(command, handler);
+		}
+	}
+	private static void s_parseMessageDispatcher(Element e, FeatureTemplate f) throws DOMException, ParsingException {
+		String dispatcher = e.getTextContent();
+		if (dispatcher == null) throw new ParsingException("Could not find MessageDispatcher for: " + e.getTextContent());
+		f.setMessageDispatcher(dispatcher);
+	}
+	private static void s_parsePollHandler(Element e, FeatureTemplate f) throws ParsingException {
+		String pollHandler = e.getTextContent();
+		if (pollHandler == null) throw new ParsingException("Could not find PollHandler: " + pollHandler);
+		f.setPollHandler(pollHandler);
+	}
+	
+	private static Class<? extends Command> s_parseCommandClass(String c) throws ParsingException {
+		if (c.equals("OnOffType")) return OnOffType.class;
+		else if (c.equals("PercentType")) return PercentType.class;
+		else if (c.equals("DecimalType")) return DecimalType.class;
+		else throw new ParsingException("Unknown Command Type");
+	}
+	
+	public static void main(String[] args) throws Exception {
+		File f = new File(System.getProperty("user.home") + 
+				"/workspace/openhab/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml");
+		InputStream s = new FileInputStream(f);
+		ArrayList<FeatureTemplate> features = s_readTemplates(s);
+		for (FeatureTemplate feature : features) {
+			System.out.println(feature);
+			System.out.println("\tPOLL: " + feature.getPollHandler() + "\n\tDISPATCH: " + feature.getDispatcher());
+			System.out.println("\tDCH: " + feature.getDefaultCommandHandler() + "\n\tDMH: " + feature.getDefaultMessageHandler());
+			System.out.println("\tMSG HANDLERS: " + feature.getMessageHandlers());
+			System.out.println("\tCMD HANDLERS: " + feature.getCommandHandlers());
+		}
+	}
+}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/Msg.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/Msg.java
@@ -15,8 +15,8 @@ import java.util.HashMap;
 import java.util.TreeSet;
 
 import org.openhab.binding.insteonplm.internal.device.InsteonAddress;
-import org.openhab.binding.insteonplm.internal.message.XMLMessageReader.ParsingException;
 import org.openhab.binding.insteonplm.internal.utils.Utils;
+import org.openhab.binding.insteonplm.internal.utils.Utils.ParsingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/XMLMessageReader.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/XMLMessageReader.java
@@ -20,9 +20,9 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.openhab.binding.insteonplm.internal.device.InsteonAddress;
 import org.openhab.binding.insteonplm.internal.utils.Pair;
-import org.openhab.binding.insteonplm.internal.utils.Utils;
+import org.openhab.binding.insteonplm.internal.utils.Utils.DataTypeParser;
+import org.openhab.binding.insteonplm.internal.utils.Utils.ParsingException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -37,18 +37,6 @@ import org.xml.sax.SAXException;
 */
 
 public class XMLMessageReader {
-	/**
-	 * Exception to indicate various xml parsing errors.
-	 */
-	@SuppressWarnings("serial")
-	public static class ParsingException  extends Exception { 
-		public ParsingException(String msg) {
-			super(msg);
-		}
-		public ParsingException(String msg, Throwable cause) {
-			super(msg, cause);
-		}
-	}
 	/**
 	 * Reads the message definitions from an xml file
 	 * @param input input stream from which to read
@@ -157,7 +145,7 @@ public class XMLMessageReader {
 		Field f = new Field(name, dType, offset);
 		//Now we have field, only need value
 		String sVal = field.getTextContent();
-		Object val = FieldValueParser.s_parseDataType(dType, sVal);
+		Object val = DataTypeParser.s_parseDataType(dType, sVal);
 		Pair<Field, Object> pair = new Pair<Field, Object>(f, val);
 		return pair;
 	}
@@ -172,38 +160,7 @@ public class XMLMessageReader {
 		return msg;
 	}
 	
-	private static class FieldValueParser {
-		public static Object s_parseDataType(DataType type, String val) {
-			switch(type) {
-			case BYTE: 		return s_parseByte(val);
-			case INT:		return s_parseInt(val);
-			case FLOAT: 	return s_parseFloat(val);
-			case ADDRESS:	return s_parseAddress(val);
-			default : throw new IllegalArgumentException("Data Type not implemented in Field Value Parser!");
-			}
-		}
-		
-		public static byte s_parseByte(String val) {
-			if (val != null && !val.trim().equals("")) {
-				return (byte) Utils.from0xHexString(val.trim());
-			} else return 0x00;
-		}
-		public static int s_parseInt(String val) {
-			if (val != null && !val.trim().equals("")) {
-				return Integer.parseInt(val);
-			} else return 0x00;
-		}
-		public static float s_parseFloat(String val) {
-			if (val != null && !val.trim().equals("")) {
-				return Float.parseFloat(val.trim());
-			} else return 0;
-		}
-		public static InsteonAddress s_parseAddress(String val) {
-			if (val != null && !val.trim().equals("")) {
-				return InsteonAddress.s_parseAddress(val.trim());
-			} else return new InsteonAddress();
-		}
-	}
+
 	public static void main(String[] args) throws Exception {
 		// for local testing
 		File f = new File(System.getProperty("user.home") + 

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/utils/Utils.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/utils/Utils.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.insteonplm.internal.utils;
 
+import org.openhab.binding.insteonplm.internal.device.InsteonAddress;
+import org.openhab.binding.insteonplm.internal.message.DataType;
+
 /**
  * Various utility functions for e.g. hex string parsing
  * @author Daniel Pfrommer
@@ -47,5 +50,49 @@ public class Utils {
 	
 	public static String getHexByte(int b) {
 		return String.format("0x%02X", b);
+	}
+	public static class DataTypeParser {
+		public static Object s_parseDataType(DataType type, String val) {
+			switch(type) {
+			case BYTE: 		return s_parseByte(val);
+			case INT:		return s_parseInt(val);
+			case FLOAT: 	return s_parseFloat(val);
+			case ADDRESS:	return s_parseAddress(val);
+			default : throw new IllegalArgumentException("Data Type not implemented in Field Value Parser!");
+			}
+		}
+		
+		public static byte s_parseByte(String val) {
+			if (val != null && !val.trim().equals("")) {
+				return (byte) Utils.from0xHexString(val.trim());
+			} else return 0x00;
+		}
+		public static int s_parseInt(String val) {
+			if (val != null && !val.trim().equals("")) {
+				return Integer.parseInt(val);
+			} else return 0x00;
+		}
+		public static float s_parseFloat(String val) {
+			if (val != null && !val.trim().equals("")) {
+				return Float.parseFloat(val.trim());
+			} else return 0;
+		}
+		public static InsteonAddress s_parseAddress(String val) {
+			if (val != null && !val.trim().equals("")) {
+				return InsteonAddress.s_parseAddress(val.trim());
+			} else return new InsteonAddress();
+		}
+	}
+	/**
+	 * Exception to indicate various xml parsing errors.
+	 */
+	@SuppressWarnings("serial")
+	public static class ParsingException  extends Exception { 
+		public ParsingException(String msg) {
+			super(msg);
+		}
+		public ParsingException(String msg, Throwable cause) {
+			super(msg, cause);
+		}
 	}
 }

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/categories.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/categories.xml
@@ -19,12 +19,66 @@ Example:
   <description>Dimmable Lighting Control</description>
   <devCat>0x01</devCat>
   <subcategory>
+    <name>LampLinc V2</name>
+    <description>2456D3</description>
+    <subCat>0x00</subCat>
+    <productKey name="F00.00.05">
+    	<feature name="dimmer">GenericDimmer</feature>
+    	<feature name="lastheardfrom">GenericLastTime</feature>
+    </productKey>
+  </subcategory>
+  <subcategory>
+    <name>KepadLinc Dimmer</name>
+    <description>2486D</description>
+    <subCat>0x09</subCat>
+    <productKey name="0x000037">
+    	<feature name="dimmer">GenericDimmer</feature>
+    	<feature name="lastheardfrom">GenericLastTime</feature>
+    </productKey>
+  </subcategory>
+  <subcategory>
+    <name>KeypadLinc Dimmer</name>
+    <description>2486DWH8</description>
+    <subCat>0x1C</subCat>
+    <productKey name="0x000051">
+    	<feature name="dimmer">GenericDimmer</feature>
+    	<feature name="lastheardfrom">GenericLastTime</feature>
+    </productKey>
+  </subcategory>
+  <subcategory>
     <name>SwitchLinc Dimmer</name>
     <description>2477D</description>
     <subCat>0x20</subCat>
     <productKey name="F00.00.01">
-    	<feature name="dimmer">2477Ddimmer</feature>
-    	<feature name="lastheardfrom">2477Dlasttime</feature>
+    	<feature name="dimmer">GenericDimmer</feature>
+    	<feature name="lastheardfrom">GenericLastTime</feature>
+    </productKey>
+  </subcategory>
+  <subcategory>
+    <name>OutletLinc Dimmer</name>
+    <description>2472D</description>
+    <subCat>0x21</subCat>
+    <productKey name="0x000068">
+    	<feature name="dimmer">GenericDimmer</feature>
+ 	<feature name="lastheardfrom">GenericLastTime</feature>
+    </productKey>
+  </subcategory>
+  <subcategory>
+    <name>DIN Rail Dimmer</name>
+    <description>2452-222</description>
+    <subCat>0x34</subCat>
+    <productKey name="F00.00.08">
+    	<feature name="dimmer">GenericDimmer</feature>
+ 	<feature name="lastheardfrom">GenericLastTime</feature>
+    </productKey>
+  </subcategory>
+  <subcategory>
+    <name>Micro Dimmer</name>
+    <description>2442-222</description>
+    <subCat>0x35</subCat>
+    <productKey name="F00.00.06">
+    	<feature name="dimmer">GenericDimmer</feature>
+ 	<feature name="lastheardfrom">GenericLastTime</feature>
     </productKey>
   </subcategory>
   <subcategory>
@@ -51,12 +105,30 @@ Example:
   <description>Switchable Lighting</description>
   <devCat>0x02</devCat>
   <subcategory>
+    <name>ICON Switch</name>
+    <description>2876S</description>
+    <subCat>0x0B</subCat>
+    <productKey name="F00.00.04">
+    	<feature name="switch">GenericSwitch</feature>
+    	<feature name="lastheardfrom">GenericLastTime</feature>
+    </productKey>
+  </subcategory>
+  <subcategory>
     <name>SwitchLinc Switch</name>
-    <description>Switch</description>
+    <description>2477S</description>
     <subCat>0x2A</subCat>
     <productKey name="F00.00.02">
-    	<feature name="switch">2477Sswitch</feature>
-    	<feature name="lastheardfrom">2477Slasttime</feature>
+    	<feature name="switch">GenericSwitch</feature>
+    	<feature name="lastheardfrom">GenericLastTime</feature>
+    </productKey>
+  </subcategory>
+  <subcategory>
+    <name>DIN Rail On/Off</name>
+    <description>2453-222</description>
+    <subCat>0x2e</subCat>
+    <productKey name="F00.00.07">
+    	<feature name="switch">GenericSwitch</feature>
+    	<feature name="lastheardfrom">GenericLastTime</feature>
     </productKey>
   </subcategory>
 </category>
@@ -68,7 +140,7 @@ Example:
     <name>PowerLinc 2413U USB modem</name>
     <description>2413U</description>
     <productKey name="0x000045">
-    	<feature name="control">2413Ucontrol</feature>
+    	<feature name="control">GenericModemControl</feature>
     </productKey>
     <subCat>0x15</subCat>
   </subcategory>
@@ -100,12 +172,12 @@ Example:
 
   <subcategory>
     <name>IO Link</name>
-    <description>[2450]</description>
+    <description>2450</description>
     <subCat>0x00</subCat>
     <productKey name="0x00001A">
-    	<feature name="contact">2450IOLincContact</feature>
-    	<feature name="lastheardfrom">2450IOLinclasttime</feature>
-    	<feature name="switch">2450IOLincSwitch</feature>
+    	<feature name="contact">IOLincContact</feature>
+    	<feature name="lastheardfrom">GenericLastTime</feature>
+    	<feature name="switch">IOLincSwitch</feature>
     </productKey>
   </subcategory>
 
@@ -155,14 +227,23 @@ Example:
   <description>Door and Window Sensors, Motion sensors, Scales</description>
   <devCat>0x10</devCat>
     <subcategory>
-    <name>Motion Sensor</name>
-    <description>Motion Sensor</description>
-    <subCat>0x01</subCat>
-    <productKey name="0x00004A">
-    	<feature name="contact">2842contact</feature>
-    	<feature name="lastheardfrom">2842lasttime</feature>
-    </productKey>
-  </subcategory>
+	<name>Motion Sensor</name>
+    	<description>2842-222</description>
+    	<subCat>0x01</subCat>
+    	<productKey name="0x00004A">
+    	  <feature name="contact">MotionSensorContact</feature>
+    	  <feature name="lastheardfrom">GenericLastTime</feature>
+    	</productKey>
+    </subcategory>
+    <subcategory>
+	<name>Hidden Door Sensor</name>
+    	<description>2845-222</description>
+    	<subCat>0x11</subCat>
+    	<productKey name="F00.00.03">
+    	  <feature name="contact">GenericContact</feature>
+    	  <feature name="lastheardfrom">GenericLastTime</feature>
+    	</productKey>
+    </subcategory>
 </category>
 <category>
   <name>Surveillance Control</name>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -1,0 +1,67 @@
+<xml>
+
+<feature name="GenericSwitch">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x11">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x13">LightOffHandler</message-handler>
+	<message-handler cmd="0x19">LightStateSwitchHandler</message-handler>
+	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
+	<poll-handler>DefaultPollHandler</poll-handler>
+</feature>
+<feature name="GenericLastTime" statusFeature="true">
+	<message-dispatcher>PassThroughDispatcher</message-dispatcher>
+	<message-handler default="true">LastTimeHandler</message-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+</feature>
+<feature name="GenericDimmer">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x06">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x11">LightOnDimmerHandler</message-handler>
+	<message-handler cmd="0x13">LightOffHandler</message-handler>
+	<message-handler cmd="0x17">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x18">StopManualChangeHandler</message-handler>
+	<message-handler cmd="0x19">LightStateDimmerHandler</message-handler>
+	<command-handler command="PercentType">PercentHandler</command-handler>
+	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
+	<poll-handler>DefaultPollHandler</poll-handler>
+</feature>
+<feature name="IOLincContact">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x06">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x11">OpenedContactHandler</message-handler>
+	<message-handler cmd="0x13">ClosedContactHandler</message-handler>
+	<message-handler cmd="0x19">StateContactHandler</message-handler>
+	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="IOLincSwitch">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x06">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x11">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x13">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x19">LightStateSwitchHandler</message-handler>
+	<command-handler command="OnOffType">IOLincOnOffCommandHandler</command-handler>
+	<poll-handler>DefaultPollHandler</poll-handler>
+</feature>
+<feature name="MotionSensorContact">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x06">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x11">OpenedContactHandler</message-handler>
+	<message-handler cmd="0x13">ClosedContactHandler</message-handler>
+	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="GenericContact">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x06">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x11">OpenedContactHandler</message-handler>
+	<message-handler cmd="0x13">ClosedContactHandler</message-handler>
+	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="GenericModemControl">
+	<message-dispatcher>PassThroughDispatcher</message-dispatcher>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler command="DecimalType">ModemCommandHandler</command-handler>
+</feature>
+</xml>


### PR DESCRIPTION
Introduced feature templates that make it easier to add new devices to the InsteonPLM binding.
For most cases an update of the xml files should suffice now.

Along with the change, a handful of new devices where added as well, to be documented in the wiki page once they have been tested.
