### PR TITLE
org.openhab.io.console: fix build error with recent eclipse

### DIFF
--- a/bundles/io/org.openhab.io.console/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.console/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Bundle-Description: This is the runtime component of the open Home Aut
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: com.google.common.base,
  org.apache.commons.lang,
+ org.eclipse.emf.ecore,
  org.eclipse.osgi.framework.console,
  org.openhab.core.events,
  org.openhab.core.items,


### PR DESCRIPTION
Building the project org.openhab.io.console with recent eclipse (Luna) will
fail.

The project was not built since its build path is incomplete.
Cannot find the class file for org.eclipse.emf.ecore.resource.Resource$Diagnostic.
Fix the build path then try building this project.

The type org.eclipse.emf.ecore.resource.Resource$Diagnostic cannot be resolved.
It is indirectly referenced from required .class files
ConsoleInterpreter.java
/org.openhab.io.console/src/main/java/org/openhab/io/console
line 1
