### PR TITLE
Bugfix which solves a conflict between CV and REST binding

### DIFF
--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/RESTApplication.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/RESTApplication.java
@@ -196,7 +196,9 @@ public class RESTApplication extends Application {
         // use the default interceptors without PaddingAtmosphereInterceptor
         // see: https://groups.google.com/forum/#!topic/openhab/Z-DVBXdNiYE
         jerseyServletParams.put("org.atmosphere.cpr.AtmosphereInterceptor", "org.atmosphere.interceptor.DefaultHeadersInterceptor,org.atmosphere.interceptor.AndroidAtmosphereInterceptor,org.atmosphere.interceptor.SSEAtmosphereInterceptor,org.atmosphere.interceptor.JSONPAtmosphereInterceptor,org.atmosphere.interceptor.JavaScriptProtocol,org.atmosphere.interceptor.OnDisconnectInterceptor");
-        jerseyServletParams.put("org.atmosphere.cpr.broadcasterCacheClass", "org.atmosphere.cache.UUIDBroadcasterCache");
+//      The BroadcasterCache is set in ResourceStateChangeListener.registerItems(), because otherwise
+//      it gets somehow overridden by other registered servlets (e.g. the CV-bundle)
+//        jerseyServletParams.put("org.atmosphere.cpr.broadcasterCacheClass", "org.atmosphere.cache.UUIDBroadcasterCache");
         jerseyServletParams.put("org.atmosphere.cpr.broadcasterLifeCyclePolicy", "NEVER");
         jerseyServletParams.put("org.atmosphere.cpr.CometSupport.maxInactiveActivity", "3000000");
         

--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/listeners/ResourceStateChangeListener.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/listeners/ResourceStateChangeListener.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.atmosphere.cache.UUIDBroadcasterCache;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.BroadcastFilter.BroadcastAction.ACTION;
 import org.atmosphere.cpr.PerRequestBroadcastFilter;
@@ -66,6 +67,8 @@ abstract public class ResourceStateChangeListener {
 	}
 	
 	public void registerItems(){
+		broadcaster.getBroadcasterConfig().setBroadcasterCache(new UUIDBroadcasterCache());
+		
 		broadcaster.getBroadcasterConfig().addFilter(new PerRequestBroadcastFilter() {
 			
 			@Override


### PR DESCRIPTION
setting the BroadcasterCache in the servlet params seems to lead to a conflict. The CV-Binding is not working with the current 1.5.0 release. This fix solves the problem
