### PR TITLE
EnOcean binding: Fix illumunation value conversion.

### DIFF
--- a/bundles/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/converter/IlluminationConverter.java
+++ b/bundles/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/converter/IlluminationConverter.java
@@ -13,7 +13,6 @@ import java.math.BigDecimal;
 import org.enocean.java.common.values.NumberWithUnit;
 import org.enocean.java.common.values.Unit;
 import org.openhab.core.library.types.DecimalType;
-import org.openhab.core.library.types.PercentType;
 
 /**
  * A converter to convert a NumberWithUnit ILLUMINATION to a DecimalType
@@ -31,7 +30,7 @@ public class IlluminationConverter extends StateConverter<NumberWithUnit, Decima
 
     @Override
     protected DecimalType convertToImpl(NumberWithUnit source) {
-        return new PercentType((BigDecimal) source.getValue());
+        return new DecimalType((BigDecimal) source.getValue());
     }
 
 }


### PR DESCRIPTION
The EEP A5:08:02 uses plain data values to transfer the illumination value,
no percent type is used.
So we have to fix the internal IlluminationConverter of the EnOcean binding.

Below the error, that is raised before.

15:46:07.863 INFO  org.opencean.core.ESP3Host[:15] - Received RadioPacket with value 536lx
15:46:07.863 DEBUG o.o.b.e.i.bus.EnoceanBinding[:270] - Received new value 536lx for device at EnoceanParameter: {id="00:86:50:20", parameter="ILLUMINANCE"}
15:46:07.863 INFO  runtime.busevents[:26] - MDTemperature state updated to 29
15:46:07.867 ERROR org.opencean.core.ESP3Host[:78] - Error
java.lang.IllegalArgumentException: Value must be between 0 and 100
        at org.openhab.core.library.types.PercentType.validateValue(PercentType.java:48)
        at org.openhab.core.library.types.PercentType.<init>(PercentType.java:43)
        at org.openhab.binding.enocean.internal.converter.IlluminationConverter.convertToImpl(IlluminationConverter.java:34)
        at org.openhab.binding.enocean.internal.converter.IlluminationConverter.convertToImpl(IlluminationConverter.java:1)
        at org.openhab.binding.enocean.internal.converter.StateConverter.convertTo(StateConverter.java:68)
        at org.openhab.binding.enocean.internal.profiles.StandardProfile.valueChanged(StandardProfile.java:75)
        at org.openhab.binding.enocean.internal.bus.EnoceanBinding.valueChanged(EnoceanBinding.java:283)
        at org.opencean.core.ParameterChangeNotifier.receivePacket(ParameterChangeNotifier.java:47)
        at org.opencean.core.ESP3Host.notifyReceivers(ESP3Host.java:52)
        at org.opencean.core.ESP3Host.run(ESP3Host.java:73)
