### PR TITLE
Maxcube Fix - wrong values for ACTUAL & MODE items

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
@@ -291,7 +291,7 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 							} else if (provider.getBindingType(itemName) == BindingType.ACTUAL
 									&& ((HeatingThermostat) device).isTemperatureActualUpdated()) {
 								eventPublisher.postUpdate(itemName, ((HeatingThermostat) device).getTemperatureActual());
-							} else if (((HeatingThermostat) device).isTemperatureSetpointUpdated()){
+							} else if (((HeatingThermostat) device).isTemperatureSetpointUpdated() && provider.getBindingType(itemName) == null){
 								eventPublisher.postUpdate(itemName, ((HeatingThermostat) device).getTemperatureSetpoint());
 							}
 							break;


### PR DESCRIPTION
Similar to issue #1728, items of BindingType.ACTUAL and BindingType.MODE have been updated with false values by getTemperatureSetpoint() with every change of TemperatureSetpoint. 
With this addition only the real valve item without a binding type will be updated if there is a change of the TemperatureSetpoint.
