### PR TITLE
Enable the 'Player.Label' property to be used in an Item. Without this c...

### DIFF
--- a/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/calls/PlayerGetItem.java
+++ b/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/calls/PlayerGetItem.java
@@ -54,6 +54,8 @@ public class PlayerGetItem extends RpcCall {
 		for (String property : properties) {
 			if (property.equals("Player.Type"))
 				continue;
+			if (property.equals("Player.Label"))
+				continue;
 			String paramProperty = getParamProperty(property);
 			paramProperties.add(paramProperty);
 		}


### PR DESCRIPTION
...hange, the XBMC host (Gotham 13.1) will return an error, as XBMC does currently not support querying the 'Label' property. It does, however return this property with every other query by default.
