### PR TITLE
Changed Philips Hue On/Off switching behavior

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBinding.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBinding.java
@@ -104,7 +104,7 @@ public class HueBinding extends AbstractBinding<HueBindingProvider> implements M
 		}
 
 		if (command instanceof OnOffType) {
-			bulb.setOnAtFullBrightness(OnOffType.ON.equals(command));
+			bulb.switchOn(OnOffType.ON.equals(command));
 		}
 
 		if (command instanceof HSBType) {

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java
@@ -141,6 +141,22 @@ public class HueBulb {
 		return (int) Math.round((100.0 / 255.0) * this.brightness);
 
 	}
+	
+	/**
+	 * Set bulb ON/OFF without changing the brightness
+	 * @param on
+	 * 			true	turn bulb on
+	 * 			false	turn bulb off
+	 */
+	
+	public boolean switchOn(boolean powerOn) {
+		if(powerOn) {
+			executeMessage("{\"on\":true}");
+		} else {
+			executeMessage("{\"on\":false}");
+		}
+		return true;
+	}
 
 	/**
 	 * Increases the color temperature of the bulb by the given amount to a


### PR DESCRIPTION
When switching a bulb on, it will be switched on at the last brightness level.
