### PR TITLE
Support binding Service Discovery to specific IP or hostname

### DIFF
--- a/bundles/io/org.openhab.io.servicediscovery/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.servicediscovery/META-INF/MANIFEST.MF
@@ -8,6 +8,8 @@ Service-Component: OSGI-INF/servicediscovery.xml
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: org.osgi.framework,
+ org.osgi.service.cm;version="1.4.0",
+ org.apache.commons.lang;version="2.6.0",
  org.slf4j;version="1.6.1"
 Export-Package: org.openhab.io.servicediscovery
 Bundle-ClassPath: lib/jmdns-3.4.1.jar,

--- a/bundles/io/org.openhab.io.servicediscovery/OSGI-INF/servicediscovery.xml
+++ b/bundles/io/org.openhab.io.servicediscovery/OSGI-INF/servicediscovery.xml
@@ -13,5 +13,7 @@
    <implementation class="org.openhab.io.servicediscovery.internal.DiscoveryServiceImpl"/>
    <service>
 	   <provide interface="org.openhab.io.servicediscovery.DiscoveryService"/>
+	   <provide interface="org.osgi.service.cm.ManagedService"/>
    </service>
+   <property name="service.pid" type="String" value="org.openhab.servicediscovery"/>
 </scr:component>

--- a/bundles/io/org.openhab.io.servicediscovery/src/main/java/org/openhab/io/servicediscovery/internal/DiscoveryServiceImpl.java
+++ b/bundles/io/org.openhab.io.servicediscovery/src/main/java/org/openhab/io/servicediscovery/internal/DiscoveryServiceImpl.java
@@ -9,12 +9,17 @@
 package org.openhab.io.servicediscovery.internal;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Dictionary;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceInfo;
 
+import org.apache.commons.lang.StringUtils;
 import org.openhab.io.servicediscovery.DiscoveryService;
 import org.openhab.io.servicediscovery.ServiceDescription;
+import org.osgi.service.cm.ManagedService;
+import org.osgi.service.cm.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,14 +30,32 @@ import org.slf4j.LoggerFactory;
  * @since 1.0.0
  *
  */
-public class DiscoveryServiceImpl implements DiscoveryService {
+public class DiscoveryServiceImpl implements DiscoveryService, ManagedService {
 
 	private static Logger logger = LoggerFactory.getLogger(DiscoveryServiceImpl.class);
 	private JmDNS jmdns;
 	
 	public DiscoveryServiceImpl() {
 	}
-	
+
+	@Override
+	public void updated(Dictionary<String, ?> config) throws ConfigurationException {
+		try {
+			if (config != null) {
+				String bindAddress = (String)config.get("bind_address");
+				if (bindAddress != null && StringUtils.isNotBlank(bindAddress)) {
+					jmdns = JmDNS.create(InetAddress.getByName(bindAddress));
+					logger.info("Service Discovery initialization completed (bound to address: {}).", bindAddress);
+					return;
+				}
+			}
+			jmdns = JmDNS.create();
+			logger.info("Service Discovery initialization completed.");
+		} catch (IOException e) {
+			logger.error(e.getMessage());
+		}
+	}
+
 	/**
 	 * @{inheritDoc}
 	 */
@@ -67,12 +90,7 @@ public class DiscoveryServiceImpl implements DiscoveryService {
 	}
 	
 	public void activate() {
-		try {
-			jmdns = JmDNS.create();
-			logger.info("mDNS service has been started");
-		} catch (IOException e) {
-			logger.error(e.getMessage());
-		}
+		logger.info("mDNS service has been started");
 	}
 	
 	public void deactivate() {

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -38,6 +38,8 @@ persistence:default=rrd4j
 # deactivates the scan (optional, defaults to '-1' hence scanning is deactivated)
 #mainconfig:refresh=
 
+# Bind service discovery to specific hostname or IP address
+#servicediscovery:bind_address=127.0.0.1
 
 ################################## Chart Servlet ######################################
 #


### PR DESCRIPTION
Now it's possible to specify where to bind the mDNS service to. Previously it would use whatever Java returned as the local host address. On multi interface systems that could cause problems as it sometimes would bind to the wrong interface.
