### PR TITLE
Added X10 support to the InsteonPLM binding

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMActiveBinding.java
@@ -30,6 +30,7 @@ import org.openhab.binding.insteonplm.internal.driver.Driver;
 import org.openhab.binding.insteonplm.internal.driver.DriverListener;
 import org.openhab.binding.insteonplm.internal.driver.ModemDBEntry;
 import org.openhab.binding.insteonplm.internal.driver.Poller;
+import org.openhab.binding.insteonplm.internal.message.FieldException;
 import org.openhab.binding.insteonplm.internal.message.Msg;
 import org.openhab.binding.insteonplm.internal.message.MsgListener;
 import org.openhab.core.binding.AbstractActiveBinding;
@@ -98,6 +99,7 @@ public class InsteonPLMActiveBinding
 	private int						m_messagesReceived		= 0;
 	private boolean					m_isActive		  		= false; // state of binding
 	private boolean					m_hasInitialItemConfig	= false;
+	private int						m_x10HouseUnit			= -1;
 
 	/**
 	 * Constructor
@@ -465,7 +467,7 @@ public class InsteonPLMActiveBinding
 				dev.setHasModemDBEntry(true);
 			}
 		} else {
-			if (m_driver.isModemDBComplete()) {
+			if (m_driver.isModemDBComplete() && !addr.isX10()) {
 				logger.warn("device {} not found in the modem database. Did you forget to link?", addr);
 			}
 		}
@@ -507,25 +509,12 @@ public class InsteonPLMActiveBinding
 			if (msg.isEcho() || msg.isPureNack()) return;
 			m_messagesReceived++;
 			logger.debug("got msg: {}", msg);
-			InsteonAddress toAddr = msg.getAddr("toAddress");
-			if (!msg.isBroadcast() && !m_driver.isMsgForUs(toAddr)) {
-				// not for one of our modems, do not process
-				return;
+			if (msg.isX10()) {
+				handleX10Message(msg, fromPort);
+			} else {
+				handleInsteonMessage(msg, fromPort);
 			}
-
-			InsteonAddress fromAddr = msg.getAddr("fromAddress");
-			if (fromAddr == null) {
-				logger.debug("invalid fromAddress, ignoring msg {}", msg);
-				return;
-			}
-			synchronized (m_devices) {
-				InsteonDevice  dev = getDevice(fromAddr);
-				if (dev == null) {
-					logger.debug("dropping message from unknown device with address {}", fromAddr);
-				} else {
-					dev.handleMessage(fromPort, msg);
-				}
-			}
+			
 		}
 		/**
 		 * {@inheritDoc}
@@ -544,7 +533,8 @@ public class InsteonPLMActiveBinding
 				for (InsteonDevice dev : m_devices.values()) {
 					InsteonAddress a = dev.getAddress();
 					if (!dbes.containsKey(a)) {
-						logger.warn("device {} not found in the modem database. Did you forget to link?", a);
+						if (!a.isX10())
+							logger.warn("device {} not found in the modem database. Did you forget to link?", a);
 					} else {
 						if (!dev.hasModemDBEntry()) {
 							logger.info("device {}     found in the modem database!", a);
@@ -557,6 +547,48 @@ public class InsteonPLMActiveBinding
 				}
 			}
 			m_driver.unlockModemDBEntries();
+		}
+		private void handleInsteonMessage(Msg msg, String fromPort) {
+			InsteonAddress toAddr = msg.getAddr("toAddress");
+			if (!msg.isBroadcast() && !m_driver.isMsgForUs(toAddr)) {
+				// not for one of our modems, do not process
+				return;
+			}
+			InsteonAddress fromAddr = msg.getAddr("fromAddress");
+			if (fromAddr == null) {
+				logger.debug("invalid fromAddress, ignoring msg {}", msg);
+				return;
+			}
+			handleMessage(fromPort, fromAddr, msg);
+		}
+
+		private void handleX10Message(Msg msg, String fromPort) {
+			try {
+				int x10Flag	= msg.getByte("X10Flag") & 0xff;
+				int rawX10	= msg.getByte("rawX10") & 0xff;
+				if (x10Flag == 0x80) { // actual command
+					if (m_x10HouseUnit != -1) {
+						InsteonAddress fromAddr = new InsteonAddress((byte)m_x10HouseUnit);
+						handleMessage(fromPort, fromAddr, msg);
+					}
+				} else if (x10Flag == 0) {
+					// what unit the next cmd will apply to
+					m_x10HouseUnit = rawX10 & 0xFF; 
+				}
+			} catch (FieldException e) {
+				logger.error("got bad X10 message: {}", msg, e);
+				return;
+			}
+		}
+		private void handleMessage(String fromPort, InsteonAddress fromAddr, Msg msg) {
+			synchronized (m_devices) {
+				InsteonDevice  dev = getDevice(fromAddr);
+				if (dev == null) {
+					logger.debug("dropping message from unknown device with address {}", fromAddr);
+				} else {
+					dev.handleMessage(fromPort, msg);
+				}
+			}
 		}
 	}
 	

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMGenericBindingProvider.java
@@ -72,10 +72,9 @@ public class InsteonPLMGenericBindingProvider extends AbstractGenericBindingProv
 				logger.error("parameter {} does not have format a=b", params[i]);
 			}
 		}
-
 		InsteonPLMBindingConfig config = new InsteonPLMBindingConfig(addr, feature, parts[1], args);
 		addBindingConfig(item, config);
-		
+
 		logger.trace("processing item \"{}\" read from .items file with cfg string {}",
 					item.getName(), bindingConfig);
 		items.put(item.getName(), item);
@@ -127,8 +126,10 @@ public class InsteonPLMGenericBindingProvider extends AbstractGenericBindingProv
 		String addr = dev[0];
 		String [] retval = {addr, dev[1], segments[1]};
 		if (!InsteonAddress.s_isValid(addr)) {
-			throw new BindingConfigParseException("invalid insteon device address: "
-					+ addr + " in items file. Must have format AB.CD.EF");
+			String errstr = "invalid insteon or X10 device address: " + addr +
+						" in items file. Must have format AB.CD.EF or (for X10): H.U";
+			logger.error(errstr);
+			throw new BindingConfigParseException(errstr);
 		}
 		return retval;
 	}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/FeatureTemplateLoader.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/FeatureTemplateLoader.java
@@ -21,6 +21,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.openhab.binding.insteonplm.internal.utils.Utils;
 import org.openhab.binding.insteonplm.internal.utils.Utils.ParsingException;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.types.Command;
@@ -100,7 +101,8 @@ public class FeatureTemplateLoader {
 		if (e.getAttribute("default").equals("true")) {
 			f.setDefaultMessageHandler(handler);
 		} else {
-			int command = Utils.from0xHexString(e.getAttribute("cmd"));
+			String attr = e.getAttribute("cmd");
+			int command = (attr == null) ? 0 : Utils.from0xHexString(attr);
 			f.addMessageHandler(command, handler);
 		}
 	}
@@ -129,6 +131,7 @@ public class FeatureTemplateLoader {
 		if (c.equals("OnOffType")) return OnOffType.class;
 		else if (c.equals("PercentType")) return PercentType.class;
 		else if (c.equals("DecimalType")) return DecimalType.class;
+		else if (c.equals("IncreaseDecreaseType")) return IncreaseDecreaseType.class;
 		else throw new ParsingException("Unknown Command Type");
 	}
 	

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/InsteonDevice.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/InsteonDevice.java
@@ -68,13 +68,17 @@ public class InsteonDevice {
 	public String			getProductKey()		{ return m_productKey; }
 	public boolean 			hasModemDBEntry()	{ return m_hasModemDBEntry; }
 	public DeviceStatus 	getStatus()			{ return m_status; }
-	public InsteonAddress	getAddress() 		{ return (m_address);	}
+	public InsteonAddress	getAddress() 		{ return (m_address); }
 	public Driver			getDriver()			{ return m_driver; }
 	public boolean 			hasValidPorts()		{ return (!m_ports.isEmpty());	}
 	public long				getPollInterval()	{ return m_pollInterval; }
 	public boolean			isModem()	 		{ return m_isModem; }
 	public DeviceFeature	getFeature(String f) { 	return m_features.get(f);	}
 	public HashMap<String, DeviceFeature> getFeatures() { return m_features; }
+	public byte				getX10HouseCode()	{ return (m_address.getX10HouseCode()); }
+	public byte				getX10UnitCode()	{ return (m_address.getX10UnitCode()); }
+
+	
 	public boolean			hasProductKey(String key) {
 		return m_productKey != null && m_productKey.equals(key);
 	}
@@ -230,6 +234,15 @@ public class InsteonDevice {
 		m.setByte("messageFlags", flags);
 		m.setByte("command1", cmd1);
 		m.setByte("command2", cmd2);
+		return m;
+	}
+
+	public Msg makeX10Message(byte rawX10, byte X10Flag)
+			throws FieldException, IOException {
+		Msg m = Msg.s_makeMessage("SendX10Message");
+		m.setByte("rawX10", rawX10);
+		m.setByte("X10Flag", X10Flag);
+		m.setQuietTime(300L);
 		return m;
 	}
 

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
@@ -457,6 +457,69 @@ public abstract class MessageHandler {
 		}
 	}
 	/**
+	 * Process X10 messages that are generated when another controller
+	 * changes the state of an X10 device.
+	 */
+	public static class X10OnHandler extends  MessageHandler {
+		X10OnHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
+				String fromPort) {
+			InsteonAddress a = f.getDevice().getAddress();
+			logger.info("X10OnHandler: set X10 device {} to ON", a);
+			m_feature.publishAll(OnOffType.ON);
+		}
+	}
+	public static class X10OffHandler extends  MessageHandler {
+		X10OffHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
+				String fromPort) {
+			InsteonAddress a = f.getDevice().getAddress();
+			logger.info("X10OffHandler: set X10 device {} to OFF", a);
+			m_feature.publishAll(OnOffType.OFF);
+		}
+	}
+	public static class X10BrightHandler extends  MessageHandler {
+		X10BrightHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
+				String fromPort) {
+			InsteonAddress a = f.getDevice().getAddress();
+			logger.debug("X10BrightHandler: ignoring brighten message for device {}", a);
+		}
+	}
+	public static class X10DimHandler extends  MessageHandler {
+		X10DimHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
+				String fromPort) {
+			InsteonAddress a = f.getDevice().getAddress();
+			logger.debug("X10DimHandler: ignoring dim message for device {}", a);
+		}
+	}
+	public static class X10OpenHandler extends  MessageHandler {
+		X10OpenHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
+				String fromPort) {
+			InsteonAddress a = f.getDevice().getAddress();
+			logger.info("X10OpenHandler: set X10 device {} to OPEN", a);
+			m_feature.publishAll(OpenClosedType.OPEN);
+		}
+	}
+	public static class X10ClosedHandler extends  MessageHandler {
+		X10ClosedHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(byte cmd1, Msg msg, DeviceFeature f,
+				String fromPort) {
+			InsteonAddress a = f.getDevice().getAddress();
+			logger.info("X10ClosedHandler: set X10 device {} to CLOSED", a);
+			m_feature.publishAll(OpenClosedType.CLOSED);
+		}
+	}
+
+	/**
 	 * Factory method for creating handlers of a given name using java reflection
 	 * @param name the name of the handler to create
 	 * @param f the feature for which to create the handler

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/PollHandler.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/PollHandler.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * @since 1.5.0
  */
 public abstract class PollHandler {
-	private static final Logger logger = LoggerFactory.getLogger(MessageDispatcher.class);		
+	private static final Logger logger = LoggerFactory.getLogger(PollHandler.class);		
 	DeviceFeature m_feature = null;
 	/**
 	 * Constructor

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/X10.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/X10.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2010-2013, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.insteonplm.internal.device;
+
+import java.util.HashMap;
+import java.util.Map.Entry;
+/*
+ * This class has utilities related to the X10 protocol.
+ * 
+ * @author Bernd Pfrommer
+ * @since 1.7.0
+ */
+public class X10 {
+	/**
+	 * Enumerates the X10 command codes.
+	 * @author Bernd Pfrommer
+	 *
+	 */
+	public enum Command {
+		ALL_LIGHTS_OFF(0x6),
+		STATUS_OFF(0xE),
+		ON(0x2),
+		PRESET_DIM_1(0xA),
+		ALL_LIGHTS_ON(0x1),
+		HAIL_ACKNOWLEDGE(0x9),
+		BRIGHT(0x5),
+		STATUS_ON(0xD),
+		EXTENDED_CODE(0x9),
+		STATUS_REQUEST(0xF),
+		OFF(0x3),
+		PRESET_DIM_2(0xB),
+		ALL_UNITS_OFF(0x0),
+		HAIL_REQUEST(0x8),
+		DIM(0x4),
+		EXTENDED_DATA(0xC);
+		
+		private final byte m_code;
+		Command(int b) {
+			m_code = (byte)b;
+		}
+		public byte code() { return m_code; }
+	}
+	/**
+	 * converts house code to clear text
+	 * @param c house code as per X10 spec
+	 * @return clear text house code, i.e letter A-P 
+	 */
+	public static String s_houseToString(byte c) {
+		String s = s_houseCodeToString.get(new Integer(c & 0xff));
+		return (s == null) ? "X" : s;
+	}
+	/**
+	 * converts unit code to regular integer
+	 * @param c unit code per X10 spec
+	 * @return decoded integer, i.e. number 0-16
+	 */
+	public static int s_unitToInt(byte c) {
+		Integer i = s_unitCodeToInt.get(new Integer(c & 0xff));
+		return (i == null) ? -1 : i;
+	}
+	/**
+	 * Test if string has valid X10 address of form "H.U", e.g. A.10
+	 * @param s string to test
+	 * @return true if is valid X10 address
+	 */
+	public static boolean s_isValidAddress(String s) {
+		String [] parts = s.split("\\.");
+		if (parts.length != 2) return false;
+		return parts[0].matches("[A-P]") &&
+					parts[1].matches("\\d{1,2}");
+	}
+	/**
+	 * Turn clear text address ("A.10") to byte code 
+	 * @param addr clear text address
+	 * @return byte that encodes house + unit code
+	 */
+	public static byte s_addressToByte(String addr) {
+		String[] parts = addr.split("\\.");
+		int ih = s_houseStringToCode(parts[0]);
+		int iu = s_unitStringToCode(parts[1]);
+		int itot = ih << 4 | iu;
+		return (byte)(itot & 0xff);
+	}
+	/**
+	 * converts String to house byte code
+	 * @param s clear text house string
+	 * @return coded house byte
+	 */
+	public static int s_houseStringToCode(String s) {
+		Integer i = s_findKey(s_houseCodeToString, s);
+		return (i == null) ? 0xf : i;
+	}
+	/**
+	 * converts unit string to unit code 
+	 * @param s string with clear text integer inside
+	 * @return encoded unit byte
+	 */
+	public static int s_unitStringToCode(String s) {
+		try {
+			Integer key = Integer.parseInt(s); 
+			Integer i = s_findKey(s_unitCodeToInt, key);
+			return i;
+		} catch (NumberFormatException e) {
+		}
+		return 0xf;
+	}
+	
+	private static <T, E> T s_findKey(HashMap<T, E> map, E value) {
+	    for (Entry<T, E> entry : map.entrySet()) {
+	        if (value.equals(entry.getValue())) {
+	            return entry.getKey();
+	        }
+	    }
+	    return null;
+	}
+	/**
+	 * Map between 4-bit X10 code and the house code.
+	 */
+	private static HashMap<Integer, String> s_houseCodeToString = new HashMap<Integer, String>();
+	/**
+	 * Map between 4-bit X10 code and the unit code.
+	 */
+	private static HashMap<Integer, Integer> s_unitCodeToInt = new HashMap<Integer, Integer>();
+	static {
+		s_houseCodeToString.put(0x6, "A"); s_unitCodeToInt.put(0x6, 1);
+		s_houseCodeToString.put(0xe, "B"); s_unitCodeToInt.put(0xe, 2);
+		s_houseCodeToString.put(0x2, "C"); s_unitCodeToInt.put(0x2, 3);
+		s_houseCodeToString.put(0xa, "D"); s_unitCodeToInt.put(0xa, 4);
+		s_houseCodeToString.put(0x1, "E"); s_unitCodeToInt.put(0x1, 5);
+		s_houseCodeToString.put(0x9, "F"); s_unitCodeToInt.put(0x9, 6);
+		s_houseCodeToString.put(0x5, "G"); s_unitCodeToInt.put(0x5, 7);
+		s_houseCodeToString.put(0xd, "H"); s_unitCodeToInt.put(0xd, 8);
+		s_houseCodeToString.put(0x7, "I"); s_unitCodeToInt.put(0x7, 9);
+		s_houseCodeToString.put(0xf, "J"); s_unitCodeToInt.put(0xf, 10);
+		s_houseCodeToString.put(0x3, "K"); s_unitCodeToInt.put(0x3, 11);
+		s_houseCodeToString.put(0xb, "L"); s_unitCodeToInt.put(0xb, 12);
+		s_houseCodeToString.put(0x0, "M"); s_unitCodeToInt.put(0x0, 13);
+		s_houseCodeToString.put(0x8, "N"); s_unitCodeToInt.put(0x8, 14);
+		s_houseCodeToString.put(0x4, "O"); s_unitCodeToInt.put(0x4, 15);
+		s_houseCodeToString.put(0xc, "P"); s_unitCodeToInt.put(0xc, 16);
+	}
+}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/Msg.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/Msg.java
@@ -198,6 +198,17 @@ public class Msg {
 		return false;
 	}
 	
+	public boolean isX10() {
+		try {
+			int cmd = getByte("Cmd") & 0xff;
+			if (cmd == 0x63 || cmd == 0x52) {
+				return true;
+			} 
+		} catch (FieldException e) {
+		}
+		return false;
+	}
+	
 	public void setDefinition(MsgDefinition d) {	m_definition = d; }
 	public void setQuietTime(long t) { m_quietTime = t; }
 

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -109,4 +109,34 @@
 	<message-handler default="true">NoOpMsgHandler</message-handler>
 	<command-handler command="OnOffType">ModemCommandHandler</command-handler>
 </feature>
+<feature name="X10Dimmer">
+	<message-dispatcher>X10Dispatcher</message-dispatcher>
+	<message-handler cmd="0x02">X10OnHandler</message-handler>
+	<message-handler cmd="0x03">X10OffHandler</message-handler>
+	<message-handler cmd="0x05">X10BrightHandler</message-handler>
+	<message-handler cmd="0x04">X10DimHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler command="OnOffType">X10OnOffCommandHandler</command-handler>
+	<command-handler command="PercentType">X10PercentCommandHandler</command-handler>
+	<command-handler command="IncreaseDecreaseType">X10IncreaseDecreaseCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="X10Switch">
+	<message-dispatcher>X10Dispatcher</message-dispatcher>
+	<message-handler cmd="0x02">X10OnHandler</message-handler>
+	<message-handler cmd="0x03">X10OffHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler command="OnOffType">X10OnOffCommandHandler</command-handler>
+	<command-handler command="PercentType">NoOpCommandHandler</command-handler>
+	<command-handler command="IncreaseDecreaseType">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="X10Contact">
+	<message-dispatcher>X10Dispatcher</message-dispatcher>
+	<message-handler cmd="0x02">X10OpenHandler</message-handler>
+	<message-handler cmd="0x03">X10ClosedHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
 </xml>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
@@ -156,4 +156,20 @@ Example:
      <feature name="contact">GenericContact</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
+ <device productKey="X00.00.01">
+	 <model>X10 switch</model>
+	 <description>any simple X10 switch</description>
+	 <feature name="switch">X10Switch</feature>
+ </device>
+ <device productKey="X00.00.02">
+	 <model>X10 dimmer</model>
+	 <description>Generic X10 Dimmer without preset</description>
+	<feature name="switch">X10Switch</feature>
+	<feature name="dimmer">X10Dimmer</feature>
+ </device>
+ <device productKey="X00.00.03">
+	 <model>X10 motion sensor</model>
+	 <description>Generic X10 motion sensor</description>
+	<feature name="contact">X10Contact</feature>
+ </device>
 </xml>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/msg_definitions.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/msg_definitions.xml
@@ -209,6 +209,23 @@
 		<byte name = "userData14"/>
 		<byte name = "ACK/NACK"/>
 	</msg>
+	<msg name = "SendX10Message" length="4" direction = "TO_MODEM">
+		<header length="2">
+		 	<byte>0x02</byte>
+			<byte name = "Cmd">0x63</byte>
+		</header>
+		<byte name = "rawX10"></byte>
+		<byte name = "X10Flag">0x00</byte>
+	</msg>
+	<msg name = "SendX10MessageReply" length="5" direction = "FROM_MODEM">
+		<header length="2">
+		 	<byte>0x02</byte>
+			<byte name = "Cmd">0x63</byte>
+		</header>
+		<byte name = "rawX10"></byte>
+		<byte name = "X10Flag">0x00</byte>
+		<byte name = "ACK/NACK"/>
+	</msg>
 	<msg name = "GetFirstALLLinkRecord" length="2" direction = "TO_MODEM">
 		<header length="2">
 		 	<byte>0x02</byte>


### PR DESCRIPTION
The PLM modem supports sending and receiving legacy X10 messages. There are a significant number of X10 devices installed.

This pull request enhances the binding to allow openHAB users to interact with X10 devices via the PLM. The modifications have been tested with an X10 switch, dimmer, and a motion sensor. Regression testing has been performed to ensure the functionality of Insteon devices is not impacted.
