### PR TITLE
Debian startup script changes: introduce new option and add short description

### DIFF
--- a/distribution/src/deb/etc/default/openhab
+++ b/distribution/src/deb/etc/default/openhab
@@ -1,7 +1,29 @@
+# Execution account and group. The user account should be member of group
+# "openhab" if it's different than "root" and "openhab".
+# Note that some bindings may require "root" access to the system.
+# Default value if isn't specified - "root:root".
 USER_AND_GROUP=openhab:openhab
+
+# Web server's listening ports (plain and SSL). Note that if execution account
+# is different than "root" the port numbers should be greater than 1024.
+# Default value if isn't specified - none, must be specified.
 HTTP_PORT=8080
 HTTPS_PORT=8443
+
+# Console's listening port, same restriction as this for web server's ports.
+# Default value if isn't specified - none, must be specified.
 TELNET_PORT=5555
+
+# Extra arguments passed to Java
 JAVA_ARGS=
+
+# Extra arguments passed to openHAB
 OPENHAB_ARGS=
+
+# Use non-default Java VM.
+# Default value if isn't specified - system default Java VM.
 #OPENHAB_JAVA=/usr/bin/java
+
+# To enable debugging set to "yes" (case insensitive).
+# Default value if isn't specified - debugging is disabled. 
+DEBUG=no

--- a/distribution/src/deb/etc/init.d/openhab
+++ b/distribution/src/deb/etc/init.d/openhab
@@ -86,6 +86,11 @@ fi
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh
 
+DEBUG_ARGS="-Xdebug \
+  -Xnoagent \
+  -Djava.compiler=NONE \
+  -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=n \
+  -Dlogback.configurationFile=${OPENHAB_CONF_DIR}/logback_debug.xml"
 
 JAVA_ARGS_DEFAULT="-Dosgi.clean=true \
  -Declipse.ignoreApp=true \
@@ -99,7 +104,6 @@ JAVA_ARGS_DEFAULT="-Dosgi.clean=true \
  -Djetty.config="${OPENHAB_CONF_DIR}/jetty" \
  -Djetty.logs="${OPENHAB_LOG_DIR}" \
  -Djetty.rundir="${OPENHAB_DIR}" \
- -Dlogback.configurationFile="${OPENHAB_CONF_DIR}/logback.xml" \
  -Dfelix.fileinstall.dir="${OPENHAB_DIR}/addons" \
  -Djava.library.path="${OPENHAB_DIR}/lib" \
  -Djava.security.auth.login.config="${OPENHAB_CONF_DIR}/login.conf" \
@@ -121,6 +125,11 @@ if [ x"${OPENHAB_ARGS}" != x ]; then
 	JAVA_ARGS_DEFAULT="${JAVA_ARGS_DEFAULT} ${OPENHAB_ARGS}"
 fi
 
+if (echo ${DEBUG} | grep -qi "^yes$"); then
+	JAVA_ARGS_DEFAULT="${DEBUG_ARGS} ${JAVA_ARGS_DEFAULT}"
+else
+	JAVA_ARGS_DEFAULT="-Dlogback.configurationFile=${OPENHAB_CONF_DIR}/logback.xml ${JAVA_ARGS_DEFAULT}"
+fi
 
 case "$1" in
   start)


### PR DESCRIPTION
New option "DEBUG" corresponding to "start_debug.sh".
Short options description.
