### PR TITLE
Treat a SendDataMessage ACK as a received message.

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SendDataMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SendDataMessageClass.java
@@ -67,6 +67,9 @@ public class SendDataMessageClass extends ZWaveCommandProcessor {
 			ZWaveNode node = zController.getNode(originalMessage.getMessageNode());
 			if(node == null)
 				break;
+			
+			// Consider this as a received frame since the controller did receive an ACK from the device.
+			node.incrementReceiveCount();
 
 			// If the node is DEAD, but we've just received a message from it, then it's not dead!
 			if(node.isDead()) {


### PR DESCRIPTION
This ensures the last received time is really the last time we actually heard this device since all the network polls are simply pings, and there is no response other than the ACK.
