### PR TITLE
Dimmer updates

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/ge/dimmer.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/ge/dimmer.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Product>
-	<Model>45603</Model>
-	<Label lang="en">Fluorescent Light &amp; Appliance Module</Label>
-	<CommandClasses>
-		<Class><id>0x70</id></Class>
-	</CommandClasses>
-	
-	<Configuration>
-
-	</Configuration>
-	
-</Product>
-<Product>
 	<Model>45606</Model>
 	<Endpoints>1</Endpoints>
 	<Label lang="en">In-Wall Dimmer</Label>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1168,19 +1168,14 @@
 				<Type>0401</Type>
 				<Id>0209</Id>
 			</Reference>
+			 <Reference>
+                <Type>0401</Type>
+                <Id>0334</Id>
+            </Reference>
 			<Model>VRI06-1LZ</Model>
 			<Label lang="en">Scene Capable Push On/Off Dimmer</Label>
 			<ConfigFile>leviton/vri06-1lz.xml</ConfigFile>
 		</Product>
-		<Product>
-            <Reference>
-                <Type>0401</Type>
-                <Id>0334</Id>
-            </Reference>
-            <Model>VRI06-1LZ</Model>
-            <Label lang="en">Scene Capable Push On/Off Dimmer</Label>
-            <ConfigFile>leviton/vri06-1lz.xml</ConfigFile>
-        </Product>
 		<Product>
 			<Reference>
 				<Type>1c02</Type>


### PR DESCRIPTION
This updates the product database to correct an error with GE/Jasco dimmers as well as add a new reference type id for certain Leviton dimmers. 
