### PR TITLE
Update Z-wave products.xml for additional Everspring HSM02 id values

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -246,12 +246,6 @@
 				<Type>0002</Type>
 				<Id>0001</Id>
 			</Reference>
-			<Model>HSM02</Model>
-			<Label lang="en">Door/Window Contact</Label>
-			<Label lang="de">Tür/Fenster Kontakt</Label>
-			<ConfigFile>everspring/hsm02.xml</ConfigFile>
-		</Product>
-		<Product>
 			<Reference>
 				<Type>0002</Type>
 				<Id>0002</Id>


### PR DESCRIPTION
My Everspring HSM02 gives a product ID of 0002.  There already exists an entry for this devices in the Z-Wave database but for product ID 0001.  Mine appears to be identical to the existing everspring/hsm02.xml, so I've just modified products.xml to use the existing hsm02.xml for product ID 0002.

Perhaps a different ID value for the north american frequency? 
