### PR TITLE
Added support for relative urls for Webview widgets in sitemaps.

### DIFF
--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/resources/SitemapResource.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/resources/SitemapResource.java
@@ -8,7 +8,9 @@
  */
 package org.openhab.io.rest.internal.resources;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.concurrent.TimeUnit;
@@ -368,43 +370,51 @@ public class SitemapResource {
     		List listWidget = (List) widget;
     		bean.separator = listWidget.getSeparator();
     	}
-    	if(widget instanceof Image) {
-    		Image imageWidget = (Image) widget;
-    		String wId = itemUIRegistry.getWidgetId(widget);
-			if (uri.getPort() < 0 || uri.getPort() == 80) {
-				bean.url = uri.getScheme() + "://" + uri.getHost() + "/proxy?sitemap=" + sitemapName + ".sitemap&widgetId=" + wId;
-			} else {
-				bean.url = uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort() + "/proxy?sitemap=" + sitemapName + ".sitemap&widgetId=" + wId;
+    	if (widget instanceof Image ||
+    		widget instanceof Video ||
+    		widget instanceof Webview) {
+
+        	if(widget instanceof Image) {
+        		Image imageWidget = (Image) widget;
+        		if(imageWidget.getRefresh() > 0) {
+        			bean.refresh = imageWidget.getRefresh(); 
+        		}
+        		bean.url = imageWidget.getUrl();
+        	}
+        	else if (widget instanceof Video) {
+        		Video videoWidget = (Video) widget;
+        		if(videoWidget.getEncoding() != null) {
+        			bean.encoding = videoWidget.getEncoding();
+        		}
+        		bean.url = videoWidget.getUrl();
+        	}
+        	else {
+				Webview webViewWidget = (Webview) widget;
+				bean.height = webViewWidget.getHeight();
+				bean.url = webViewWidget.getUrl();
+        	}
+
+			String wId = itemUIRegistry.getWidgetId(widget);
+
+			StringBuilder sbBaseUrl = new StringBuilder();
+			sbBaseUrl.append(uri.getScheme()).append("://").append(uri.getHost());
+			if (uri.getPort() >= 0 && uri.getPort() != 80) {
+				sbBaseUrl.append(":").append(uri.getPort());
 			}
-    		if(imageWidget.getRefresh()>0) {
-    			bean.refresh = imageWidget.getRefresh(); 
-    		}
-    	}
-    	if(widget instanceof Video) {
-    		Video videoWidget = (Video) widget;
-    		String wId = itemUIRegistry.getWidgetId(widget);
-    		if(videoWidget.getEncoding()!=null) {
-    			bean.encoding = videoWidget.getEncoding();
-    		}
-			if (uri.getPort() < 0 || uri.getPort() == 80) {
-				bean.url = uri.getScheme() + "://" + uri.getHost() + "/proxy?sitemap=" + sitemapName + ".sitemap&widgetId=" + wId;
-			} else {
-				bean.url = uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort() + "/proxy?sitemap=" + sitemapName	+ ".sitemap&widgetId=" + wId;
+			StringBuilder sb = new StringBuilder();
+			sb.append("/proxy?");
+			sb.append("sitemap=").append(sitemapName).append(".sitemap&");
+			sb.append("widgetId=").append(wId);
+			if (bean.url != null && bean.url.startsWith("/")) {
+	        	try {
+	        		sb.append("&").append("baseUrl=").append(URLEncoder.encode(sbBaseUrl.toString(), "UTF-8"));
+	        	}
+				catch (UnsupportedEncodingException ex) {
+					throw new RuntimeException(ex.getMessage(), ex);
+				}
 			}
-    	}
-    	if(widget instanceof Webview) {
-    		Webview webViewWidget = (Webview) widget;
-    		if (webViewWidget.getUrl().startsWith("/")) {
-    			if (uri.getPort() < 0 || uri.getPort() == 80) {
-    				bean.url = uri.getScheme() + "://" + uri.getHost() + webViewWidget.getUrl();
-    			} else {
-    				bean.url = uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort() + webViewWidget.getUrl();
-    			}
-    		}
-    		else {
-    			bean.url = webViewWidget.getUrl();
-    		}
-    		bean.height = webViewWidget.getHeight();
+			sbBaseUrl.append(sb.toString());
+			bean.url = sbBaseUrl.toString();
     	}
     	if(widget instanceof Chart) {
     		Chart chartWidget = (Chart) widget;

--- a/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/proxy/ProxyServlet.java
+++ b/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/proxy/ProxyServlet.java
@@ -29,6 +29,7 @@ import org.openhab.model.core.ModelRepository;
 import org.openhab.model.sitemap.Image;
 import org.openhab.model.sitemap.Sitemap;
 import org.openhab.model.sitemap.Video;
+import org.openhab.model.sitemap.Webview;
 import org.openhab.model.sitemap.Widget;
 import org.openhab.ui.items.ItemUIRegistry;
 import org.osgi.service.http.HttpContext;
@@ -129,14 +130,17 @@ public class ProxyServlet extends HttpServlet {
 			HttpServletResponse response) throws ServletException, IOException {
 		String sitemapName = request.getParameter("sitemap");
 		String widgetId = request.getParameter("widgetId");
+		String baseUrl = request.getParameter("baseUrl");
 
-		if(sitemapName==null) {
+		if(sitemapName == null) {
 			throw new ServletException("Parameter 'sitemap' must be provided!");
 		}
-		if(widgetId==null) {
-			throw new ServletException("Parameter 'widget' must be provided!");
+		if(widgetId == null) {
+			throw new ServletException("Parameter 'widgetId' must be provided!");
 		}
-		
+		if(baseUrl == null) {
+			baseUrl = "";
+		}
 		String uriString = null;
 		
 		Sitemap sitemap = (Sitemap) modelRepository.getModel(sitemapName);
@@ -144,10 +148,13 @@ public class ProxyServlet extends HttpServlet {
 			Widget widget = itemUIRegistry.getWidget(sitemap, widgetId);
 			if(widget instanceof Image) {
 				Image image = (Image) widget;
-				uriString = image.getUrl();
+				uriString = baseUrl + image.getUrl();
 			} else if(widget instanceof Video) {
 				Video video = (Video) widget;
-				uriString = video.getUrl();
+				uriString = baseUrl + video.getUrl();
+			} else if(widget instanceof Webview) {
+				Webview webview = (Webview) widget;
+				uriString = baseUrl + webview.getUrl();
 			} else {
 				if(widget==null) {
 					throw new ServletException("Widget '" + widgetId + "' could not be found!");


### PR DESCRIPTION
Now it's possible to use relative urls to access resources in the webapps folder:
`Webview url="/weather"`

Required for the weather-binding (https://github.com/openhab/openhab/pull/1423) to show weather layout files and icons.
