### PR TITLE
XBMC - Update the player status with each refreshInterval

### DIFF
--- a/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/internal/XbmcActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/internal/XbmcActiveBinding.java
@@ -229,6 +229,8 @@ public class XbmcActiveBinding extends AbstractActiveBinding<XbmcBindingProvider
 			if (connector.isConnected()) {
 				// we are still connected but send a ping to make sure
 				connector.ping();
+				// refresh all players
+				connector.updatePlayerStatus();
 			} else {
 				// broken connection so attempt to reconnect
 				logger.debug("Broken connection found for '{}', attempting to reconnect...", entry.getKey());


### PR DESCRIPTION
When playing some streams (e.g. MP3 radio streams), there are no automatic player updates while songs change. This pull request will query all players at every refresh interval to actively pull the information for all items defined. 
