### PR TITLE
Fix for issue #1267: Allow leading whitespaces in openhab.cfg

### DIFF
--- a/bundles/config/org.openhab.config.core/src/main/java/org/openhab/config/core/ConfigDispatcher.java
+++ b/bundles/config/org.openhab.config.core/src/main/java/org/openhab/config/core/ConfigDispatcher.java
@@ -219,20 +219,22 @@ public class ConfigDispatcher implements ManagedService {
 		if (trimmedLine.startsWith("#") || trimmedLine.isEmpty()) {
 			return null;
 		}
-		
-		if (trimmedLine.substring(1).contains(":")) { 
-			String pid = StringUtils.substringBefore(line, ":");
-			String rest = line.substring(pid.length() + 1);
-			if(!pid.contains(".")) {
+
+		if (trimmedLine.substring(1).contains(":")) {
+			String pid = StringUtils.substringBefore(trimmedLine, ":");
+			String rest = trimmedLine.substring(pid.length() + 1);
+			if (!pid.contains(".")) {
 				pid = "org.openhab." + pid;
 			}
-			if(!rest.isEmpty() && rest.substring(1).contains("=")) {
+			if (!rest.isEmpty() && rest.substring(1).contains("=")) {
 				String property = StringUtils.substringBefore(rest, "=");
 				String value = rest.substring(property.length() + 1);
-				return new String[] { pid.trim(), property.trim(), value.trim() };
+				String[] parsedLine = { pid.trim(), property.trim(), value.trim() };
+				logger.debug("Parsed configuration line {}:{}={}", (Object[]) parsedLine);
+				return parsedLine;
 			}
 		}
-		
+
 		logger.warn("Cannot parse line '{}' of main configuration file '{}'.", line, filePath);
 		return null;
 	}


### PR DESCRIPTION
This is the fix for issue #1267 which allows leading whitespaces in the openhab.cfg.
It also adds more debugging output for parsing of the config file.
