### PR TITLE
start broadcaster lifecycle management manually

### DIFF
--- a/bundles/io/org.openhab.io.cv/src/main/java/org/openhab/io/cv/internal/listeners/ResourceStateChangeListener.java
+++ b/bundles/io/org.openhab.io.cv/src/main/java/org/openhab/io/cv/internal/listeners/ResourceStateChangeListener.java
@@ -71,6 +71,9 @@ abstract public class ResourceStateChangeListener {
 	
 	public void registerItems(){
 		broadcaster.getBroadcasterConfig().setBroadcasterCache(new CVBroadcasterCache());
+		broadcaster.getBroadcasterConfig().getBroadcasterCache().configure(broadcaster.getBroadcasterConfig());
+        broadcaster.getBroadcasterConfig().getBroadcasterCache().start();
+        
 		broadcaster.getBroadcasterConfig().addFilter(new PerRequestBroadcastFilter() {
 			
 			@Override


### PR DESCRIPTION
according to pull request #1376 this adds the same fix to the CV bundle
