### PR TITLE
bump java environment to fix annotation compliance

### DIFF
--- a/bundles/binding/org.openhab.binding.sonos/.classpath
+++ b/bundles/binding/org.openhab.binding.sonos/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="lib/cling-core-1.0.5.jar" sourcepath="/Users/kgoderis/Documents/Eclipse/karelgoderis-irtrans3/bundles/binding/org.openhab.binding.sonos/lib/cling-core-1.0.5-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/teleal-common-1.0.13.jar"/>

--- a/bundles/binding/org.openhab.binding.sonos/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/binding/org.openhab.binding.sonos/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.compliance=1.6
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/bundles/binding/org.openhab.binding.sonos/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.sonos/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.openhab.binding.sonos
 Bundle-Version: 1.6.0.qualifier
 Bundle-Activator: org.openhab.binding.sonos.internal.SonosActivator
 Bundle-Vendor: openhab.org
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: J2SE-1.6
 Import-Package: org.apache.commons.lang;version="2.4.0",
  org.joda.time,
  org.joda.time.base,


### PR DESCRIPTION
the class StreamClientImpl (package: org.openhab.binding.sonos.internal) implements the following interface: StreamClient<StreamClientConfigurationImpl>

It adds implementation for the following functions:
public StreamClientConfigurationImpl getConfiguration();
public StreamResponseMessage sendRequest(StreamRequestMessage requestMessage);
public void stop();

The override annotation does not work for interfaces (see below).

IMHO: org.openhab.core already uses 1.6, so it should not break something to use that for a binding, too.

cite:

Well, there is a @Override annotation on one of the methods, but it
doesn’t have a superclass – it is annotating a method that is being
implemented (from an interface), not a method that is inherited (from a
superclass).

The @Override annotation is a Java 1.5 feature, and the error message I
was getting was coming (correctly) from a 1.5 compiler. However in Java
1.6 the @Override annotation can also be applied to methods that are
implemented from an interface.

Quote:
http://www.filsa.net/2008/02/11/maven-and-the-method-does-not-override-a-method-from-its-superclass-error/
