### PR TITLE
Zwave version

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
@@ -292,12 +292,15 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 
 				// Add the action buttons
 				record.addAction("Heal", "Heal Node");
-
+				
 				// Add the delete button if the node is not "operational"
 				if(canDelete) {
 					record.addAction("Delete", "Delete Node");
 				}
 				records.add(record);
+
+				// This needs to be removed - temporary only until it's added to initialisation code.
+				record.addAction("Version", "Version Info");
 			}
 			return records;
 		}
@@ -435,8 +438,30 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 				}
 				records.add(record);
 
-				// Add controller specific status information
-				if(node.getNodeId() == zController.getDeviceId()) {
+				ZWaveVersionCommandClass versionCommandClass = (ZWaveVersionCommandClass) node
+						.getCommandClass(CommandClass.VERSION);
+
+				if (versionCommandClass != null) {
+					record = new OpenHABConfigurationRecord(domain, "LibType", "Library Type", true);
+					if(versionCommandClass.getLibraryType() == null)
+						record.value = "Unknown";
+					else
+						record.value = versionCommandClass.getLibraryType().getLabel();
+					records.add(record);
+
+					record = new OpenHABConfigurationRecord(domain, "ProtocolVersion", "Protocol Version", true);
+					if(versionCommandClass.getProtocolVersion() == null)
+						record.value = "Unknown";
+					else
+						record.value = Double.toString(versionCommandClass.getProtocolVersion());
+					records.add(record);
+
+					record = new OpenHABConfigurationRecord(domain, "AppVersion", "Application Version", true);
+					if(versionCommandClass.getApplicationVersion() == null)
+						record.value = "Unknown";
+					else
+						record.value = Double.toString(versionCommandClass.getApplicationVersion());
+					records.add(record);
 				}
 			} else if (arg.equals("parameters/")) {
 				if (database.FindProduct(node.getManufacturer(), node.getDeviceType(), node.getDeviceId()) != false) {
@@ -790,12 +815,12 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 				// This is temporary
 				// It should be in the startup code, but that needs refactoring
 				if (action.equals("Version")) {
-					logger.debug("NODE {}: Delete node", nodeId);
+					logger.debug("NODE {}: Get node version", nodeId);
 					ZWaveVersionCommandClass versionCommandClass = (ZWaveVersionCommandClass) node
 							.getCommandClass(CommandClass.VERSION);
 
 					if (versionCommandClass == null) {
-						logger.error("NODE {}: Error getting wakeupCommandClass in doAction", nodeId);
+						logger.error("NODE {}: Error getting versionCommandClass in doAction", nodeId);
 						return;
 					}
 

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveVersionCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveVersionCommandClass.java
@@ -43,7 +43,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 	public static final int VERSION_COMMAND_CLASS_GET = 0x13;
 	public static final int VERSION_COMMAND_CLASS_REPORT = 0x14;
 	
-	private LibraryType libraryType;
+	private LibraryType libraryType = LibraryType.LIB_UNKNOWN;
 	private Double protocolVersion;
 	private Double applicationVersion;
 	
@@ -198,8 +198,8 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 	/**
 	 * Returns the current ZWave library type
 	 */
-	public void getLibraryType() {
-		
+	public LibraryType getLibraryType() {
+		return libraryType;
 	}
 
 	/**
@@ -220,6 +220,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 	
 	public enum LibraryType
 	{
+		LIB_UNKNOWN(0,"Unknown"),
 		LIB_CONTROLLER_STATIC(1,"Static Controller"),
 		LIB_CONTROLLER(2,"Controller"),
 		LIB_SLAVE_ENHANCED(3,"Slave Enhanced"),
@@ -261,6 +262,9 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 				initMapping();
 			}
 			
+			if(libraryMapping.get(i) == null)
+				return LIB_UNKNOWN;
+
 			return libraryMapping.get(i);
 		}
 


### PR DESCRIPTION
This enhances the version command class to be able to read back the firmware version (and some other information) from each node.
Tested by myself and @casperleenheer to read out the firmware version of the latest Fibaro Motion Sensor (of which some versions have a bug).
