### PR TITLE
Changing Mood switches to work as Numbers rather than strings

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
@@ -30,7 +30,7 @@ public enum RFXComValueSelector {
 	RAW_DATA ("RawData", StringItem.class),
 	SHUTTER ("Shutter", RollershutterItem.class),
 	COMMAND ("Command", SwitchItem.class),
-	MOOD ("Mood", StringItem.class),
+	MOOD ("Mood", NumberItem.class),
 	SIGNAL_LEVEL ("SignalLevel", NumberItem.class),
 	DIMMING_LEVEL ("DimmingLevel", DimmerItem.class),
 	TEMPERATURE ("Temperature", NumberItem.class),

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
@@ -233,6 +233,29 @@ public class RFXComLighting5Message extends RFXComBaseMessage {
 
 				state = new DecimalType(signalLevel);
 
+			} else if (valueSelector == RFXComValueSelector.MOOD) {
+				switch (command) {
+				case GROUP_OFF:
+					state = new DecimalType(0);
+					break;
+				case MOOD1:
+					state = new DecimalType(1);
+					break;
+				case MOOD2:
+					state = new DecimalType(2);
+					break;
+				case MOOD3:
+					state = new DecimalType(3);
+					break;
+				case MOOD4:
+					state = new DecimalType(4);
+					break;
+				case MOOD5:
+					state = new DecimalType(5);					
+					break;
+				default:
+					throw new RFXComException("Unexpected mood: " + command);
+				}
 			} else {
 				throw new RFXComException("Can't convert "
 						+ valueSelector + " to NumberItem");
@@ -304,8 +327,6 @@ public class RFXComLighting5Message extends RFXComBaseMessage {
 			if (valueSelector == RFXComValueSelector.RAW_DATA) {
 				state = new StringType(
 						DatatypeConverter.printHexBinary(rawMessage));
-			} else if (valueSelector == RFXComValueSelector.MOOD) {
-				state = new StringType(command.toString());
 			} else {
 				throw new RFXComException("Can't convert "
 						+ valueSelector + " to StringItem");


### PR DESCRIPTION
As recommened on the mailing list changing LightwaveRF mood switch to use NumberItem rather than StringItem
