### PR TITLE
Zwave wakeup queue

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
@@ -242,7 +242,6 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass implements ZWaveC
 		if (this.wakeUpQueue.contains(serialMessage)) {
 			logger.debug("NODE {}: Message already on the wake-up queue. Removing original.", this.getNode().getNodeId());
 			this.wakeUpQueue.remove(serialMessage);
-//			return false;
 		}
 
 		logger.debug("NODE {}: Putting message in wakeup queue.", this.getNode().getNodeId());


### PR DESCRIPTION
This will remove old requests from the wakeup queue and requeue the new request. This ensures that an update is sent in the correct order.
