### PR TITLE
Added methods hashCode() and equals() to PercentType

### DIFF
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PercentType.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PercentType.java
@@ -53,4 +53,17 @@ public class PercentType extends DecimalType {
 		return new PercentType(value);
 	}
 
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (getClass() != obj.getClass())
+			return false;
+		return super.equals(obj);
+	}
 }


### PR DESCRIPTION
PercentType was missing the methods hashCode() and equals(), this pull requests add them to PercentType.
