### PR TITLE
Added Possibility to filter incoming messages for MQTT subscriber

### DIFF
--- a/bundles/binding/org.openhab.binding.mqtt.test/src/test/java/org/openhab/binding/mqtt/internal/MqttMessageSubscriberTest.java
+++ b/bundles/binding/org.openhab.binding.mqtt.test/src/test/java/org/openhab/binding/mqtt/internal/MqttMessageSubscriberTest.java
@@ -49,7 +49,7 @@ public class MqttMessageSubscriberTest {
 	private void validateBadConfig(String configString) {
 		try {
 			new MqttMessageSubscriber(configString);
-			fail("Missing exception..");
+			fail("Missing exception for config " + configString);
 		} catch (BindingConfigParseException e) {
 			return;
 		}
@@ -103,17 +103,16 @@ public class MqttMessageSubscriberTest {
 	@Test
 	public void canDetectInvalidConfigurations() {
 
-		validateBadConfig(" :/mytopic:command:ON:1");
-		validateBadConfig("mybroker:/mytopic:command:ON:1");
+		validateBadConfig(" :/mytopic:command:ON:.*:1");
+		validateBadConfig("mybroker:/mytopic:command:ON:.*:1");
 		validateBadConfig("mybroker:/mytopic:command:ON:1:99");
 		validateBadConfig("mybroker::/mytopic:command:ON:1");
 		validateBadConfig("mybroker:command:ON:1");
-		validateBadConfig("mybroker:/mytopic:command:ON:1");
-		validateBadConfig("mybroker:/mytopic:command:ON:1");
+		validateBadConfig("mybroker:/mytopic:command:ON:.*:1");
 		validateBadConfig(null);
 		validateBadConfig("");
-		validateBadConfig("  mybroker : /mytopic : command : * : file(/tmp/myfile.txt)");
-		validateBadConfig("mybroker:/mytopic:command:ON:1");
+		validateBadConfig("  mybroker : /mytopic : command : * : .* : file(/tmp/myfile.txt)");
+		validateBadConfig("mybroker:/mytopic:comand:ON:1");
 	}
 
 	@Test

--- a/bundles/binding/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttMessageSubscriber.java
+++ b/bundles/binding/org.openhab.binding.mqtt/src/main/java/org/openhab/binding/mqtt/internal/MqttMessageSubscriber.java
@@ -62,9 +62,9 @@ public class MqttMessageSubscriber extends AbstractMqttMessagePubSub implements
 		String[] config = splitConfigurationString(configuration);
 		try {
 
-			if (config.length < 4) {
+			if (config.length != 4 && config.length != 5) {
 				throw new BindingConfigParseException(
-						"Configuration requires at least 4 parameters separated by ':'");
+						"Configuration requires 4 or 5 parameters separated by ':'");
 			}
 
 			if (StringUtils.isEmpty(config[0])) {


### PR DESCRIPTION
If multiple types of messages are broadcasted on one MQTT topic, then this change allows to just process messages that match a regular expression and skip all the others

Thus the binding configuration for incoming messages is extended by a fifth (optional) field that defines a regular expression. like:
`mqtt="<[<broker>:<topic>:<type>:<transformer>[:<regexfilter>]]`
