### PR TITLE
Added http status 202 ACCEPTED as valid no-content status

### DIFF
--- a/bundles/io/org.openhab.io.net/src/main/java/org/openhab/io/net/http/HttpUtil.java
+++ b/bundles/io/org.openhab.io.net/src/main/java/org/openhab/io/net/http/HttpUtil.java
@@ -196,7 +196,7 @@ public class HttpUtil {
 		try {
 			
 			int statusCode = client.executeMethod(method);
-			if (statusCode == HttpStatus.SC_NO_CONTENT) {
+			if (statusCode == HttpStatus.SC_NO_CONTENT || statusCode == HttpStatus.SC_ACCEPTED) {
 				// perfectly fine but we cannot expect any answer...
 				return null;
 			}


### PR DESCRIPTION
Fibaro Home Center returns 202 ACCEPTED, so I added that as an accepted status code without content.
