### PR TITLE
fix #1728 valve and battery error

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
@@ -274,13 +274,14 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 					//all devices have a battery state, so this is type-independent
 					if (provider.getBindingType(itemName) == BindingType.BATTERY && device.isBatteryLowUpdated()) {
 						eventPublisher.postUpdate(itemName, device.getBatteryLow());
-					} else {
+					} else if  (provider.getBindingType(itemName) != BindingType.BATTERY) {
 					switch (device.getType()) {
 						case HeatingThermostatPlus:
 						case HeatingThermostat:
 							if (provider.getBindingType(itemName) == BindingType.VALVE
 									&& ((HeatingThermostat) device).isValvePositionUpdated()) {
 								eventPublisher.postUpdate(itemName, ((HeatingThermostat) device).getValvePosition());
+								break;
 							}
 							//omitted break, fall through
 						case WallMountedThermostat: // and also HeatingThermostat


### PR DESCRIPTION
addition to fix #1793, regarding BindingType.VALVE and BindingType.BATTERY:
BindingType.VALVE still has been updated with wrong value in line 295
BindingType.BATTERY also, if  device.isBatteryLowUpdated() was false
