### PR TITLE
DateTimeType as a command

### DIFF
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -14,11 +14,12 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
+import org.openhab.core.types.Command;
 import org.openhab.core.types.PrimitiveType;
 import org.openhab.core.types.State;
 
 
-public class DateTimeType implements PrimitiveType, State {
+public class DateTimeType implements PrimitiveType, State, Command {
 	
 	public final static SimpleDateFormat DATE_FORMATTER_WITH_TZ = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz");
 	public final static SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");


### PR DESCRIPTION
This PR allows to send DateTime values as commands.
Example:

```
rule "Time sync"
when
    Item Ntp_DateTime received update
then
    DateTime_Value.sendCommand(Ntp_DateTime.state as DateTimeType)
end
```
