### PR TITLE
Update association to use 'get all' function rather than cycling through the database.

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
@@ -937,10 +937,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 
 					if (splitDomain.length == 3) {
 						// Request all groups for this node
-						List<ZWaveDbAssociationGroup> groupList = database.getProductAssociationGroups();
-
-						for (ZWaveDbAssociationGroup group : groupList)
-							this.zController.sendData(associationCommandClass.getAssociationMessage(group.Index));
+						associationCommandClass.getAllAssociations();
 					} else if (splitDomain.length == 4) {
 						// Request a single group
 						int nodeArg = Integer.parseInt(splitDomain[3].substring(11));


### PR DESCRIPTION
This is less reliant on the database since it asks the node how many groups it supports!
