### PR TITLE
MiOS: Only change Item state during incremental updates from MiOS Unit

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosUnit.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosUnit.java
@@ -44,6 +44,10 @@ public class MiosUnit {
 	 */
 	private static final int CONFIG_MIN_TIMEOUT = 5000;
 	private static final int CONFIG_DEFAULT_TIMEOUT = 60000;
+
+	private static final int CONFIG_MIN_MINIMUM_DELAY = 0;
+	private static final int CONFIG_DEFAULT_MINIMUM_DELAY = 0;
+
 	private static final int CONFIG_DEFAULT_PORT = 3480;
 	private static final String CONFIG_DEFAULT_HOSTNAME = "127.0.0.1";
 
@@ -51,12 +55,13 @@ public class MiosUnit {
 	private static final int CONFIG_DEFAULT_REFRESH_COUNT = CONFIG_DISABLE_REFRESH_COUNT;
 
 	private static final int CONFIG_DISABLE_ERROR_COUNT = 0;
-	private static final int CONFIG_DEFAULT_ERROR_COUNT = CONFIG_DISABLE_ERROR_COUNT;
+	private static final int CONFIG_DEFAULT_ERROR_COUNT = 1;
 
 	private String name = null;
 	private String hostname = CONFIG_DEFAULT_HOSTNAME;
 	private int port = CONFIG_DEFAULT_PORT;
 	private int timeout = CONFIG_DEFAULT_TIMEOUT;
+	private int minimumDelay = CONFIG_DEFAULT_MINIMUM_DELAY;
 
 	private int refreshCount = CONFIG_DEFAULT_REFRESH_COUNT;
 	private int errorCount = CONFIG_DEFAULT_ERROR_COUNT;
@@ -102,6 +107,20 @@ public class MiosUnit {
 	 */
 	public int getTimeout() {
 		return timeout;
+	}
+
+	/**
+	 * Get the Minimum time, in ms, that the MiOS Unit should wait/delay in
+	 * order to "bundle" changes in their response.
+	 * 
+	 * If this configuration is not specified, then it will default to 0ms, or
+	 * no-delay.
+	 * 
+	 * @return the Minimum Delay for dealing with the MiOS Unit, in
+	 *         milliseconds.
+	 */
+	public int getMinimumDelay() {
+		return minimumDelay;
 	}
 
 	/**
@@ -174,6 +193,23 @@ public class MiosUnit {
 			timeout = CONFIG_MIN_TIMEOUT;
 		}
 		this.timeout = timeout;
+	}
+
+	/**
+	 * Set the Minimum Delay of the MiOS Unit configuration.
+	 * 
+	 * @param delay
+	 *            the minimum delay, in ms, to use for any connections
+	 *            associated with this MiOS Unit.
+	 */
+	public void setMinimumDelay(int delay) {
+		if (delay < CONFIG_MIN_MINIMUM_DELAY) {
+			logger.warn(
+					"Minimum Delay of {} below minimum permitted, {] used.",
+					minimumDelay, CONFIG_MIN_MINIMUM_DELAY);
+			delay = CONFIG_MIN_MINIMUM_DELAY;
+		}
+		this.minimumDelay = delay;
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/MiosBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/MiosBindingConfig.java
@@ -34,6 +34,7 @@ import org.openhab.core.transform.TransformationService;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.TypeParser;
+import org.openhab.core.types.UnDefType;
 import org.openhab.model.item.binding.BindingConfigParseException;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -332,7 +333,16 @@ public abstract class MiosBindingConfig implements BindingConfig {
 		State result;
 		try {
 			if (itemType.isAssignableFrom(NumberItem.class)) {
-				result = DecimalType.valueOf(value);
+				//
+				// For things like Weather Items when they're bound to
+				// NumberItems.
+				//
+				// eg. Heat Index
+				if ("".equals(value)) {
+					result = UnDefType.NULL;
+				} else {
+					result = DecimalType.valueOf(value);
+				}
 			} else if (itemType.isAssignableFrom(ContactItem.class)) {
 				result = OpenClosedType.valueOf(value);
 			} else if (itemType.isAssignableFrom(SwitchItem.class)) {
@@ -343,19 +353,32 @@ public abstract class MiosBindingConfig implements BindingConfig {
 				result = PercentType.valueOf(value);
 			} else if (itemType.isAssignableFrom(DateTimeItem.class)) {
 				try {
-					// See if it "looks" like an Epoch-style date. MiOS Units
-					// return these as String/Integer versions of the date and
-					// they need to be converted.
 					//
-					// This logic really belongs inside the OH 1.x core class
-					// DateTimeType, but that's closed to changes... doing it
-					// here also avoids the thread-safety issues present in the
-					// DateTimeType class.
+					// If we're presented with the empty string, then consider
+					// it to be the Undefined NULL value.
 					//
-					long l = Long.parseLong(value) * 1000;
-					Calendar c = Calendar.getInstance();
-					c.setTimeInMillis(l);
-					result = new DateTimeType(c);
+					// This has been observed during Full-updates from a MiOS
+					// unit that has Leviton Scene Controllers present
+					// (LastUpdated).
+					//
+					if ("".equals(value)) {
+						result = UnDefType.NULL;
+					} else {
+						//
+						// See if it "looks" like an Epoch-style date. MiOS
+						// Units return these as String/Integer versions of the
+						// date and they need to be converted.
+						//
+						// This logic really belongs inside the OH 1.x core
+						// class DateTimeType, but that's closed to changes...
+						// doing it here also avoids the thread-safety issues
+						// present in the DateTimeType class.
+						//
+						long l = Long.parseLong(value) * 1000;
+						Calendar c = Calendar.getInstance();
+						c.setTimeInMillis(l);
+						result = new DateTimeType(c);
+					}
 				} catch (NumberFormatException nfe) {
 					result = DateTimeType.valueOf(value);
 				}


### PR DESCRIPTION
When we detect a MiOS Unit has been restarted, we force a _Full refresh_ to see if anything has changed (as openHAB might be out of sync). During these full/forced refreshes, Item states _will only_ be updated in openHAB if they're different from the state currently in openHAB. This is done to keep things in sync that might have changed around the time of the MiOS Unit restart.

By using conditional Item state-changes Item during the Full refresh, we avoid unwanted Rule execution, as these would normally be re-triggered by the corresponding Item state change(s)

Move to using `UnDefType.NULL` for `Number` and `Date` Items, when the value comes in as the empty String.

Force the Character-Set on the MiOS JSON Response stream to UTF-8, for i18n, since MiOS doesn't apply it in their Response headers.

Add some [intentionally undocumented] parameters to allow for tweaks during field testing.

Fix setting the right value in newly added (MiosUnit) parameter, as identified by @watou during review of the original PR (# 1888)
