### PR TITLE
Fix openhab_default.cfg MySQL JDBC template text

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -293,7 +293,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 #db4o:maxbackups=
 
 ############################ SQL Persistence Service ##################################
-# the database url like 'jdbc:mysql://<host>:<port>/<user>'
+# the database url like 'jdbc:mysql://<host>:<port>/<database>'
 #mysql:url=
 
 # the database user


### PR DESCRIPTION
As reported on the openhab google group, this is just a small change to the openhab_default.cfg to correct the template given for people to create their JDBC connection strings.  Currently its telling people to put a username where it should be the database name.
