### PR TITLE
KNX : fixed bug regarding double usage of datapoints in Item definition + DPT 7.001

### DIFF
--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/config/KNXGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/config/KNXGenericBindingProvider.java
@@ -356,7 +356,12 @@ public class KNXGenericBindingProvider extends AbstractGenericBindingProvider im
 					if (isReadable) {
 						configItem.readableDataPoint = dp;
 					}
-					configItem.allDataPoints.add(dp);
+					if(!configItem.allDataPoints.contains(dp)) {
+						configItem.allDataPoints.add(dp);
+					} else {
+						throw new BindingConfigParseException(
+								"Datapoint '"+dp.getDPT() + "' already exists for item '"+item.getName()+"'.");
+					}
 				}
 				
 				config.add(configItem);

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
@@ -78,6 +78,7 @@ public class KNXCoreTypeMapper implements KNXTypeMapper {
 		dptTypeMap.put(DPTXlator2ByteUnsigned.DPT_ELECTRICAL_CURRENT.getID(), DecimalType.class);
 		dptTypeMap.put(DPTXlator2ByteUnsigned.DPT_BRIGHTNESS.getID(), DecimalType.class);
 		dptTypeMap.put(DPTXlator2ByteUnsigned.DPT_TIMEPERIOD_HOURS.getID(), DecimalType.class);
+		dptTypeMap.put(DPTXlator2ByteUnsigned.DPT_VALUE_2_UCOUNT.getID(), DecimalType.class);		
 		dptTypeMap.put("9.001", DecimalType.class);
 		dptTypeMap.put(DPTXlator4ByteSigned.DPT_COUNT.getID(), DecimalType.class);
 		dptTypeMap.put(DPTXlator4ByteSigned.DPT_ACTIVE_ENERGY.getID(), DecimalType.class);


### PR DESCRIPTION
KNX : fixed bug regarding double usage of datapoints in Item definition + Added support for DPT 7.001
