### PR TITLE
Update version of samsungac.test pom

### DIFF
--- a/bundles/binding/org.openhab.binding.samsungac.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.samsungac.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>1.7.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Version is still set to 1.6.0-SNAPSHOT, which creates an error in eclipse when cleaning/building. Must be set to 1.7.0-SNAPSHOT instead.
