### PR TITLE
ZWave: Allow load of Node Neighbors XML data

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -590,7 +590,14 @@ public class ZWaveNode {
 	public void clearNeighbors() {
 		nodeNeighbors.clear();
 	}
-
+	/**
+	 * Set the node neighbour list
+	 * @param neighbours
+	 */
+	public void setNeighbors(List<Integer> neighbors) {
+		this.nodeNeighbors = neighbors;
+	}	
+	
 	/**
 	 * Updates a nodes routing information
 	 * Generation of routes uses associations

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
@@ -343,6 +343,8 @@ public class ZWaveNodeStageAdvancer {
 		this.node.setDeviceId(restoredNode.getDeviceId());
 		this.node.setDeviceType(restoredNode.getDeviceType());
 		this.node.setManufacturer(restoredNode.getManufacturer());
+		
+		this.node.setNeighbors(restoredNode.getNeighbors());
 
 		for (ZWaveCommandClass commandClass : restoredNode.getCommandClasses()) {
 			commandClass.setController(this.controller);


### PR DESCRIPTION
Loads the node Neighbor list from the node stored XML config when
starting up the binding
