### PR TITLE
MAX Cube boost needs a setpoint temperature

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
@@ -364,7 +364,8 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 					cmd = new S_Command(rfAddress, device.getRoomId(), commandThermoType);
 				} else if (commandContent.contentEquals(ThermostatModeType.BOOST.toString())) {
 					commandThermoType = ThermostatModeType.BOOST;
-					cmd = new S_Command(rfAddress, device.getRoomId(), commandThermoType);
+					Double setTemp = Double.parseDouble( ((HeatingThermostat) device).getTemperatureSetpoint().toString());
+					cmd = new S_Command(rfAddress, device.getRoomId(), commandThermoType, setTemp);
 				} else if (commandContent.contentEquals(ThermostatModeType.MANUAL.toString())) {
 					commandThermoType = ThermostatModeType.MANUAL;
 					Double setTemp = Double.parseDouble( ((HeatingThermostat) device).getTemperatureSetpoint().toString());

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/S_Command.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/S_Command.java
@@ -57,6 +57,9 @@ public class S_Command {
 		if (mode.equals(ThermostatModeType.MANUAL)){
 			bits[7] = false;  // A (MSB)
 			bits[6] = true;   // B
+		} else if (mode.equals(ThermostatModeType.BOOST)){
+			bits[7] = true;   // A (MSB)
+			bits[6] = true;   // B
 		} else
 		{
 			bits[7] = false ;  // A (MSB)


### PR DESCRIPTION
when switching to boost mode one should provide the new/current setpoint
temperature.
With just 1s it will wake up at 30,5 C once the boost is over
