### PR TITLE
Improve BenQ projector binding connection handling and exception handling

### DIFF
--- a/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorBinding.java
+++ b/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorBinding.java
@@ -161,7 +161,11 @@ public class BenqProjectorBinding extends
 
 			String deviceIdString = (String) config.get("deviceId");
 			if (StringUtils.isNotBlank(deviceIdString)) {
-				setProperlyConfigured(transport.setupConnection(deviceIdString));
+				transport.setupConnection(deviceIdString);
+				/* we always want the refresh service to start, it will attempt
+				 * to reconnect next time if necessary
+				 */				
+				setProperlyConfigured(true); 
 			}
 		}
 	}

--- a/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorItemMode.java
+++ b/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorItemMode.java
@@ -66,9 +66,16 @@ public enum BenqProjectorItemMode {
 
 	private State parseNumberResponse(String response) {
 		String[] responseParts = response.split("=");
-		if (responseParts.length == 2) {
-			return new DecimalType(Integer.parseInt(responseParts[1].substring(
-					0, responseParts[1].length() - 1)));
+		if (responseParts.length == 2 ) {
+			try
+			{
+				return new DecimalType(Integer.parseInt(responseParts[1].substring(
+						0, responseParts[1].length() - 1)));
+			}
+			catch (NumberFormatException nfe)
+			{
+				return UnDefType.UNDEF;
+			}
 		}
 		return UnDefType.UNDEF;
 	}


### PR DESCRIPTION
These commits contain 3 improvements:

1) Tidy up of string handling so that non-numeric strings in the case where a numeric string is expected is handled properly

2) Improve the connection and reconnection process in the case where the host is not available or goes down. This also has a fix to avoid null pointer exceptions in the closing of reader/writer/sockets.

3) Delay reading the power status after a power command is sent to the projector. This stops you getting an item toggle when you send a power off request and then read the status when the projector will return 'ON' as it is cooling down. This means that rules tied to the power status will behave correctly (before my projector screen would start going up, then go back down and then finally go up again - now it will just go up).

I am testing locally. Would be good to get feedback from users who have had similar problems that have been reported in the forum. See https://groups.google.com/d/msg/openhab/KboLzufnsnc/NGBE3SGaNPgJ
