### PR TITLE
Message waiting indicator fix

### DIFF
--- a/bundles/binding/org.openhab.binding.freeswitch/src/main/java/org/openhab/binding/freeswitch/internal/FreeswitchBinding.java
+++ b/bundles/binding/org.openhab.binding.freeswitch/src/main/java/org/openhab/binding/freeswitch/internal/FreeswitchBinding.java
@@ -486,7 +486,6 @@ public class FreeswitchBinding extends AbstractBinding<FreeswitchBindingProvider
 			return;
 		}
 
-		//Pattern pattern = Pattern.compile("([0-9]+)/([0-9]+)\\s\\([0-9]+\\/[0-9]+\\)");
 		Pattern pattern = Pattern.compile("([0-9]+)/([0-9]+).*");
 
 		Matcher matcher = pattern.matcher(messagesString);


### PR DESCRIPTION
Fixes issue where some freeswitch boxes do not report on urgent messages which was breaking a regular expression
