### PR TITLE
Add missing Insteon device catagories

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/categories.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/categories.xml
@@ -171,6 +171,15 @@ Example:
     	<feature name="lastheardfrom">GenericLastTime</feature>
     </productKey>
   </subcategory>
+  <subcategory>
+    <name>On/Off Dual-Band Outdoor Module</name>
+    <description>2634-222</description>
+    <subCat>0x38</subCat>
+    <productKey name="F00.00.0C">
+    	<feature name="switch">GenericSwitch</feature>
+    	<feature name="lastheardfrom">GenericLastTime</feature>
+    </productKey>
+  </subcategory>
 </category>
 <category>
   <name>Network Bridge</name>


### PR DESCRIPTION
The 2 devices added are devices I have in my home. I added these to get my home Insteon network fully working.
