### PR TITLE
Changed logger for openhab.log from FileAppender to RollingFileAppender ...

### DIFF
--- a/distribution/openhabhome/configurations/logback.xml
+++ b/distribution/openhabhome/configurations/logback.xml
@@ -6,8 +6,14 @@
 		</encoder>
 	</appender>
 
-	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
+	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 		<file>${openhab.logdir:-logs}/openhab.log</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<!-- weekly rollover and archiving -->
+			<fileNamePattern>${openhab.logdir:-logs}/openhab-%d{yyyy-ww}.log.zip</fileNamePattern>
+			<!-- keep 30 days' worth of history -->
+			<maxHistory>30</maxHistory>
+		</rollingPolicy>
 		<encoder>
 			<pattern>%d{HH:mm:ss.SSS} %-5level %logger{30}[:%line]- %msg%n%ex{5}</pattern>
 		</encoder>


### PR DESCRIPTION
...to handle logs in the same manner as on event.log.
