### PR TITLE
Throw exception if incorrect number format decoded in command class

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
+import java.lang.NumberFormatException;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
@@ -231,7 +232,7 @@ public abstract class ZWaveCommandClass {
 		if((size+offset) >= buffer.length) {
 			logger.error("Error extracting value - length={}, offset={}, size={}.", 
 					new Object[] { buffer.length, offset, size});
-			return BigDecimal.ZERO;
+			throw new NumberFormatException();
 		}
 		
 		int value = 0;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveConfigurationCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveConfigurationCommandClass.java
@@ -107,18 +107,23 @@ public class ZWaveConfigurationCommandClass extends ZWaveCommandClass {
 		int size = serialMessage.getMessagePayloadByte(offset + 2);
 
 		// Recover the data
-		int value = extractValue(serialMessage.getMessagePayload(), offset + 3, size);
+		try {
+			int value = extractValue(serialMessage.getMessagePayload(), offset + 3, size);
 
-		logger.debug(String.format("NODE %d: Node configuration report, parameter = %d, value = 0x%02X", this
-				.getNode().getNodeId(), parameter, value));
+			logger.debug(String.format("NODE %d: Node configuration report, parameter = %d, value = 0x%02X", this
+					.getNode().getNodeId(), parameter, value));
 
-		ConfigurationParameter configurationParameter = new ConfigurationParameter(parameter, value, size);
-		
-		this.configParameters.put(parameter, configurationParameter);
-		
-		ZWaveConfigurationParameterEvent zEvent = new ZWaveConfigurationParameterEvent(this.getNode().getNodeId(),
-				configurationParameter);
-		this.getController().notifyEventListeners(zEvent);
+			ConfigurationParameter configurationParameter = new ConfigurationParameter(parameter, value, size);
+			
+			this.configParameters.put(parameter, configurationParameter);
+			
+			ZWaveConfigurationParameterEvent zEvent = new ZWaveConfigurationParameterEvent(this.getNode().getNodeId(),
+					configurationParameter);
+			this.getController().notifyEventListeners(zEvent);
+		}
+		catch (NumberFormatException e) {
+			return;
+		}
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterCommandClass.java
@@ -138,14 +138,18 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass implements ZWaveGe
 			if (!this.meterScales.contains(scale))
 				this.meterScales.add(scale);
 
+			try {
+				BigDecimal value = extractValue(serialMessage.getMessagePayload(), offset + 2);
+				logger.debug(String.format("Meter Value = (%f)", value));
+	
+				ZWaveMeterValueEvent zEvent = new ZWaveMeterValueEvent(this.getNode().getNodeId(), endpoint, 
+						meterType, scale, value);
+				this.getController().notifyEventListeners(zEvent);
+			}
+			catch (NumberFormatException e) {
+				return;
+			}
 
-			BigDecimal value = extractValue(serialMessage.getMessagePayload(), offset + 2);
-			logger.debug(String.format("Meter Value = (%f)", value));
-
-			ZWaveMeterValueEvent zEvent = new ZWaveMeterValueEvent(this.getNode().getNodeId(), endpoint, 
-					meterType, scale, value);
-			this.getController().notifyEventListeners(zEvent);
-			
 			if (this.getNode().getNodeStage() != NodeStage.DONE)
 				this.getNode().advanceNodeStage(NodeStage.DONE);
 			break;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
@@ -139,12 +139,17 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass impleme
 			if (!sensors.contains(sensorType))
 				this.sensors.add(sensorType);
 
-			BigDecimal value = extractValue(serialMessage.getMessagePayload(), offset + 2);
+			try {
+				BigDecimal value = extractValue(serialMessage.getMessagePayload(), offset + 2);
 
-			logger.debug(String.format("NODE %d: Sensor Value = (%f)", this.getNode().getNodeId(), value));
-			
-			ZWaveMultiLevelSensorValueEvent zEvent = new ZWaveMultiLevelSensorValueEvent(this.getNode().getNodeId(), endpoint, sensorType, sensorScale, value);
-			this.getController().notifyEventListeners(zEvent);
+				logger.debug(String.format("NODE %d: Sensor Value = (%f)", this.getNode().getNodeId(), value));
+				
+				ZWaveMultiLevelSensorValueEvent zEvent = new ZWaveMultiLevelSensorValueEvent(this.getNode().getNodeId(), endpoint, sensorType, sensorScale, value);
+				this.getController().notifyEventListeners(zEvent);
+			}
+			catch (NumberFormatException e) {
+				return;
+			}
 			
 			if (this.getNode().getNodeStage() != NodeStage.DONE)
 				this.getNode().advanceNodeStage(NodeStage.DONE);

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClass.java
@@ -147,27 +147,33 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
 		
 		int setpointTypeCode = serialMessage.getMessagePayloadByte(offset + 1);
 		int scale = (serialMessage.getMessagePayloadByte(offset + 2) >> 3) & 0x03;
-		BigDecimal value = extractValue(serialMessage.getMessagePayload(), offset + 2);
 		
-		logger.debug(String.format("Thermostat Setpoint report from nodeId = %d, Scale = %d", this.getNode().getNodeId(), scale));
-		logger.debug(String.format("Thermostat Setpoint Value = (%f)", value));
-		
-		SetpointType setpointType = SetpointType.getSetpointType(setpointTypeCode);
-		
-		if (setpointType == null) {
-			logger.error(String.format("Unknown Setpoint Type = 0x%02x, ignoring report.", setpointTypeCode));
+		try {
+			BigDecimal value = extractValue(serialMessage.getMessagePayload(), offset + 2);
+			
+			logger.debug(String.format("Thermostat Setpoint report from nodeId = %d, Scale = %d", this.getNode().getNodeId(), scale));
+			logger.debug(String.format("Thermostat Setpoint Value = (%f)", value));
+			
+			SetpointType setpointType = SetpointType.getSetpointType(setpointTypeCode);
+			
+			if (setpointType == null) {
+				logger.error(String.format("Unknown Setpoint Type = 0x%02x, ignoring report.", setpointTypeCode));
+				return;
+			}
+			
+			// setpoint type seems to be supported, add it to the list.
+			if (!this.setpointTypes.contains(setpointType))
+				this.setpointTypes.add(setpointType);
+	
+			logger.debug(String.format("Setpoint Type = %s (0x%02x)", setpointType.getLabel(), setpointTypeCode));
+			
+			logger.debug(String.format("Thermostat Setpoint Report from Node ID = %d, value = %s", this.getNode().getNodeId(), value.toPlainString()));
+			ZWaveThermostatSetpointValueEvent zEvent = new ZWaveThermostatSetpointValueEvent(this.getNode().getNodeId(), endpoint, setpointType, scale, value);
+			this.getController().notifyEventListeners(zEvent);
+		}
+		catch (NumberFormatException e) {
 			return;
 		}
-		
-		// setpoint type seems to be supported, add it to the list.
-		if (!this.setpointTypes.contains(setpointType))
-			this.setpointTypes.add(setpointType);
-
-		logger.debug(String.format("Setpoint Type = %s (0x%02x)", setpointType.getLabel(), setpointTypeCode));
-		
-		logger.debug(String.format("Thermostat Setpoint Report from Node ID = %d, value = %s", this.getNode().getNodeId(), value.toPlainString()));
-		ZWaveThermostatSetpointValueEvent zEvent = new ZWaveThermostatSetpointValueEvent(this.getNode().getNodeId(), endpoint, setpointType, scale, value);
-		this.getController().notifyEventListeners(zEvent);
 	}
 	
 	/**


### PR DESCRIPTION
This PR changes the response to a format error with a received packet. Previously the error was caught and ZERO returned. This now throws a NumberFormat exception which is then caught in the command classes so that we can ignore the error rather than sending an invalid value into the system.
