### PR TITLE
ZWave binding: detect sensor type for binary sensors

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBinarySensorCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBinarySensorCommandClass.java
@@ -93,7 +93,7 @@ public class ZWaveBinarySensorCommandClass extends ZWaveCommandClass implements 
 						}
 						logger.debug("Sensor Type is {}", sensorType);
 					} else {
-						logger.debug("Message payload doesn't contain MessageType. Using UNKNOWN");
+						logger.debug("Message payload doesn't contain SensorType. Using {}", sensorType);
 					}
 				}
 


### PR DESCRIPTION
- corrected getVersion(). Use from Node instead of CommandClass which always returns 1.
- check size of Message-Payload to prevent ArrayOutOfBound-Exceptions in method "serialMessage.getMessagePayloadByte()"
