### PR TITLE
Fix for ZWave meter nodes to support RESET commands

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMeterConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMeterConverter.java
@@ -88,14 +88,20 @@ public class ZWaveMeterConverter extends ZWaveCommandClassConverter<ZWaveMeterCo
 	@Override
 	public void handleEvent(ZWaveCommandClassValueEvent event, Item item, Map<String,String> arguments) {
 		ZWaveStateConverter<?,?> converter = this.getStateConverter(item, event.getValue());
-		String meterScale = arguments.get("meter_scale");
-		String meterZero = arguments.get("meter_zero");
-		ZWaveMeterValueEvent meterEvent = (ZWaveMeterValueEvent)event;
-
+		
 		if (converter == null) {
 			logger.warn("No converter found for item = {}, node = {} endpoint = {}, ignoring event.", item.getName(), event.getNodeId(), event.getEndpoint());
 			return;
 		}
+		
+		// we ignore any meter reports for item bindings configured with 'meter_reset=true' 
+		// since we don't want to be updating the 'reset' switch
+		if ("true".equalsIgnoreCase(arguments.get("meter_reset")))
+			return;
+
+		String meterScale = arguments.get("meter_scale");
+		String meterZero = arguments.get("meter_zero");
+		ZWaveMeterValueEvent meterEvent = (ZWaveMeterValueEvent)event;
 
 		// Don't trigger event if this item is bound to another sensor type
 		if (meterScale != null && MeterScale.getMeterScale(meterScale) != meterEvent.getMeterScale())


### PR DESCRIPTION
Previously any meter value report would set the reset switch during the event handling. Added a new binding argument 'meter_reset=true' to prevent this happening.
