### PR TITLE
OpenHAB Designer Pushover and Notify My Android Additions

### DIFF
--- a/features/org.openhab.designer.feature/feature.xml
+++ b/features/org.openhab.designer.feature/feature.xml
@@ -293,7 +293,21 @@
          unpack="false"/>
 
    <plugin
+         id="org.openhab.action.nma"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.openhab.action.prowl"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.openhab.action.pushover"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Added dependency info to the feature.xml file for the OpenHAB designer. Should fix bug #1096
