### PR TITLE
Fixed error message on parsing a step size

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConfig.java
@@ -136,7 +136,7 @@ public class HueBindingConfig implements BindingConfig {
 			return Integer.parseInt(configString);
 		} catch (Exception e) {
 			throw new BindingConfigParseException(
-					"Error parsing device number.");
+					"Error parsing step size.");
 		}
 	}
 


### PR DESCRIPTION
Hi, this is just a kind of typo fix. The message that came when the step size could not be parsed was wrong.
The message was error parsing device number. And btw. thanks for your work.
Matthias
