### PR TITLE
Support for multiple netmasks and IPv6

### DIFF
--- a/bundles/io/org.openhab.io.net.test/src/test/java/org/openhab/io/net/http/SecureHttpContextTest.java
+++ b/bundles/io/org.openhab.io.net.test/src/test/java/org/openhab/io/net/http/SecureHttpContextTest.java
@@ -1,0 +1,59 @@
+package org.openhab.io.net.http;
+
+import static org.junit.Assert.*;
+
+import java.net.UnknownHostException;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.junit.Test;
+import org.osgi.service.cm.ConfigurationException;
+
+public class SecureHttpContextTest {
+	@Test
+	public void ipv4() throws UnknownHostException, ConfigurationException {
+		init("192.168.0.0/24");
+		assertFalse(ctx.isExternalIp("127.0.0.1"));
+		assertFalse(ctx.isExternalIp("192.168.0.100"));
+		assertTrue(ctx.isExternalIp("1.1.1.1"));
+	}
+
+	@Test
+	public void ipv6() throws UnknownHostException, ConfigurationException {
+		init("fe80::/64");
+		assertFalse(ctx.isExternalIp("::1"));
+		assertFalse(ctx.isExternalIp("fe80:0000:0000:0000:0000:0000:0000:0001"));
+		assertTrue(ctx.isExternalIp("fe80:0000:0000:0001:0000:0000:0000:0000"));
+	}
+
+	@Test
+	public void dualstack() throws UnknownHostException, ConfigurationException {
+		init("192.168.0.0/24,fe80::/64");
+		assertFalse(ctx.isExternalIp("127.0.0.1"));
+		assertFalse(ctx.isExternalIp("192.168.0.100"));
+		assertTrue(ctx.isExternalIp("1.1.1.1"));
+		assertFalse(ctx.isExternalIp("::1"));
+		assertFalse(ctx.isExternalIp("fe80:0000:0000:0000:0000:0000:0000:0001"));
+		assertTrue(ctx.isExternalIp("fe80:0000:0000:0001:0000:0000:0000:0000"));
+	}
+
+	@Test
+	public void undef() throws UnknownHostException, ConfigurationException {
+		init(null);
+		assertFalse(ctx.isExternalIp("127.0.0.1"));
+		assertFalse(ctx.isExternalIp("::1"));
+		assertFalse(ctx.isExternalIp("192.168.1.111"));
+		assertTrue(ctx.isExternalIp("192.168.100.111"));
+		assertTrue(ctx.isExternalIp("fe80:0000:0000:0000:0000:0000:0000:0001"));
+		assertTrue(ctx.isExternalIp("fe80:0000:0000:0001:0000:0000:0000:0000"));
+	}
+
+	private SecureHttpContext ctx;
+	public void init(String netmask) throws ConfigurationException {
+		ctx = new SecureHttpContext();
+		Dictionary<String, String> cfg = new Hashtable<String, String>();
+		if (netmask != null)
+			cfg.put("netmask", netmask);
+		ctx.updated(cfg);
+	}
+}

--- a/bundles/io/org.openhab.io.net/src/main/java/org/openhab/io/net/http/IpAddressMatcher.java
+++ b/bundles/io/org.openhab.io.net/src/main/java/org/openhab/io/net/http/IpAddressMatcher.java
@@ -1,0 +1,74 @@
+package org.openhab.io.net.http;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+/**
+ * Based on: https://github.com/spring-projects/spring-security/blob/master/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
+ * License: Apache License, Version 2.0, January 2004
+ */
+public final class IpAddressMatcher {
+	private final int nMaskBits;
+	private final InetAddress requiredAddress;
+
+	/**
+	 * Takes a specific IP address or a range specified using the IP/Netmask
+	 * (e.g. 192.168.1.0/24 or 202.24.0.0/14).
+	 * 
+	 * @param ipAddress the address or range of addresses from which the request must come.
+	 */
+	public IpAddressMatcher(String ipAddress) {
+		if (ipAddress.indexOf('/') > 0) {
+			String[] addressAndMask = ipAddress.split("/");
+			ipAddress = addressAndMask[0];
+			nMaskBits = Integer.parseInt(addressAndMask[1]);
+		} else {
+			nMaskBits = -1;
+		}
+		requiredAddress = parseAddress(ipAddress);
+	}
+
+	public boolean matches(String address) {
+		InetAddress remoteAddress = parseAddress(address);
+
+		if (!requiredAddress.getClass().equals(remoteAddress.getClass())) {
+			return false;
+		}
+
+		if (nMaskBits < 0) {
+			return remoteAddress.equals(requiredAddress);
+		}
+
+		byte[] remAddr = remoteAddress.getAddress();
+		byte[] reqAddr = requiredAddress.getAddress();
+
+		int oddBits = nMaskBits % 8;
+		int nMaskBytes = nMaskBits / 8 + (oddBits == 0 ? 0 : 1);
+		byte[] mask = new byte[nMaskBytes];
+
+		Arrays.fill(mask, 0, oddBits == 0 ? mask.length : mask.length - 1, (byte)0xFF);
+
+		if (oddBits != 0) {
+			int finalByte = (1 << oddBits) - 1;
+			finalByte <<= 8 - oddBits;
+			mask[mask.length - 1] = (byte)finalByte;
+		}
+
+		for (int i = 0; i < mask.length; i++) {
+			if ((remAddr[i] & mask[i]) != (reqAddr[i] & mask[i])) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private InetAddress parseAddress(String address) {
+		try {
+			return InetAddress.getByName(address);
+		} catch (UnknownHostException e) {
+			throw new IllegalArgumentException("Failed to parse address" + address, e);
+		}
+	}
+}


### PR DESCRIPTION
Previously one could only specify a single IPv4 subnet. When using dual stack with IPv6 one couldn't use OpenHAB with IP based restrictions at all.
