### PR TITLE
Modbus binding: Add more serial configurable parameters: datasize, parity and stop bit.

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -280,8 +280,17 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 						}
 					} else if (modbusSlave instanceof ModbusSerialSlave) {
 						((ModbusSerialSlave) modbusSlave).setPort(chunks[0]);
-						if (chunks.length == 2) {
+						if (chunks.length >= 2) {
 							((ModbusSerialSlave) modbusSlave).setBaud(Integer.valueOf(chunks[1]));
+						}
+						if (chunks.length >= 3) {
+							((ModbusSerialSlave) modbusSlave).setDatabits(Integer.valueOf(chunks[2]));
+						}
+						if (chunks.length >= 4) {
+							((ModbusSerialSlave) modbusSlave).setParity(chunks[3]);
+						}
+						if (chunks.length == 5) {
+							((ModbusSerialSlave) modbusSlave).setStopbits(Integer.valueOf(chunks[4]));
 						}
 					}
 				} else if ("start".equals(configKey)) {

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSerialSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSerialSlave.java
@@ -35,6 +35,10 @@ public class ModbusSerialSlave extends ModbusSlave {
 
 	private static String port = null;
 	private static int baud = 9600;
+	private static int dataBits = 8;
+	private static String parity = "None"; // "none", "even" or "odd"
+	private static int stopBits = 1;
+	
 	public void setPort(String port) {
 		ModbusSerialSlave.port = port;
 	}
@@ -43,6 +47,18 @@ public class ModbusSerialSlave extends ModbusSlave {
 		ModbusSerialSlave.baud = baud;
 	}
 
+	public void setDatabits(int dataBits) {
+		ModbusSerialSlave.dataBits = dataBits;
+	}
+	
+	// Parity string should be "none", "even" or "odd"
+	public void setParity(String parity) {
+		ModbusSerialSlave.parity = parity;
+	}
+	
+	public void setStopbits(int stopBits) {
+		ModbusSerialSlave.stopBits = stopBits;
+	}
 	//	String port = null;
 
 	private static SerialConnection connection = null;
@@ -77,9 +93,9 @@ public class ModbusSerialSlave extends ModbusSlave {
 				SerialParameters params = new SerialParameters();
 				params.setPortName(port);
 				params.setBaudRate(baud);
-				params.setDatabits(8);
-				params.setParity("None");
-				params.setStopbits(1);
+				params.setDatabits(dataBits);
+				params.setParity(parity);
+				params.setStopbits(stopBits);
 				params.setEncoding(Modbus.SERIAL_ENCODING_RTU);
 				params.setEcho(false);
 				connection = new SerialConnection(params);


### PR DESCRIPTION
Hi,

I have added few more configurable parameters in openhab.cfg for modbus RTU binding.
Only port and baud was configurable in current version, and I have added data size (7 or 8), parity ("none", "odd" or "even") and stop bit (1 or 2).

So, in openhab.cfg, a config line can look like:
modbus:serial.slave1.connection=/dev/ttyUSB0:19200:8:even:1

Regards.
