### PR TITLE
Pushover Action and InsteonPLM Binding Dependancy For Nightly Builds

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -349,6 +349,12 @@
             <version>${project.version}</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.openhab.action</groupId>
+            <artifactId>org.openhab.action.pushover</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
 
         <dependency>
             <groupId>org.openhab.binding</groupId>
@@ -731,6 +737,12 @@
         <dependency>
             <groupId>org.openhab.binding</groupId>
             <artifactId>org.openhab.binding.insteonhub</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.binding</groupId>
+            <artifactId>org.openhab.binding.insteonplm</artifactId>
             <version>${project.version}</version>
             <type>jar</type>
         </dependency>


### PR DESCRIPTION
Added entries to the pom.xml in ./distribution for generation of the Pushover Action and InsteonPLM binding distributable files.
