### PR TITLE
RFXCOM Binding: LIGHTING protocols - Fix support for Contact Items

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting1Message.java
@@ -92,7 +92,8 @@ public class RFXComLighting1Message extends RFXComBaseMessage {
 	private final static List<RFXComValueSelector> supportedValueSelectors = Arrays
 			.asList(RFXComValueSelector.RAW_DATA,
 					RFXComValueSelector.SIGNAL_LEVEL,
-					RFXComValueSelector.COMMAND);
+					RFXComValueSelector.COMMAND,
+					RFXComValueSelector.CONTACT);
 
 	public SubType subType = SubType.X10;
 	public char sensorId = 'A';
@@ -225,23 +226,23 @@ public class RFXComLighting1Message extends RFXComBaseMessage {
 
 		} else if (valueSelector.getItemClass() == ContactItem.class) {
 
-			if (valueSelector == RFXComValueSelector.COMMAND) {
+			if (valueSelector == RFXComValueSelector.CONTACT) {
 
 				switch (command) {
 				case OFF:
 				case GROUP_OFF:
 				case DIM:
-					state = OpenClosedType.OPEN;
+					state = OpenClosedType.CLOSED;
 					break;
 
 				case ON:
 				case GROUP_ON:
 				case BRIGHT:
-					state = OpenClosedType.CLOSED;
+					state = OpenClosedType.OPEN;
 					break;
 
 				case CHIME:
-					state = OpenClosedType.CLOSED;
+					state = OpenClosedType.OPEN;
 					break;
 					
 				default:

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting2Message.java
@@ -91,7 +91,8 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
 			.asList(RFXComValueSelector.RAW_DATA,
 					RFXComValueSelector.SIGNAL_LEVEL,
 					RFXComValueSelector.COMMAND,
-					RFXComValueSelector.DIMMING_LEVEL);
+					RFXComValueSelector.DIMMING_LEVEL,
+					RFXComValueSelector.CONTACT);
 
 	public SubType subType = SubType.AC;
 	public int sensorId = 0;
@@ -269,17 +270,17 @@ public class RFXComLighting2Message extends RFXComBaseMessage {
 
 		} else if (valueSelector.getItemClass() == ContactItem.class) {
 
-			if (valueSelector == RFXComValueSelector.COMMAND) {
+			if (valueSelector == RFXComValueSelector.CONTACT) {
 
 				switch (command) {
 				case OFF:
 				case GROUP_OFF:
-					state = OpenClosedType.OPEN;
+					state = OpenClosedType.CLOSED;
 					break;
 
 				case ON:
 				case GROUP_ON:
-					state = OpenClosedType.CLOSED;
+					state = OpenClosedType.OPEN;
 					break;
 
 				case SET_GROUP_LEVEL:

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting5Message.java
@@ -106,7 +106,8 @@ public class RFXComLighting5Message extends RFXComBaseMessage {
 					RFXComValueSelector.SIGNAL_LEVEL,
 					RFXComValueSelector.COMMAND,
 					RFXComValueSelector.MOOD,
-					RFXComValueSelector.DIMMING_LEVEL);
+					RFXComValueSelector.DIMMING_LEVEL,
+					RFXComValueSelector.CONTACT);
 
 	public SubType subType = SubType.LIGHTWAVERF;
 	public int sensorId = 0;
@@ -300,16 +301,16 @@ public class RFXComLighting5Message extends RFXComBaseMessage {
 
 		} else if (valueSelector.getItemClass() == ContactItem.class) {
 
-			if (valueSelector == RFXComValueSelector.COMMAND) {
+			if (valueSelector == RFXComValueSelector.CONTACT) {
 
 				switch (command) {
 				case OFF:
 				case GROUP_OFF:
-					state = OpenClosedType.OPEN;
+					state = OpenClosedType.CLOSED;
 					break;
 
 				case ON:				
-					state = OpenClosedType.CLOSED;
+					state = OpenClosedType.OPEN;
 					break;
 				
 				case SET_LEVEL:

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting6Message.java
@@ -81,7 +81,8 @@ public class RFXComLighting6Message extends RFXComBaseMessage {
 	private final static List<RFXComValueSelector> supportedValueSelectors = Arrays
 			.asList(RFXComValueSelector.RAW_DATA,
 					RFXComValueSelector.SIGNAL_LEVEL,
-					RFXComValueSelector.COMMAND);
+					RFXComValueSelector.COMMAND,
+					RFXComValueSelector.CONTACT);
 
 	public SubType subType = SubType.BLYSS;
 	public int sensorId = 0;
@@ -210,17 +211,17 @@ public class RFXComLighting6Message extends RFXComBaseMessage {
 
 		} else if (valueSelector.getItemClass() == ContactItem.class) {
 
-			if (valueSelector == RFXComValueSelector.COMMAND) {
+			if (valueSelector == RFXComValueSelector.CONTACT) {
 
 				switch (command) {
 				case OFF:
 				case GROUP_OFF:
-					state = OpenClosedType.OPEN;
+					state = OpenClosedType.CLOSED;
 					break;
 
 				case ON:
 				case GROUP_ON:
-					state = OpenClosedType.CLOSED;
+					state = OpenClosedType.OPEN;
 					break;
 					
 				default:


### PR DESCRIPTION
This commit adds support for Contact Items to the RFXCom Lighting protocols.

While there is existing code to support Contact Items for eaching of the Lighting1, 2, 5 & 6 rfxcom protocols it appears to be unreachable.  The existing Code required the openhab Item to be a "Contact" Item; and for the rfxcom ValueSelector to be "Command".  However, the code RFXComValueSelector only permits an openhab "Switch" to be used with the rfxcom "Command" value selector.

I have resolved this by adding support for the existing "Contact" valueselector.  This means a contact item can be used as in the following example:

```
Contact Sensor_Hall_FrontDoor (Room_Hall) { rfxcom="<93056.10:Contact" }
```

I have also inverted the ON/OFF -> OPEN/CLOSED mapping as in my hardware ON is sent when the contact is OPEN (which is logical as the intended use-case for these is to turn on a light when you open a door).  I figured this wouldn't break backwards compatibility for anyone as the existing code was unreachable.
