### PR TITLE
Change Java back to 1.5

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.zwave/META-INF/MANIFEST.MF
@@ -28,6 +28,6 @@ Import-Package: gnu.io,
 Export-Package: org.openhab.binding.zwave,org.openhab.binding.zwave.in
  ternal.config
 Bundle-DocURL: http://www.openhab.org
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Service-Component: OSGI-INF/activebinding.xml, OSGI-INF/genericbindingprovider.xml
 Bundle-ClassPath: ., lib/xstream-1.4.6.jar


### PR DESCRIPTION
Thomas. I've posted a few emails about this, but not got a reply, so I propose to restore Java back to 1.5.  I'm not sure why you changed this - maybe there's a reason, but it means some people now can't run the zwave binding, and it seems strange that only zwave was changed to require 1.7 while most bindings (or at least a few that I looked at) were still 1.5.
Feel free to reject if this is needed for some reason...

Chris
