### PR TITLE
fix writing TemperatureSetPoint to battery/valve

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
@@ -274,13 +274,14 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 					//all devices have a battery state, so this is type-independent
 					if (provider.getBindingType(itemName) == BindingType.BATTERY && device.isBatteryLowUpdated()) {
 						eventPublisher.postUpdate(itemName, device.getBatteryLow());
-					} else {
+					} else if (provider.getBindingType(itemName) != BindingType.BATTERY) {
 					switch (device.getType()) {
 						case HeatingThermostatPlus:
 						case HeatingThermostat:
 							if (provider.getBindingType(itemName) == BindingType.VALVE
 									&& ((HeatingThermostat) device).isValvePositionUpdated()) {
 								eventPublisher.postUpdate(itemName, ((HeatingThermostat) device).getValvePosition());
+								break;
 							}
 							//omitted break, fall through
 						case WallMountedThermostat: // and also HeatingThermostat


### PR DESCRIPTION
If the BindingType is BATTERY or VALVE, the previous version of the MaxCubeBinding.java tried to write the TemperatureSetPoint to a "Battery Low Item" or "Valve Position Item" on every update of TemperatureSetpoint, because 'if's and 'case's fall down to line 295, ignoring the BindingType.

Adding a break; for the BindingType.VALVE and an if-statement for the BindingType.Battery should solve this issue.
