### PR TITLE
Adding LightwaveRF Mood Switch

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
@@ -22,7 +22,7 @@ import org.openhab.core.library.items.RollershutterItem;
  * Represents all valid value selectors which could be processed by this
  * binding.
  * 
- * @author Pauli Anttila, Evert van Es
+ * @author Pauli Anttila, Evert van Es, Neil Renaud
  * @since 1.2.0
  */
 public enum RFXComValueSelector {

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
@@ -35,7 +35,7 @@ import org.openhab.core.types.UnDefType;
 /**
  * RFXCOM data class for lighting5 message.
  * 
- * @author Paul Hampson
+ * @author Paul Hampson, Neil Renaud
  * @since 1.3.0
  */
 public class RFXComLighting5Message extends RFXComBaseMessage {


### PR DESCRIPTION
Adding a mood switch to LightwaveRF using a StringItem to represent the text of the mood button pressed (MOOD1, MOOD2, etc). Configure like this:

String MoodSwitch "MoodSwitch [Command %s]" (ALL) { rfxcom="<15774805.16:Mood" }
