### PR TITLE
Squeezebox Binding: Sync "remove" players incorrect

### DIFF
--- a/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeboxBinding.java
+++ b/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeboxBinding.java
@@ -135,7 +135,7 @@ public class SqueezeboxBinding extends AbstractBinding<SqueezeboxBindingProvider
 						if (command.equals(OnOffType.ON))
 							squeezeServer.syncPlayer(playerId, bindingConfig.getExtra()); 
 						else if (command.equals(OnOffType.OFF))
-							squeezeServer.unSyncPlayer(playerId);
+							squeezeServer.unSyncPlayer(bindingConfig.getExtra());
 						break;
 
 					default:


### PR DESCRIPTION
The "sync:XXX" binding command for multi-player playback sync & its
respective OFF command is incorrect. It's removing the source player and
not the target player.
As the LMS "sync -" CLI command only supports a single playerID then it
should be the target synced player and not the source one.

Also means that when re-adding another player into another player group
the OFF command will always remove the correct respective player.
