### PR TITLE
Add basic Z-Wave product database entries for Leviton (Company)

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/leviton/dzs15-1lz.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/leviton/dzs15-1lz.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+	<Model>DZS15-1LZ</Model>
+	<Label lang="en">Scene Capable Push On/Off</Label>
+	<CommandClasses>
+		<Class><id>0x20</id></Class>
+		<Class><id>0x25</id></Class>
+		<Class><id>0x86</id></Class>
+		<Class><id>0x27</id></Class>
+		<Class><id>0x2b</id></Class>
+		<Class><id>0x2c</id></Class>
+		<Class><id>0x91</id></Class>
+		<Class><id>0x72</id></Class>
+		<Class><id>0x73</id></Class>
+		<Class><id>0x77</id></Class>
+		<Class><id>0x85</id></Class>
+	</CommandClasses>
+	
+	<Configuration>
+
+	</Configuration>
+	
+</Product>
+

--- a/bundles/binding/org.openhab.binding.zwave/database/leviton/vri06-l1z.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/leviton/vri06-l1z.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+	<Model>VRI06-1LZ</Model>
+	<Label lang="en">Scene Capable Push On/Off Dimmer</Label>
+	<CommandClasses>
+		<Class><id>0x20</id></Class>
+		<Class><id>0x85</id></Class>
+		<Class><id>0x26</id></Class>
+		<Class><id>0x27</id></Class>
+		<Class><id>0x2b</id></Class>
+		<Class><id>0x2c</id></Class>
+		<Class><id>0x91</id></Class>
+		<Class><id>0x72</id></Class>
+		<Class><id>0x73</id></Class>
+		<Class><id>0x77</id></Class>
+		<Class><id>0x86</id></Class>
+	</CommandClasses>
+	
+	<Configuration>
+
+	</Configuration>
+	
+</Product>
+

--- a/bundles/binding/org.openhab.binding.zwave/database/leviton/vrs15-1lz.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/leviton/vrs15-1lz.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+	<Model>VRS15-1LZ</Model>
+	<Label lang="en">Scene Capable Push On/Off</Label>
+	<CommandClasses>
+		<Class><id>0x20</id></Class>
+		<Class><id>0x25</id></Class>
+		<Class><id>0x86</id></Class>
+		<Class><id>0x27</id></Class>
+		<Class><id>0x2b</id></Class>
+		<Class><id>0x2c</id></Class>
+		<Class><id>0x91</id></Class>
+		<Class><id>0x72</id></Class>
+		<Class><id>0x73</id></Class>
+		<Class><id>0x77</id></Class>
+		<Class><id>0x85</id></Class>
+	</CommandClasses>
+	
+	<Configuration>
+
+	</Configuration>
+	
+</Product>
+

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1133,4 +1133,35 @@
 			<Label lang="en">Plugin Lamp Module</Label>
 		</Product>
 	</Manufacturer>
+	<Manufacturer>
+		<Id>001d</Id>
+		<Name>Leviton</Name>
+		<Product>
+			<Reference>
+				<Type>0301</Type>
+				<Id>0209</Id>
+			</Reference>
+			<Model>VRS15-1LZ</Model>
+			<Label lang="en">Scene Capable Push On/Off</Label>
+			<ConfigFile>leviton/vrs15-1lz.xml</ConfigFile>
+		</Product>
+		<Product>
+			<Reference>
+				<Type>0401</Type>
+				<Id>0209</Id>
+			</Reference>
+			<Model>VRI06-1LZ</Model>
+			<Label lang="en">Scene Capable Push On/Off Dimmer</Label>
+			<ConfigFile>leviton/vri06-1lz.xml</ConfigFile>
+		</Product>
+		<Product>
+			<Reference>
+				<Type>1c02</Type>
+				<Id>0334</Id>
+			</Reference>
+			<Model>DZS15-1LZ</Model>
+			<Label lang="en">Scene Capable Push On/Off</Label>
+			<ConfigFile>leviton/dzs15-1lz.xml</ConfigFile>
+		</Product>
+	</Manufacturer>
 </Manufacturers>


### PR DESCRIPTION
Add basic Z-Wave product database support for Z-Wave Products from Leviton. 

To start, I'm only adding the following items:
   VRI06-1LZ (Dimmer), VRS15 (Switch) and the newly added DZS15-1LZ (Switch)

The DZS15-1LZ is a new Leviton Z-Wave switch that's sold at Home Depot, so it doesn't yet have an entry in Pepper.  For now, I've copied the entry for the VRS15 (since it's almost identical) and I will tweak up the entry once we know more about it.
