### PR TITLE
XBMC - Add binding option to use 'Player.open' RPC call.

### DIFF
--- a/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/internal/XbmcActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/internal/XbmcActiveBinding.java
@@ -270,6 +270,8 @@ public class XbmcActiveBinding extends AbstractActiveBinding<XbmcBindingProvider
 			// TODO: handle other commands
 			if (property.equals("Player.PlayPause"))
 				connector.playerPlayPause();
+			if (property.equals("Player.Open"))
+				connector.playerOpen(command.toString());
 			if (property.equals("Player.Stop"))			
 				connector.playerStop();
 			if (property.equals("GUI.ShowNotification"))

--- a/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/XbmcConnector.java
+++ b/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/XbmcConnector.java
@@ -24,6 +24,7 @@ import org.openhab.binding.xbmc.rpc.calls.GUIShowNotification;
 import org.openhab.binding.xbmc.rpc.calls.JSONRPCPing;
 import org.openhab.binding.xbmc.rpc.calls.PlayerGetActivePlayers;
 import org.openhab.binding.xbmc.rpc.calls.PlayerGetItem;
+import org.openhab.binding.xbmc.rpc.calls.PlayerOpen;
 import org.openhab.binding.xbmc.rpc.calls.PlayerPlayPause;
 import org.openhab.binding.xbmc.rpc.calls.PlayerStop;
 import org.openhab.binding.xbmc.rpc.calls.SystemShutdown;
@@ -310,6 +311,12 @@ public class XbmcConnector {
 	public void systemShutdown() {
 		final SystemShutdown shutdown = new SystemShutdown(client, httpUri);
 		shutdown.execute();
+	}
+
+	public void playerOpen(String file) {
+		final PlayerOpen playeropen = new PlayerOpen(client, httpUri);		
+		playeropen.setFile(file);
+		playeropen.execute();
 	}
 
 	private void processPlayerStateChanged(String method, Map<String, Object> json) {

--- a/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/calls/PlayerOpen.java
+++ b/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/calls/PlayerOpen.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.xbmc.rpc.calls;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openhab.binding.xbmc.rpc.RpcCall;
+
+import com.ning.http.client.AsyncHttpClient;
+
+/**
+ * Player.Open RPC
+ * 
+ * @author Ard van der Leeuw
+ * @since 1.6.0
+ */
+public class PlayerOpen extends RpcCall {
+	
+	private String file;
+
+	public PlayerOpen(AsyncHttpClient client, String uri) {
+		super(client, uri);
+	}
+	
+	public void setFile(String file) {
+		this.file = file;
+	}
+
+	@Override
+	protected String getName() {
+		return "Player.Open";
+	}
+	
+	@Override
+	protected Map<String, Object> getParams() {
+		Map<String, Object> params = new HashMap<String, Object>();
+		Map<String, Object> item = new HashMap<String, Object>();
+				
+		item.put("file", file);
+		params.put("item", item);
+		return params;
+	}
+	
+	@Override
+	protected void processResponse(Map<String, Object> response) {
+	}
+}


### PR DESCRIPTION
Use this in combination with a String item and a sendCommand call in your rules. The string should be set to the URL that XBMC needs to open.
