### PR TITLE
EnOcean binding: Support PercentType for NumberItems

### DIFF
--- a/bundles/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/converter/ConverterFactory.java
+++ b/bundles/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/converter/ConverterFactory.java
@@ -94,11 +94,21 @@ public class ConverterFactory {
      *         protocolKey to a state for the item.
      */
     public StateConverter<?, ?> getToStateConverter(String protocolValue, Item item) {
-        List<Class<? extends State>> acceptedTypes = new ArrayList<Class<? extends State>>(item.getAcceptedDataTypes());
-        acceptedTypes.retainAll(converters.getMatchingStates(protocolValue));
-        if (acceptedTypes.isEmpty()) {
-            return null;
-        }
+        List<Class<? extends State>> acceptedTypes = new ArrayList<Class<? extends State>>();
+	List<Class<? extends State>> itemTypes = new ArrayList<Class<? extends State>>(item.getAcceptedDataTypes());
+	List<Class<? extends State>> matchingTypes = converters.getMatchingStates(protocolValue);
+        for (Class<? extends State> matchingType : matchingTypes) {
+	    for (Class<? extends State> itemType : itemTypes) {
+		    if(itemType.isAssignableFrom(matchingType)){
+			acceptedTypes.add(matchingType);
+			break;
+		    }
+	    }
+	}
+
+	if (acceptedTypes.isEmpty()) {
+	    return null;
+	}
         // Take best matching as accepted Type. Best matching is calculated by
         // ordering by importance of state.
         Collections.sort(acceptedTypes, new StateComparator());


### PR DESCRIPTION
ConverterFactory only checks if classes are equal. 
It lacks types which are assignable from the supported types of an item.

Added a check to get the assignable types also as accepted types.
