### PR TITLE
Add check the command class isn't null

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -535,7 +535,7 @@ public class ZWaveNode {
 		}
 		else if (multiInstanceCommandClass.getVersion() == 1) {
 			ZWaveCommandClass result = getCommandClass(commandClass);
-			if (endpointId <= result.getInstances()) {
+			if (result != null && endpointId <= result.getInstances()) {
 				return result;
 			}
 		} else {


### PR DESCRIPTION
This prevents an NPE during creation of the polling table.
