### PR TITLE
Zwave logic fix

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
@@ -225,7 +225,6 @@ public class ZWaveNodeStageAdvancer {
 			queriesPending = -1;
 			this.node.setNodeStage(NodeStage.DYNAMIC);
 		case DYNAMIC:
-			logger.trace("NODE {}: queriesPending {} ", this.node.getNodeId(), queriesPending);
 			if (queriesPending == -1) {
 				queriesPending = 0;
 				for (ZWaveCommandClass zwaveCommandClass : this.node.getCommandClasses()) {
@@ -273,7 +272,7 @@ public class ZWaveNodeStageAdvancer {
 					}
 				}
 			}
-			logger.trace("NODE {}: queriesPending part 2 {} ", this.node.getNodeId(), queriesPending);
+			
 			if (--queriesPending > 0) // there is still something to be
 										// initialized.
 				break;


### PR DESCRIPTION
I noticed a bug when a switch reported a status, it would only work every other time, I tracked it down to a statement that should be using a prefix decrement operator vs a postfix one.  
