### PR TITLE
Fix Broken unit test

### DIFF
--- a/bundles/core/org.openhab.core.library.test/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/core/org.openhab.core.library.test/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -8,51 +8,85 @@
  */
 package org.openhab.core.library.types;
 
-import static java.util.Calendar.HOUR;
+import static java.util.Calendar.HOUR_OF_DAY;
 import static org.junit.Assert.assertEquals;
 
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.TimeZone;
 
 import org.junit.Before;
 import org.junit.Test;
-
 /**
  * @author Thomas.Eichstaedt-Engelen
+ * @author Neil Renaud
  * @since 1.5.0
  */
 public class DateTimeTypeTest {
-	
-	Calendar calendarUTC = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-	
-	String inputUTC = "2014-03-30T04:58:47";
-	String inputCET = inputUTC + "CET";
-	String inputWithBrokenTZ = inputUTC + "brokenTZ";
-	
-	int expectedUTC = 4;
-	int expectedCET = 5;
-	
-	@Before
-	public void setup() {
-		calendarUTC.set(2014, 2, 30, 4, 58, 47);
-	}
+	private final static String OTHER_TIMEZONE_CODE = "CET";
+ 	private final static String BROKEN_TIMEZONE_CODE = "Broken";
 
-	@Test
-	public void createDate() {
-		DateTimeType dt = DateTimeType.valueOf(inputUTC);
-		assertEquals(expectedUTC, dt.getCalendar().get(HOUR));
-	}
-	
-	@Test
-	public void createDateWithTz() {
-		DateTimeType dt = DateTimeType.valueOf(inputCET);
-		assertEquals(expectedCET, dt.getCalendar().get(HOUR));
-	}
-	
-	@Test
-	public void createDateWithBrokenTz() {
-		DateTimeType dt = DateTimeType.valueOf(inputWithBrokenTZ);
-		assertEquals(expectedUTC, dt.getCalendar().get(HOUR));
-	}
-	
+  	private final static TimeZone DEFAULT_TIMEZONE = TimeZone.getDefault();
+ 	private final static TimeZone OTHER_TIMEZONE = TimeZone
+ 			.getTimeZone(OTHER_TIMEZONE_CODE);
+
+  	private SimpleDateFormat dateFormatterDefaultTz;
+ 	private SimpleDateFormat dateFormatterOtherTz;
+ 	private SimpleDateFormat hourFormatterDefaultTz;
+ 	private SimpleDateFormat hourFormatterOtherTz;
+
+  	private String inputNoTz;
+ 	private String inputCET;
+ 	private String inputWithBrokenTZ;
+
+  	long expectedHourOtherTimezone;
+ 	long expectedHourLocalTimezone;
+
+  	@Before
+	public void setup() {
+ 		dateFormatterDefaultTz = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+ 		dateFormatterDefaultTz.setTimeZone(DEFAULT_TIMEZONE);
+
+  		dateFormatterOtherTz = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+ 		dateFormatterOtherTz.setTimeZone(OTHER_TIMEZONE);
+
+  		hourFormatterDefaultTz = new SimpleDateFormat("HH");
+ 		hourFormatterDefaultTz.setTimeZone(DEFAULT_TIMEZONE);
+
+  		hourFormatterOtherTz = new SimpleDateFormat("HH");
+ 		hourFormatterOtherTz.setTimeZone(OTHER_TIMEZONE);
+
+  		Calendar now = Calendar.getInstance();
+ 		now.set(HOUR_OF_DAY, 11);
+  		inputNoTz = dateFormatterDefaultTz.format(now.getTime());
+ 		inputCET = dateFormatterOtherTz.format(now.getTime())
+ 				+ OTHER_TIMEZONE.getID();
+ 		inputWithBrokenTZ = inputNoTz + BROKEN_TIMEZONE_CODE;
+
+  		expectedHourLocalTimezone = Integer.valueOf(hourFormatterDefaultTz
+ 				.format(now.getTime()));
+ 		expectedHourOtherTimezone = Integer.valueOf(hourFormatterOtherTz
+ 				.format(now.getTime()));
+ 	}
+
+  	@Test
+ 	public void createDate() {
+ 		DateTimeType dt = DateTimeType.valueOf(inputNoTz);
+ 		assertEquals(expectedHourLocalTimezone,
+ 				dt.getCalendar().get(HOUR_OF_DAY));
+ 	}
+
+  	@Test
+ 	public void createDateWithTz() {
+ 		DateTimeType dt = DateTimeType.valueOf(inputCET);
+ 		assertEquals(expectedHourOtherTimezone,
+ 				dt.getCalendar().get(HOUR_OF_DAY));
+ 	}
+
+  	@Test
+ 	public void createDateWithBrokenTz() {
+ 		DateTimeType dt = DateTimeType.valueOf(inputWithBrokenTZ);
+ 		assertEquals(expectedHourLocalTimezone,
+ 				dt.getCalendar().get(HOUR_OF_DAY));
+ 	}
 }


### PR DESCRIPTION
Fixed the DateTimeType unit Test Made the test work based on the Calendar.getInstance() which is what the DateTimeType uses.
