### PR TITLE
fix typo error (missing </Product> at line 864)

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -861,6 +861,7 @@
 			<Model>DWZWAVE2</Model>
 			<Label lang="en">Z-Wave Door/Window Sensor</Label>
 			<ConfigFile>eco/dwzwave2.xml</ConfigFile>
+		</Product>
 	</Manufacturer>	
 	<Manufacturer>
 		<Id>001E</Id>


### PR DESCRIPTION
---- Debugging information ----
message             :  : ParseError at [row,col]:[864,4]
Message: The element type "Product" must be terminated by the matching end-tag "</Product>".
cause-exception     : com.thoughtworks.xstream.io.StreamException
cause-message       :  : ParseError at [row,col]:[864,4]
Message: The element type "Product" must be terminated by the matching end-tag "</Product>".
class               : org.openhab.binding.zwave.internal.config.ZWaveDbProduct
required-type       : org.openhab.binding.zwave.internal.config.ZWaveDbProduct
converter-type      : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
path                : /Manufacturers/Manufacturer[17]/Product
line number         : 864
class[1]            : org.openhab.binding.zwave.internal.config.ZWaveDbManufacturer
class[2]            : org.openhab.binding.zwave.internal.config.ZWaveProductDatabase$ZWaveDbRoot
## version             : 1.4.6
