### PR TITLE
Zwave config info

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
@@ -8,11 +8,14 @@
  */
 package org.openhab.binding.zwave.internal;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
@@ -84,6 +87,8 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
 	private boolean initialised = false;
 
+    private DateFormat df;
+
 	Map<Integer, HealNode> healNodes = new HashMap<Integer, HealNode>();
 
 	enum HealState {
@@ -104,6 +109,9 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 	HealState networkHealState = HealState.WAITING;
 
 	public ZWaveNetworkMonitor(ZWaveController controller) {
+		df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+		df.setTimeZone(TimeZone.getTimeZone("UTC"));
+
 		zController = controller;
 
 		// Set an event callback so we get notification of network events
@@ -144,13 +152,12 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 			if (node.nodeId == nodeId) {
 				switch (node.state) {
 				case IDLE:
-				case WAITING:
 					break;
 				case FAILED:
-					status = "FAILED during " + node.failState + " @ " + node.lastChange.toString();
+					status = "FAILED during " + node.failState + " @ " + df.format(node.lastChange);
 					break;
 				default:
-					status = node.state + " @ " + node.lastChange.toString();
+					status = node.state + " @ " + df.format(node.lastChange);
 					if (node.retryCnt > 1) {
 						status += " (" + node.retryCnt + ")";
 					}

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
@@ -58,18 +58,13 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 	private boolean inclusion = false;
 	private boolean exclusion = false;
 	
-	private TimeZone tz = TimeZone.getTimeZone("UTC");
-    private DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ");
+    private DateFormat df;
 
 	private Timer timer = new Timer();
 
 	private TimerTask timerTask = null;
 	
 	private PendingConfiguration PendingCfg = new PendingConfiguration();
-	
-	public ZWaveConfiguration() {
-		df.setTimeZone(tz);
-	}
 
 	/**
 	 * Constructor for the configuration class. Sets the zwave controller
@@ -77,6 +72,9 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 	 * @param controller The zWave controller
 	 */
 	public ZWaveConfiguration(ZWaveController controller, ZWaveNetworkMonitor monitor) {
+		df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+		df.setTimeZone(TimeZone.getTimeZone("UTC"));
+
 		this.zController = controller;
 		this.networkMonitor = monitor;
 
@@ -421,7 +419,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 				ZWaveBatteryCommandClass batteryCommandClass = (ZWaveBatteryCommandClass) node
 						.getCommandClass(CommandClass.BATTERY);
 				if (batteryCommandClass != null) {
-					record.value = "Battery";
+					record.value = "Battery " + batteryCommandClass.getBatteryLevel() + "%";
 				} else {
 					record.value = "Mains";
 				}


### PR DESCRIPTION
This changes some date formats to use ISO formats, and moves some of the config display information that is static into a separate domain so that it only needs to be requested once. This reduces bandwidth and processor loading when HABmin is running as it polls dynamic data.
