### PR TITLE
fix classpath's for atmosphere jars (was 2.0.7 should be 2.0.9 as included project)

### DIFF
--- a/bundles/io/org.openhab.io.cv/.classpath
+++ b/bundles/io/org.openhab.io.cv/.classpath
@@ -4,8 +4,8 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
-	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-annotations-2.0.7.jar"/>
-	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-jersey-2.0.7.jar"/>
-	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-runtime-2.0.7.jar"/>
+	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-jersey-2.0.9.jar"/>
+	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-annotations-2.0.9.jar"/>
+	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-runtime-2.0.9.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/io/org.openhab.io.rest.lib/.classpath
+++ b/bundles/io/org.openhab.io.rest.lib/.classpath
@@ -15,10 +15,10 @@
 	<classpathentry exported="true" kind="lib" path="lib/jackson-jaxrs-1.9.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jackson-mapper-asl-1.9.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jackson-xc-1.9.2.jar"/>
-	<classpathentry kind="lib" path="lib/atmosphere-annotations-2.0.7.jar"/>
-	<classpathentry kind="lib" path="lib/atmosphere-jersey-2.0.7.jar"/>
-	<classpathentry kind="lib" path="lib/atmosphere-runtime-2.0.7.jar"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="lib/atmosphere-annotations-2.0.9.jar"/>
+	<classpathentry kind="lib" path="lib/atmosphere-jersey-2.0.9.jar"/>
+	<classpathentry kind="lib" path="lib/atmosphere-runtime-2.0.9.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/io/org.openhab.io.rest/.classpath
+++ b/bundles/io/org.openhab.io.rest/.classpath
@@ -3,8 +3,8 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
-	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-annotations-2.0.7.jar"/>
-	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-jersey-2.0.7.jar"/>
-	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-runtime-2.0.7.jar"/>
+	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-annotations-2.0.9.jar"/>
+	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-jersey-2.0.9.jar"/>
+	<classpathentry kind="lib" path="/org.openhab.io.rest.lib/lib/atmosphere-runtime-2.0.9.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
classpath settings not updated to atmosphere 2.0.9 jars in (e66a8e8ce74edf7a704ed779af0c0e764fdcc669).
In a clean IDE setup as described in the wiki, the dependencies can't be resolved without manually adapt the classpath.
please also fix it in master if not already done.
