### PR TITLE
Update Fibaro devices with value 255 used in a list.

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgbs001.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgbs001.xml
@@ -116,7 +116,7 @@
 				<Label lang="en">ALARM WATER</Label>
 			</Item>
 			<Item>
-				<Value>255</Value>
+				<Value>-1</Value>
 				<Label lang="en">BASIC_SET</Label>
 			</Item>
 			<Help lang="en">Type of transmitted control frame for association group 1, activated via input IN1. The parameter allows to specify the type of alarm frame or to force transmission of control commands (BASIC_SET)</Help>
@@ -152,7 +152,7 @@
 				<Label lang="en">ALARM WATER</Label>
 			</Item>
 			<Item>
-				<Value>255</Value>
+				<Value>-1</Value>
 				<Label lang="en">BASIC_SET</Label>
 			</Item>
 			<Help lang="en">Type of transmitted control frame for association group 2, activated via input IN2. The parameter allows to specify the type of alarm frame or to force transmission of control commands (BASIC_SET)</Help>

--- a/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgd211.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgd211.xml
@@ -33,7 +33,7 @@
 				<Label lang="en">ALL ON active / ALL OFF disabled</Label>
 			</Item>
 			<Item>
-				<Value>255</Value>
+				<Value>-1</Value>
 				<Label lang="en">ALL ON active / ALL OFF active</Label>
 			</Item>
 			<Help lang="en">Activate/Deactive ALL ON/OFF</Help>

--- a/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgk101.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgk101.xml
@@ -76,7 +76,7 @@
 		<Parameter>
 			<Index>5</Index>
 			<Type>list</Type>
-			<Default>255</Default>
+			<Default>-1</Default>
 			<Size>1</Size>
 			<Label lang="en">Type of transmitted control frame for association
 				group 1
@@ -106,7 +106,7 @@
 				<Label lang="en">ALARM WATER</Label>
 			</Item>
 			<Item>
-				<Value>255</Value>
+				<Value>-1</Value>
 				<Label lang="en">BASIC_SET</Label>
 			</Item>
 			<Help lang="en">Type of transmitted control frame for association

--- a/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgr221.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgr221.xml
@@ -57,7 +57,7 @@
         <Label lang="en">ALL ON active / ALL OFF disabled</Label>
       </Item>
       <Item>
-        <Value>255</Value>
+        <Value>-1</Value>
         <Label lang="en">ALL ON active / ALL OFF active</Label>
       </Item>
       <Help lang="en">Activate/Deactive ALL ON/OFF</Help>

--- a/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgrgbw.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgrgbw.xml
@@ -36,7 +36,7 @@
 				<Label lang="en">ALL ON active ALL OFF inactive</Label>
 			</Item>
 			<Item>
-				<Value>255</Value>
+				<Value>-1</Value>
 				<Label lang="en">ALL ON active ALL OFF active</Label>
 			</Item>
 			<Help lang="en"><![CDATA[Activation/deactivation of ALL ON/ALL OFF functions. By default, ALL ON active ALL OFF active.<BR/>

--- a/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgs211.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgs211.xml
@@ -37,7 +37,7 @@
 				<Label lang="en">ALL ON active / ALL OFF disabled</Label>
 			</Item>
 			<Item>
-				<Value>255</Value>
+				<Value>-1</Value>
 				<Label lang="en">ALL ON active / ALL OFF active</Label>
 			</Item>
 			<Help lang="en">Activate/Deactive ALL ON/OFF</Help>

--- a/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgs221.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgs221.xml
@@ -37,7 +37,7 @@
 				<Label lang="en">ALL ON active / ALL OFF disabled</Label>
 			</Item>
 			<Item>
-				<Value>255</Value>
+				<Value>-1</Value>
 				<Label lang="en">ALL ON active / ALL OFF active</Label>
 			</Item>
 			<Help lang="en">Activate/Deactive ALL ON/OFF</Help>


### PR DESCRIPTION
ZWave defines configuration values as signed numbers, however Fibaro lists some numbers as signed. This can be resolved for values that are typed in, however for values in lists, this needs to be treated as signed, otherwise the system will ignore these values.
