### PR TITLE
Fixing missed section and missed bundle

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1229,3 +1229,14 @@ tcp:refreshinterval=250
 
 # Perform a module status query every x miliseconds (optional, defaults to 60000)
 #iec6205621meter:refresh=
+
+################################# GPIO Binding #####################################
+
+# Optional directory path where "sysfs" pseudo file system is mounted, when isn't
+# specified it will be determined automatically if "procfs" is mounted
+#gpio:sysfs=/sys
+
+# Optional time interval in miliseconds when pin interrupts are ignored to
+# prevent bounce effect, mainly on buttons. Global option for all pins, can be
+# overwritten per pin in item configuration. Default value if omitted: 0
+#gpio:debounce=10

--- a/distribution/src/assemble/addons.xml
+++ b/distribution/src/assemble/addons.xml
@@ -29,6 +29,7 @@
       	<include>org.openhab.io:org.openhab.io.multimedia.tts.freetts:jar:*</include>
       	<include>org.openhab.io:org.openhab.io.multimedia.tts.macintalk:jar:*</include>
         <include>org.openhab.io:org.openhab.io.multimedia.tts.marytts:jar:*</include>
+        <include>org.openhab.io:org.openhab.io.gpio:jar:*</include>
       	<include>org.openhab.io:org.openhab.io.dropbox:jar:*</include>
 		<include>org.openhab.io:org.openhab.io.cv:jar:*</include>
 		<include>org.openhab.io:org.openhab.io.squeezeserver:jar:*</include>


### PR DESCRIPTION
Missing section for GPIO binding in default configuration file, also GPIO IO module is missing in openHAB runtime archive.
