### PR TITLE
Pushover API Added -2 as Valid Priority Level

### DIFF
--- a/bundles/action/org.openhab.action.pushover/src/main/java/org/openhab/action/pushover/internal/Pushover.java
+++ b/bundles/action/org.openhab.action.pushover/src/main/java/org/openhab/action/pushover/internal/Pushover.java
@@ -55,7 +55,7 @@ public class Pushover {
 	private final static int API_MAX_MESSAGE_LENGTH = 512;
 	private final static int API_MAX_URL_LENGTH = 512;
 	private final static int API_MAX_URL_TITLE_LENGTH = 100;
-	private final static int[] API_VALID_PRIORITY_LIST = {-1, 0, 1, 2};
+	private final static int[] API_VALID_PRIORITY_LIST = {-2, -1, 0, 1, 2};
 	
 	public static final String MESSAGE_KEY_API_KEY = "token";
 	public static final String MESSAGE_KEY_USER = "user";

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -136,7 +136,7 @@ chart:provider=default
 #pushover:defaultTitle=openHAB
 
 # The priority to use for messages if not specified otherwise. Can range from
-# -1 (lowest) to 2 (highest)
+# -2 (lowest) to 2 (highest)
 #pushover:defaultPriority=
 
 # Url to attach to the message if not specified in the command (optional). Can be left empty.


### PR DESCRIPTION
Pushover has added -2 as a valid priority to their API. Added it to the validation code in the Pushover action.
