### PR TITLE
Query nodes for the number of groups supported. This Fixes #1452.

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
@@ -57,7 +57,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass {
 	@XStreamOmitField
 	private AssociationGroup pendingAssociation = null;
 	
-	@XStreamOmitField
+	//this will be set when we query a node for the number of groups it supports
 	private int maxGroups = 0;
 
 	/**


### PR DESCRIPTION
I would like @cdjackson  to sign off on this one before it gets merged please.  The zwave  binding queries devices for groups until the device reports back that a group has zero max associations.   Some devices like the Honeywell TH8320ZW thermostat simply do not reply at all when queried on a non existent group.  This change queries the node for the number of groups first, then queries each one.  I checked with the open zwave code,  and while they have logic to do it both ways,  afaik, only this way is actually used.  
