### PR TITLE
KNX : Improve handling of DPT 3.007

### DIFF
--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
@@ -143,6 +143,15 @@ public class KNXCoreTypeMapper implements KNXTypeMapper {
 			if(datapoint.getMainNumber()==9) id = "9.001"; // we do not care about the unit of a value, so map everything to 9.001
 			if(datapoint.getMainNumber()==14) id = "14.001"; // we do not care about the unit of a value, so map everything to 14.001
 			Class<? extends Type> typeClass = toTypeClass(id);
+			if(datapoint.getDPT().equals("3.007")) {
+				// if the stepcode of a 3 Bit Controlled value is zero we assume that is a "break" being signalled
+				// and therefore we ingore the control value (which, is the DPTXlatorBoolean.DPT_STEP value returned by
+				// default by the DPTXlator3BitControlled class.
+				// when the stepcode is different from zero, then the control flag must be a valid INCREASE of DECREASE
+				if(((DPTXlator3BitControlled)translator).getStepCode()==0) {
+					typeClass=null;
+				}
+			}
 			if (typeClass == null) {
 				return null;
 			}


### PR DESCRIPTION
Data returned by 3Bit controllers on the KNX network consist of 2 parts. a Control bit and and 3-bit Stepcode field. The Calimero translator take the control bit as the primary Value when translating, this yields erratic behaviour on KNX controllers that send a value when a button is touched, and a second value when the button is released ("break" value). The Basalte Deseo controller for example sends 0x9 for a volume increase (Control 1 Step 1), and a 0x0 (Control 0, step 0) as break. Volume decrease is 0x1 (control 0, step 1), followed by a break. So, in order not to generate INCREASE + DECREASE when volume goes up, and DECREASE+DECREASE when volume goes down, we have to ignore the 3Bit values where step = 0
