### PR TITLE
openhab-designer: set default swt.browser to mozilla

### DIFF
--- a/products/org.openhab.designer.product/org.openhab.designer.product.product
+++ b/products/org.openhab.designer.product/org.openhab.designer.product.product
@@ -15,7 +15,7 @@ http://p.yusukekamiyamane.com, http://www.icons-land.com
    </configIni>
 
    <launcherArgs>
-      <vmArgs>-Dorg.eclipse.equinox.p2.reconciler.dropins.directory=../../addons -DnoRules=true -Xmx256m -XX:PermSize=128M</vmArgs>
+      <vmArgs>-Dorg.eclipse.equinox.p2.reconciler.dropins.directory=../../addons -DnoRules=true -Xmx256m -XX:PermSize=128M -Dorg.eclipse.swt.browser.DefaultType=mozilla</vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts</vmArgsMac>
    </launcherArgs>
 


### PR DESCRIPTION
because using webkit ends with a segfault in libsoup.

This seems to be a common problem with this eclipse version and should
be fixed in newer versions. But according to the replies on the according
bug report: https://bugs.eclipse.org/bugs/show_bug.cgi?id=404776 this should
be a workaround that works for many people.

Signed-off-by: Manuel Traut manut@mecka.net
