### PR TITLE
persistence/mysql: increase storagesize for coloritem

### DIFF
--- a/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * 
  * Item-Type    Data-Type          MySQL-Type 
  * =========    =========          ========== 
- * ColorItem         HSBType       CHAR(25)
+ * ColorItem         HSBType       CHAR(40)
  * ContactItem       OnOffType     CHAR(6)
  * DateTimeItem      DateTimeType  DATETIME
  * DimmerItem        PercentType   TINYINT
@@ -109,7 +109,7 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 
 	public void activate() {
 		// Initialise the type array
-		sqlTypes.put("COLORITEM", "CHAR(25)");
+		sqlTypes.put("COLORITEM", "CHAR(40)");
 		sqlTypes.put("CONTACTITEM", "VARCHAR(6)");
 		sqlTypes.put("DATETIMEITEM", "DATETIME(3)");
 		sqlTypes.put("DIMMERITEM", "TINYINT");


### PR DESCRIPTION
this is needed because the value that will be stored may increase the 25
characters; e.g. with an RGB Color Picker:

0:43:17.985 ERROR o.o.p.m.i.MysqlPersistenceService[:317]- mySQL: Could not store item 'gsAmbient' in database with statement 'INSERT INTO Item2 (TIME, VALUE) VALUES(NOW(),'217.0854271356784,78.0392156862745,100') ON DUPLICATE KEY UPDATE VALUE='217.0854271356784,78.0392156862745,100';': Data truncation: Data too long for column 'Value' at row 1

Signed-off-by: Manuel Traut manut@mecka.net
