### PR TITLE
added new action: createTimerWithArgument(expiryTime, argument, closure)

### DIFF
--- a/bundles/model/org.openhab.model.script/src/org/openhab/model/script/internal/actions/TimerExecutionJob.java
+++ b/bundles/model/org.openhab.model.script/src/org/openhab/model/script/internal/actions/TimerExecutionJob.java
@@ -9,6 +9,7 @@
 package org.openhab.model.script.internal.actions;
 
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure0;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -27,7 +28,9 @@ public class TimerExecutionJob implements Job {
 
 	static final private Logger logger = LoggerFactory.getLogger(TimerExecutionJob.class);
 	
-	private Procedure0 procedure;
+	private Procedure0 procedure = null;
+	private Procedure1<Object> procedure1 = null;
+	private Object	argument1 = null;
 	private TimerImpl timer;
 
 	/**
@@ -37,17 +40,34 @@ public class TimerExecutionJob implements Job {
 	 */
 	public void execute(JobExecutionContext context) throws JobExecutionException {
 		logger.debug("Executing timer '{}'", context.getJobDetail().getKey().toString());
-		procedure.apply();
+		if (procedure != null) {
+			procedure.apply();
+		} else if (procedure1 != null) {
+			procedure1.apply(argument1);
+		}
 		timer.setTerminated(true);
 	}
 
 	/**
-	 * Sets the closure for this job
+	 * Sets the 0-parameter closure for this job
 	 * 
 	 * @param procedure a closure without parameters
 	 */
 	public void setProcedure(Procedure0 procedure) {
 		this.procedure = procedure;
+	}
+
+	/**
+	 * Sets the 1-parameter closure for this job
+	 * 
+	 * @param procedure a closure with a single argument
+	 */
+	public void setProcedure1(Procedure1<Object> procedure) {
+		this.procedure1 = procedure;
+	}
+	
+	public void setArgument1(Object argument1) {
+		this.argument1 = argument1;
 	}
 
 	/** 


### PR DESCRIPTION
to allow creation of timers with an argument passed to the closure.
This allows more complex scripting for e.g. motion sensor timeouts.

This extends the existing createTimer() to allow for scripting like this:

var String cookie = "cookie"
var Timer timer = createTimerWithArgument(now.plusSeconds(10), cookie,
                                     [ x |
                                        logInfo("timer_expired", " with cookie: " + x)
                                     ]
                            )

Having the cookie allows the expiring timer to e.g. look up its timer in hash table.

A combination of Groups, hash maps, and timers with arguments allowed me to write
some powerful rules to avoid cut-and-pasting code.
