### PR TITLE
This adds the ability to send any command to a player, usefull for playl...

### DIFF
--- a/bundles/action/org.openhab.action.squeezebox/src/main/java/org/openhab/action/squeezebox/internal/Squeezebox.java
+++ b/bundles/action/org.openhab.action.squeezebox/src/main/java/org/openhab/action/squeezebox/internal/Squeezebox.java
@@ -342,6 +342,18 @@ public class Squeezebox {
 		return true;
 	}
 	
+	@ActionDoc(text = "Issues an arbitrary command to a player", returns = "<code>true</code>, if successful and <code>false</code> otherwise.")
+	public static boolean squeezeboxPlayerCommand(
+			@ParamDoc(name = "playerId", text = "The Squeezebox to send the URL to") String playerId,
+			@ParamDoc(name = "command", text = "A command to send to the player") String command) {
+	    	SqueezePlayer player = getPlayer(playerId);
+
+	    	if (player == null) return false;
+
+		squeezeServer.playerCommand(playerId, command);
+		return true;
+	}
+	
 	private static SqueezePlayer getPlayer(String playerId) {
 		if (StringUtils.isEmpty(playerId))
 			throw new NullArgumentException("playerId");

--- a/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/CommandType.java
+++ b/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/CommandType.java
@@ -45,7 +45,9 @@ public enum CommandType {
 	REMOTETITLE("remotetitle"),
 	GENRE("genre"),
 	
-	IRCODE("ircode");
+	IRCODE("ircode"),
+	
+	COMMAND("command");
 	
 	/** Represents the player command as it will be used in *.items configuration */
 	String command;

--- a/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeboxBinding.java
+++ b/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeboxBinding.java
@@ -137,6 +137,12 @@ public class SqueezeboxBinding extends AbstractBinding<SqueezeboxBindingProvider
 						else if (command.equals(OnOffType.OFF))
 							squeezeServer.unSyncPlayer(bindingConfig.getExtra());
 						break;
+					case COMMAND:
+					    if (command instanceof StringType)
+					    	squeezeServer.playerCommand(playerId, command.toString());
+					    else
+						squeezeServer.playerCommand(playerId, bindingConfig.getExtra());
+					    	break;
 
 					default:
 						logger.warn("Unsupported command type '{}'", bindingConfig.getCommandType()); 

--- a/bundles/io/org.openhab.io.squeezeserver/src/main/java/org/openhab/io/squeezeserver/SqueezeServer.java
+++ b/bundles/io/org.openhab.io.squeezeserver/src/main/java/org/openhab/io/squeezeserver/SqueezeServer.java
@@ -347,6 +347,18 @@ public class SqueezeServer implements ManagedService {
 				+ line2 + " duration:" + String.valueOf(duration));
 	}
 	
+	/**
+	 * Send a generic command to a given player
+	 * @param playerId
+	 * @param command
+	 */
+	public void playerCommand(String playerId, String command) {
+		SqueezePlayer player = getPlayer(playerId);
+		if (player == null)
+			return;
+		sendCommand(player.getMacAddress() + " " + command);
+	}
+	
 	public String language() {
 		return language;
 	}


### PR DESCRIPTION
...ists and other plugins.  This allows triggering of playlists and other features in a squeeze server.  For example on my system I use both the spotify and pandora plugins, now I can trigger playing a playlist either with a static item bnding like so

```
Switch sq_office_pandora    "pandora" { squeeze="office:command:pandora playlist play item_id:ca30491a.0.14", autoupdate="false"
```

or pass it in via a text item from say a switch (or action or rule)

```
String sq_office_command    { squeeze="office:command", autoupdate="false" }

Switch item=sq_office_command mappings=["pandora playlist play item_id:ca30491a.0.14"="Grand National Radio", "pandora playlist play item_id:de875420.0.14"="Broken Bells Radio"]
```
