### PR TITLE
Fritzbox Binding log message #881

### DIFF
--- a/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/internal/FritzboxBinding.java
+++ b/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/internal/FritzboxBinding.java
@@ -146,7 +146,6 @@ public class FritzboxBinding extends
 	public void internalReceiveCommand(String itemName, Command command) {
 
 		if (password != null && !password.isEmpty()) {
-			logger.warn("Fritzbox password: "+password);
 			String type = null;
 			for (FritzboxBindingProvider provider : providers) {
 				type = provider.getType(itemName);


### PR DESCRIPTION
Telnet connection is now only opened if a password is set and if there
is an item configured which uses the telnet connect on the standard
port. Annoying warning message is not sent anymore.
