### PR TITLE
Fix for #851: Merged from branch 1.5.1

### DIFF
--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/connection/KNXConnection.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/connection/KNXConnection.java
@@ -49,49 +49,49 @@ import tuwien.auto.calimero.process.ProcessListener;
  */
 public class KNXConnection implements ManagedService {
 
-	private static final Logger logger = LoggerFactory.getLogger(KNXConnection.class);
+	private static final Logger sLogger = LoggerFactory.getLogger(KNXConnection.class);
 
-	private static ProcessCommunicator pc = null;
+	private static ProcessCommunicator sPC = null;
 	
-	private static ProcessListener listener = null;
+	private static ProcessListener sProcessCommunicationListener = null;
 
-	private static KNXNetworkLink link;
+	private static KNXNetworkLink sLink;
 	
 	/** signals that the connection is shut down on purpose */
-	public static boolean shutdown = false;
+	public static boolean sShutdown = false;
 
 	/** the ip address to use for connecting to the KNX bus */
-	private static String ip;
+	private static String sIp;
 	
 	/** the ip connection type for connecting to the KNX bus. Could be either TUNNEL or ROUTING */
-	private static int ipConnectionType;
+	private static int sIpConnectionType;
 	
 	/** the default multicast ip address (see <a href="http://www.iana.org/assignments/multicast-addresses/multicast-addresses.xml">iana</a> EIBnet/IP)*/
 	private static final String DEFAULT_MULTICAST_IP = "224.0.23.12";
 
 	/** KNXnet/IP port number */
-	private static int port;
+	private static int sPort;
 	
 	/** local endpoint to specify the multicast interface. no port is used */
-	private static String localIp;
+	private static String sLocalIp;
 	
 	/** the serial port to use for connecting to the KNX bus */
-	private static String serialPort;
+	private static String sSerialPort;
 
 	/** time in milliseconds of how long should be paused between two read requests to the bus during initialization. Default value is <code>50</Code> */
-	private static long readingPause = 50;
+	private static long sReadingPause = 50;
 	
 	/** timeout in milliseconds to wait for a response from the KNX bus. Default value is <code>10000</code> */
-	private static long responseTimeout = 10000;
+	private static long sResponseTimeout = 10000;
 	
 	/** limits the read retries while initialization from the KNX bus. Default value is <code>3</code> */
-	private static int readRetriesLimit = 3;
+	private static int sReadRetriesLimit = 3;
 
 	/** seconds between connect retries when KNX link has been lost, 0 means never retry. Default value is <code>0</code> */
-	private static int autoReconnectPeriod = 0;
+	private static int sAutoReconnectPeriod = 0;
 	
 	/** listeners for connection/re-connection events */
-	private static Set<KNXConnectionListener> connectionListeners = new HashSet<KNXConnectionListener>();
+	private static Set<KNXConnectionListener> sConnectionListeners = new HashSet<KNXConnectionListener>();
 	
 	/**
 	 * Returns the KNXNetworkLink for talking to the KNX bus.
@@ -100,74 +100,82 @@ public class KNXConnection implements ManagedService {
 	 * @return the KNX network link
 	 */
 	public static synchronized ProcessCommunicator getCommunicator() {
-		if(link!=null && !link.isOpen()) connect();
-		return pc;
+		if(sLink!=null && !sLink.isOpen()) {
+			connect();
+		}
+		return sPC;
 	}
 
 	public void setProcessListener(ProcessListener listener) {
-		if (pc != null) {
-			pc.removeProcessListener(KNXConnection.listener);
-			pc.addProcessListener(listener);
+		if (sPC != null) {
+			sPC.removeProcessListener(KNXConnection.sProcessCommunicationListener);
+			sPC.addProcessListener(listener);
 		}
-		KNXConnection.listener = listener;
+		KNXConnection.sProcessCommunicationListener = listener;
 	}
 	
 	public void unsetProcessListener(ProcessListener listener) {
-		if (pc != null) {
-			pc.removeProcessListener(KNXConnection.listener);
+		if (sPC != null) {
+			sPC.removeProcessListener(KNXConnection.sProcessCommunicationListener);
 		}
-		KNXConnection.listener = null;
+		KNXConnection.sProcessCommunicationListener = null;
 	}
 	
 	public static void addConnectionEstablishedListener(KNXConnectionListener listener) {
-		KNXConnection.connectionListeners.add(listener);
+		KNXConnection.sConnectionListeners.add(listener);
 	}
 
 	public static void removeConnectionEstablishedListener(KNXConnectionListener listener) {
-		KNXConnection.connectionListeners.remove(listener);
+		KNXConnection.sConnectionListeners.remove(listener);
 	}
 
-	public static synchronized void connect() {
-		shutdown = false;
+	/**
+	 * Tries to connect either by IP or serial bus, depending on supplied config data.
+	 * @return true if connection was established, false otherwise
+	 */
+	public static synchronized boolean connect() {
+		boolean successRetVal=false;
+		
+		sShutdown = false;
 		try {
-			if (StringUtils.isNotBlank(ip)) { 
-				link = connectByIp(ipConnectionType, localIp, ip, port);
-			} else if (StringUtils.isNotBlank(serialPort)) { 
-				link = connectBySerial(serialPort);
+			if (StringUtils.isNotBlank(sIp)) { 
+				sLink = connectByIp(sIpConnectionType, sLocalIp, sIp, sPort);
+			} else if (StringUtils.isNotBlank(sSerialPort)) { 
+				sLink = connectBySerial(sSerialPort);
 			} else {
-				logger.error("No IP address or serial port could be found in configuration!");
-				return;
+				sLogger.error("No IP address or serial port could be found in configuration!");
+				return false;
 			}
 
 
 			NetworkLinkListener linkListener = new NetworkLinkListener() {
 				public void linkClosed(CloseEvent e) {
 					// if the link is lost, we want to reconnect immediately
-					if(!(CloseEvent.USER_REQUEST == e.getInitiator()) && !shutdown) {
-						logger.warn("KNX link has been lost (reason: {} on object {}) - reconnecting...", e.getReason(), e.getSource().toString());
+					if(!(CloseEvent.USER_REQUEST == e.getInitiator()) && !sShutdown) {
+						sLogger.warn("KNX link has been lost (reason: {} on object {}) - reconnecting...", e.getReason(), e.getSource().toString());
 						connect();
 					}
-					if(!link.isOpen() && !shutdown) {
-						logger.error("KNX link has been lost!");
-						if(autoReconnectPeriod>0) {
-							logger.info("KNX link will be retried in " + autoReconnectPeriod + " seconds");
+					if(!sLink.isOpen() && !sShutdown) {
+						sLogger.error("KNX link has been lost!");
+						if(sAutoReconnectPeriod>0) {
+							sLogger.info("KNX link will be retried in " + sAutoReconnectPeriod + " seconds");
 							final Timer timer = new Timer();
 							TimerTask timerTask = new TimerTask() {
 								@Override
 								public void run() {
-									if(shutdown) {
+									if(sShutdown) {
 										timer.cancel();
 									}
 									else {
-										logger.info("Trying to reconnect to KNX...");
+										sLogger.info("Trying to reconnect to KNX...");
 										connect();
-										if(link.isOpen()) {
+										if(sLink.isOpen()) {
 											timer.cancel();
 										}
 									}
 								}
 							};
-							timer.schedule(timerTask, autoReconnectPeriod * 1000, autoReconnectPeriod * 1000);
+							timer.schedule(timerTask, sAutoReconnectPeriod * 1000, sAutoReconnectPeriod * 1000);
 						}
 					}
 				}
@@ -177,53 +185,56 @@ public class KNXConnection implements ManagedService {
 				public void confirmation(FrameEvent e) {}
 			};
 			
-			link.addLinkListener(linkListener);
+			sLink.addLinkListener(linkListener);
 			
-			if(pc!=null) {
-				pc.removeProcessListener(listener);
-				pc.detach();
+			if(sPC!=null) {
+				sPC.removeProcessListener(sProcessCommunicationListener);
+				sPC.detach();
 			}
 			
-			pc = new ProcessCommunicatorImpl(link);
-			pc.setResponseTimeout((int) responseTimeout/1000);
+			sPC = new ProcessCommunicatorImpl(sLink);
+			sPC.setResponseTimeout((int) sResponseTimeout/1000);
 			
-			if(listener!=null) {
-				pc.addProcessListener(listener);
+			if(sProcessCommunicationListener!=null) {
+				sPC.addProcessListener(sProcessCommunicationListener);
 			}
 
-			for(KNXConnectionListener listener : KNXConnection.connectionListeners) {
+			for(KNXConnectionListener listener : KNXConnection.sConnectionListeners) {
 				listener.connectionEstablished();
 			}
-			
-			if (logger.isInfoEnabled()) {
-				if (link instanceof KNXNetworkLinkIP) {
+
+			successRetVal=true;
+
+			if (sLogger.isInfoEnabled()) {
+				if (sLink instanceof KNXNetworkLinkIP) {
 					String ipConnectionTypeString = 
-						KNXConnection.ipConnectionType == KNXNetworkLinkIP.ROUTING ? "ROUTER" : "TUNNEL";
-					logger.info("Established connection to KNX bus on {} in mode {}.", ip + ":" + port, ipConnectionTypeString);
+						KNXConnection.sIpConnectionType == KNXNetworkLinkIP.ROUTING ? "ROUTER" : "TUNNEL";
+					sLogger.info("Established connection to KNX bus on {} in mode {}.", sIp + ":" + sPort, ipConnectionTypeString);
 				} else {
-					logger.info("Established connection to KNX bus through FT1.2 on serial port {}.", serialPort);
+					sLogger.info("Established connection to KNX bus through FT1.2 on serial port {}.", sSerialPort);
 				}
 			}
 			
 		} catch (KNXException e) {
-			logger.error("Error connecting to KNX bus: {}", e.getMessage());
+			sLogger.error("Error connecting to KNX bus: {}", e.getMessage());
 		} catch (UnknownHostException e) {
-			logger.error("Error connecting to KNX bus: {}", e.getMessage());
+			sLogger.error("Error connecting to KNX bus (unknown host): {}", e.getMessage());
 		} catch (InterruptedException e) {
-			logger.error("Error connecting to KNX bus: {}", e.getMessage());
+			sLogger.error("Error connecting to KNX bus (interrupted): {}", e.getMessage());
 		}
+		return successRetVal;
 	}
 	
 	public static synchronized void disconnect() {
-		shutdown = true;
-		if (pc!=null) {
-			KNXNetworkLink link = pc.detach();
-			if(listener!=null) {
-				pc.removeProcessListener(listener);
-				listener = null;
+		sShutdown = true;
+		if (sPC!=null) {
+			KNXNetworkLink link = sPC.detach();
+			if(sProcessCommunicationListener!=null) {
+				sPC.removeProcessListener(sProcessCommunicationListener);
+				sProcessCommunicationListener = null;
 			}
 			if (link!=null) {
-				logger.info("Closing KNX connection");
+				sLogger.info("Closing KNX connection");
 				link.close();
 			}
 		}
@@ -239,7 +250,7 @@ public class KNXConnection implements ManagedService {
 				InetAddress localHost = InetAddress.getLocalHost();
 				localEndPoint = new InetSocketAddress(localHost, 0);
 			} catch (UnknownHostException uhe) {
-				logger.warn("Couldn't find an IP address for this host. Please check the .hosts configuration or use the 'localIp' parameter to configure a valid IP address.");
+				sLogger.warn("Couldn't find an IP address for this host. Please check the .hosts configuration or use the 'localIp' parameter to configure a valid IP address.");
 			}
 		}
 		
@@ -270,50 +281,54 @@ public class KNXConnection implements ManagedService {
 		}
 	}
 	
-	@SuppressWarnings("rawtypes")
-	public void updated(Dictionary config) throws ConfigurationException {
+	/* (non-Javadoc)
+	 * @see org.osgi.service.cm.ManagedService#updated(java.util.Dictionary)
+	 */
+	@Override
+	public void updated(Dictionary<String, ?> config) throws ConfigurationException {
 		if (config != null) {
-			ip = (String) config.get("ip");
+			sLogger.debug("KNXBinding configuration present. Setting up KNX bus connection.");
+			sIp = (String) config.get("ip");
 
 			String connectionTypeString = (String) config.get("type");
 			if (StringUtils.isNotBlank(connectionTypeString)) {
 				if ("TUNNEL".equals(connectionTypeString)) {
-					ipConnectionType = KNXNetworkLinkIP.TUNNELING;
+					sIpConnectionType = KNXNetworkLinkIP.TUNNELING;
 				}
 				else if ("ROUTER".equals(connectionTypeString)) {
-					ipConnectionType = KNXNetworkLinkIP.ROUTING;
-					if (StringUtils.isBlank(ip)) {
-						ip = DEFAULT_MULTICAST_IP;
+					sIpConnectionType = KNXNetworkLinkIP.ROUTING;
+					if (StringUtils.isBlank(sIp)) {
+						sIp = DEFAULT_MULTICAST_IP;
 					}
 				}
 				else {
 					throw new ConfigurationException("type", "unknown IP connection type '" + connectionTypeString + "'! Known types are either 'TUNNEL' or 'ROUTER'");
 				}
 			} else {
-				ipConnectionType = KNXNetworkLinkIP.TUNNELING;
+				sIpConnectionType = KNXNetworkLinkIP.TUNNELING;
 			}
 
 			String portConfig = (String) config.get("port");
 			if (StringUtils.isNotBlank(portConfig)) {
-				port = Integer.parseInt(portConfig);
+				sPort = Integer.parseInt(portConfig);
 			} else {
-				port = KNXnetIPConnection.DEFAULT_PORT;
+				sPort = KNXnetIPConnection.DEFAULT_PORT;
 			}
 
-			localIp = (String) config.get("localIp");
+			sLocalIp = (String) config.get("localIp");
 
-			serialPort = (String) config.get("serialPort");
+			sSerialPort = (String) config.get("serialPort");
 
 			String readingPauseString = (String) config.get("pause");
 			if (StringUtils.isNotBlank(readingPauseString)) {
-				readingPause = Long.parseLong(readingPauseString);
+				sReadingPause = Long.parseLong(readingPauseString);
 			}
 			
 			String responseTimeoutString = (String) config.get("timeout");
 			if (StringUtils.isNotBlank(responseTimeoutString)) {
 				long timeout = Long.parseLong(responseTimeoutString);
 				if (timeout > 0) {
-					responseTimeout = timeout;
+					sResponseTimeout = timeout;
 				}
 			}
 			
@@ -321,7 +336,7 @@ public class KNXConnection implements ManagedService {
 			if (StringUtils.isNotBlank(readRetriesLimitString)) {
 				int readRetries = Integer.parseInt(readRetriesLimitString);
 				if (readRetries > 0) {
-					readRetriesLimit = readRetries;
+					sReadRetriesLimit = readRetries;
 				}
 			}
 			
@@ -329,25 +344,56 @@ public class KNXConnection implements ManagedService {
 			if (StringUtils.isNotBlank(autoReconnectPeriodString)) {
 				int autoReconnectPeriodValue = Integer.parseInt(autoReconnectPeriodString);
 				if (autoReconnectPeriodValue >= 0) {
-					autoReconnectPeriod = autoReconnectPeriodValue;
+					sAutoReconnectPeriod = autoReconnectPeriodValue;
 				}
 			}
 
 			
-			if(pc==null) connect();
+			if(sPC==null) {
+				if (!connect()) {
+					sLogger.warn("Inital connection to KNX bus failed!");
+					if(sAutoReconnectPeriod>0) {
+						sLogger.info("KNX link will be retried in {} seconds", sAutoReconnectPeriod);
+						final Timer timer = new Timer();
+						TimerTask timerTask = new TimerTask() {
+							@Override
+							public void run() {
+								if(sShutdown) {
+									timer.cancel();
+								}
+								else {
+									sLogger.info("Trying to reconnect to KNX...");
+									connect();
+									if( sLink!=null && sLink.isOpen()) {
+										sLogger.info("Connected to KNX");
+										timer.cancel();
+									}
+									else {
+										sLogger.info("KNX link will be retried in {} seconds", sAutoReconnectPeriod);
+									}
+								}
+							}
+						};
+						timer.schedule(timerTask, sAutoReconnectPeriod * 1000, sAutoReconnectPeriod * 1000);
+					}
+				}
+			}
+		}
+		else {
+			sLogger.info("KNXBinding configuration is not present. Please check your configuration file or if not needed remove the KNX addon.");
 		}
 	}
 
 	public static long getReadingPause() {
-		return readingPause;
+		return sReadingPause;
 	}
 	
 	public static int getReadRetriesLimit() {
-		return readRetriesLimit;
+		return sReadRetriesLimit;
 	}
 	
 	public static int getAutoReconnectPeriod() {
-		return autoReconnectPeriod;
+		return sAutoReconnectPeriod;
 	}
 	
 	


### PR DESCRIPTION
Added a timer thread, which will try to reconnect to the KNX bus in case
of initial connection failure.
Modified management of DP initialization, such that DPs are not removed
from the queue when connection is not established.
Added debug and trace messages.
