### PR TITLE
Added Squeezebox Action Dependancy Info for OpenHAB Designer

### DIFF
--- a/features/org.openhab.designer.feature/feature.xml
+++ b/features/org.openhab.designer.feature/feature.xml
@@ -314,6 +314,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.openhab.action.squeezebox"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.openhab.action.twitter"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Added Squeezebox action entries to the features.xml file for the Designer. This should allow syntax parser to recognize them in files. For Issue #1403 .
