### PR TITLE
Change products.xml to support specific Aeon Minimote device

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -466,6 +466,10 @@
 				<Type>0006</Type>
 				<Id>0002</Id>
 			</Reference>
+			<Reference>
+				<Type>0001</Type>
+				<Id>0003</Id>
+			</Reference>			
 			<Model>Minimote</Model>
 			<Label lang="en">4 button remote control</Label>
 			<ConfigFile>aeon/minimote.xml</ConfigFile>

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSceneActivationCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSceneActivationCommandClass.java
@@ -80,8 +80,13 @@ public class ZWaveSceneActivationCommandClass extends ZWaveCommandClass {
 	 * @param endpoint the endpoint or instance number this message is meant for.
 	 */
 	protected void processSceneActivationSet(SerialMessage serialMessage, int offset, int endpoint) {
-        int sceneId = serialMessage.getMessagePayloadByte(offset + 1);
-        int sceneTime = serialMessage.getMessagePayloadByte(offset + 2);
+        int sceneId = serialMessage.getMessagePayloadByte(offset + 1);              
+        int sceneTime = 0;
+
+        // Aeon Minimote fw 1.19 sends SceneActivationSet without Time parameter
+        if (serialMessage.getMessagePayload().length > (offset  + 2)) {
+        	sceneTime = serialMessage.getMessagePayloadByte(offset + 2);
+        }
 
         logger.debug(String.format("Scene activation node from node %d: Scene %d, Time %d", this.getNode().getNodeId(),
         		sceneId, sceneTime));


### PR DESCRIPTION
Change ZWaveSceneActivationCommandClass to not read beyond the received serial buffer. The Aeon Minimote device (firmware 1.19) doesn't send a 'time' parameter in this command.
