### PR TITLE
KNX binding should use different mapping of PercentType

### DIFF
--- a/bundles/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/config/KNXCoreTypeMapperTest.java
+++ b/bundles/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/config/KNXCoreTypeMapperTest.java
@@ -841,57 +841,6 @@ public class KNXCoreTypeMapperTest {
 	}
 
 	/**
-	 * KNXCoreTypeMapper tests method typeMapper.toType() for type “4-Octet Float Value" KNX ID: 14
-	 * Tested is if the maximum value according to KNX Spec (and IEEE 754) is handled correctly
-	 * 
-	 * @throws KNXFormatException
-	 */
-	@Test(expected = NumberFormatException.class)
-	public void testTypeMapping4ByteFloat_14_MAX() throws KNXFormatException {
-		DPT dpt =DPTXlator4ByteFloat.DPT_ACCELERATION_ANGULAR;
-
-		testToTypeClass(dpt, DecimalType.class);
-
-		/*
-		 * Test the maximum positive value
-		 * 
-		 * FIXME: There seems to be a bug in how openhab treats Floats according IEEE 754. The maximum value is given by
-		 * Float.MAX_VALUE which represented by 0x7f7ffffff, but openhab throws a NumberFormatException in DecimalType
-		 * 
-		 * The following test case tests that the erroneous Exception is thrown.
-		 */
-		Type type=testToType(DPTXlator4ByteFloat.DPT_ACCELERATION_ANGULAR, new byte[] { (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
-		Float f=Float.MAX_VALUE;	
-		testToDPTValue(dpt, type, f.toString());
-	}
-
-	/**
-	 * KNXCoreTypeMapper tests method typeMapper.toType() for type “4-Octet Float Value" KNX ID: 14.
-	 * Tested is if the minimum value according to KNX Spec (and IEEE 754) is handled correctly
-	 * 
-	 * 
-	 * @throws KNXFormatException
-	 */
-	@Test(expected = NumberFormatException.class)
-	public void testTypeMapping4ByteFloat_14_MIN() throws KNXFormatException {
-		DPT dpt =DPTXlator4ByteFloat.DPT_ACCELERATION_ANGULAR;
-
-		testToTypeClass(dpt, DecimalType.class);
-
-		/*
-		 * Test the maximum negative value
-		 * 
-		 * FIXME: There seems to be a bug in how openhab treats Floats according IEEE 754. The minimum value is given by
-		 * -Float.MAX_VALUE which represented by 0xff7ffffff, but openhab throws a NumberFormatException in DecimalType
-		 * 
-		 * The following test case tests that the erroneous Exception is thrown.
-		 */
-		Type type=testToType(DPTXlator4ByteFloat.DPT_ACCELERATION_ANGULAR, new byte[] { (byte) 0xFF, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
-		Float f=Float.MAX_VALUE;	
-		testToDPTValue(dpt, type, "-"+f.toString());
-	}
-
-	/**
 	 * KNXCoreTypeMapper tests method typeMapper.toType() for type “4-Octet Float Value" KNX ID: 14.001 DPT_ACCELERATION_ANGULAR
 	 * 
 	 * @throws KNXFormatException
@@ -912,6 +861,18 @@ public class KNXCoreTypeMapperTest {
 		// Test the smallest negative value 
 		type=testToType(DPTXlator4ByteFloat.DPT_ACCELERATION_ANGULAR, new byte[] { (byte)0x80, 0x00, 0x00, 0x01 }, DecimalType.class);
 		testToDPTValue(dpt, type, "-0.0000000000000000000000000000000000000000000014");
+
+		/*
+		 * Test the maximum positive value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_ACCELERATION_ANGULAR, new byte[] { (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "340282000000000000000000000000000000000");
+
+		/*
+		 * Test the maximum negative value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_ACCELERATION_ANGULAR, new byte[] { (byte) 0xFF, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "-340282000000000000000000000000000000000");
 	}
 
 	/**
@@ -935,6 +896,18 @@ public class KNXCoreTypeMapperTest {
 		// Test the smallest negative value 
 		type=testToType(DPTXlator4ByteFloat.DPT_ANGLE_DEG, new byte[] { (byte)0x80, 0x00, 0x00, 0x01 }, DecimalType.class);
 		testToDPTValue(dpt, type, "-0.0000000000000000000000000000000000000000000014");
+
+		/*
+		 * Test the maximum positive value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_ANGLE_DEG, new byte[] { (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "340282000000000000000000000000000000000");
+
+		/*
+		 * Test the maximum negative value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_ANGLE_DEG, new byte[] { (byte) 0xFF, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "-340282000000000000000000000000000000000");
 	}
 
 	/**
@@ -958,6 +931,18 @@ public class KNXCoreTypeMapperTest {
 		// Test the smallest negative value 
 		type=testToType(DPTXlator4ByteFloat.DPT_ELECTRIC_CURRENT, new byte[] { (byte)0x80, 0x00, 0x00, 0x01 }, DecimalType.class);
 		testToDPTValue(dpt, type, "-0.0000000000000000000000000000000000000000000014");
+
+		/*
+		 * Test the maximum positive value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_ELECTRIC_CURRENT, new byte[] { (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "340282000000000000000000000000000000000");
+
+		/*
+		 * Test the maximum negative value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_ELECTRIC_CURRENT, new byte[] { (byte) 0xFF, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "-340282000000000000000000000000000000000");
 	}
 
 	/**
@@ -981,6 +966,18 @@ public class KNXCoreTypeMapperTest {
 		// Test the smallest negative value 
 		type=testToType(DPTXlator4ByteFloat.DPT_ELECTRIC_POTENTIAL, new byte[] { (byte)0x80, 0x00, 0x00, 0x01 }, DecimalType.class);
 		testToDPTValue(dpt, type, "-0.0000000000000000000000000000000000000000000014");
+
+		/*
+		 * Test the maximum positive value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_ELECTRIC_POTENTIAL, new byte[] { (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "340282000000000000000000000000000000000");
+
+		/*
+		 * Test the maximum negative value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_ELECTRIC_POTENTIAL, new byte[] { (byte) 0xFF, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "-340282000000000000000000000000000000000");
 	}
 
 	/**
@@ -1004,6 +1001,18 @@ public class KNXCoreTypeMapperTest {
 		// Test the smallest negative value 
 		type=testToType(DPTXlator4ByteFloat.DPT_FREQUENCY, new byte[] { (byte)0x80, 0x00, 0x00, 0x01 }, DecimalType.class);
 		testToDPTValue(dpt, type, "-0.0000000000000000000000000000000000000000000014");
+
+		/*
+		 * Test the maximum positive value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_FREQUENCY, new byte[] { (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "340282000000000000000000000000000000000");
+
+		/*
+		 * Test the maximum negative value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_FREQUENCY, new byte[] { (byte) 0xFF, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "-340282000000000000000000000000000000000");
 	}
 
 	/**
@@ -1027,6 +1036,18 @@ public class KNXCoreTypeMapperTest {
 		// Test the smallest negative value 
 		type=testToType(DPTXlator4ByteFloat.DPT_POWER, new byte[] { (byte)0x80, 0x00, 0x00, 0x01 }, DecimalType.class);
 		testToDPTValue(dpt, type, "-0.0000000000000000000000000000000000000000000014");
+
+		/*
+		 * Test the maximum positive value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_POWER, new byte[] { (byte) 0x7F, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "340282000000000000000000000000000000000");
+
+		/*
+		 * Test the maximum negative value
+		 */
+		type=testToType(DPTXlator4ByteFloat.DPT_POWER, new byte[] { (byte) 0xFF, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF }, DecimalType.class);
+		testToDPTValue(dpt, type, "-340282000000000000000000000000000000000");
 	}
 
 	/**
@@ -1122,6 +1143,6 @@ public class KNXCoreTypeMapperTest {
 	 * @throws KNXFormatException
 	 */
 	private Datapoint createDP(String dpt) throws KNXFormatException {
-		return new CommandDP(new GroupAddress("1/2/3"), "test", 0, dpt);
-	}
+		int mainNumber=Integer.parseInt(dpt.substring(0, dpt.indexOf('.')));
+		return new CommandDP(new GroupAddress("1/2/3"), "test", mainNumber, dpt);	}
 }

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
@@ -164,8 +164,19 @@ public class KNXCoreTypeMapper implements KNXTypeMapper {
 			logger.trace("toType datapoint DPT = " + datapoint.getDPT());
 			logger.trace("toType datapoint getMainNumber = " + datapoint.getMainNumber());
 			if(datapoint.getMainNumber()==9) id = DPTXlator2ByteFloat.DPT_TEMPERATURE.getID(); // we do not care about the unit of a value, so map everything to 9.001
-			if(datapoint.getMainNumber()==14) id = DPTXlator4ByteFloat.DPT_ACCELERATION_ANGULAR.getID(); // we do not care about the unit of a value, so map everything to 14.001
-			Class<? extends Type> typeClass = toTypeClass(id);
+			if(datapoint.getMainNumber()==14) {
+				id = DPTXlator4ByteFloat.DPT_ACCELERATION_ANGULAR.getID(); // we do not care about the unit of a value, so map everything to 14.001
+				/*
+				* FIXME: Workaround for a bug in Calimero
+				* DPTXlator4ByteFloat.makeString(). The locale is being used when
+				* translating a float to String. It could happen the a ',' is used a separator, such as 3,14159E20
+				* Openhab expects this to be in US format an expects '.': 3.14159E20
+				* There is no issue with DPTXlator2ByteFloat since calimero is using a non-localized translation.
+				*/
+				if (value.contains(",")) {
+				value=value.replaceFirst(",", "\\.");
+				}
+				}			Class<? extends Type> typeClass = toTypeClass(id);
 			if (typeClass == null) {
 				return null;
 			}


### PR DESCRIPTION
KNXCoreTypeMapper maps Openhab's PercentType to KNX's DPT_PERCENT_U8 and vice versa. PercentType holds values from 0% to 100%, but DPT_PERCENT_U8 can hold values from 0% to 255%, where byte 0xff is 255%. 
A better match is DPT_SCALING (5.001) which translates byte 0xff to 100%.
DPT_PERCENT_U8 should be mapped to DecimalType to allow values larger then 100%.
So, 5.001 and 5.004 should now behave as spec'd in KNX Spec.
