### PR TITLE
Implement the ability to change the wall thermostat display mode

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulBinding.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulBinding.java
@@ -188,10 +188,16 @@ public class MaxCulBinding extends AbstractBinding<MaxCulBindingProvider>
 							+ bindingConfig.getDeviceType()
 							+ " that is not OnOffType");
 				break;
+			
+			case WALL_THERMOSTAT:								
 			case RADIATOR_THERMOSTAT:
 			case RADIATOR_THERMOSTAT_PLUS:
-			case WALL_THERMOSTAT:
-				if (bindingConfig.getFeature() == MaxCulFeature.THERMOSTAT) {
+				if (bindingConfig.getFeature() == MaxCulFeature.DISPLAY
+						&& bindingConfig.getDeviceType() == MaxCulDevice.WALL_THERMOSTAT
+						&& command instanceof OnOffType) {
+					boolean displayActualTemp = ((OnOffType)command == OnOffType.ON);
+					messageHandler.sendSetDisplayActualTemperature(bindingConfig.getDevAddr(), null, displayActualTemp);
+				} else if (bindingConfig.getFeature() == MaxCulFeature.THERMOSTAT) {
 					/* clear out old pacing timer */
 					if (pacedBindingTransmitTimers.containsKey(bindingConfig)) {
 						pacedBindingTransmitTimers.get(bindingConfig).cancel();

--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulBinding.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulBinding.java
@@ -524,6 +524,11 @@ public class MaxCulBinding extends AbstractBinding<MaxCulBindingProvider>
 							eventPublisher.postUpdate(itemName,
 									new DecimalType(wallThermStateMsg
 											.getControlMode().toInt()));
+						} else if (bc.getFeature() == MaxCulFeature.DISPLAY) {
+							eventPublisher
+								.postUpdate(itemName, wallThermStateMsg
+									.isDisplayMeasuredTemp() ? OnOffType.ON
+									: OnOffType.OFF);
 						}
 					}
 				}

--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulBindingConfig.java
@@ -44,6 +44,8 @@ public class MaxCulBindingConfig implements BindingConfig {
 	private boolean temperatureConfigSet = false;
 	private HashSet<String> associatedSerialNum = new HashSet<String>();
 
+	private boolean displayActualTemperature = false;
+	
 	private final String CONFIG_PROPERTIES_BASE = "etc/maxcul";
 
 	private static final Logger logger = LoggerFactory
@@ -92,6 +94,8 @@ public class MaxCulBindingConfig implements BindingConfig {
 		this.paired = true;
 		saveStoredConfig();
 	}
+	
+	
 
 	private String generateConfigFilename() {
 		String base = CONFIG_PROPERTIES_BASE;
@@ -262,5 +266,13 @@ public class MaxCulBindingConfig implements BindingConfig {
 
 	public void addAssociatedSerialNum(String assocDeviceSerial) {
 		this.associatedSerialNum.add(assocDeviceSerial);
+	}
+	
+	public void setDisplayActualTemperature(boolean displayActualTemperature) {
+		this.displayActualTemperature = displayActualTemperature;
+	}
+	
+	public boolean getDisplayActualTemperature() {
+		return this.displayActualTemperature;
 	}
 }

--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulBindingConfigParser.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulBindingConfigParser.java
@@ -72,6 +72,8 @@ public class MaxCulBindingConfigParser {
 						parseAssociation(configParts[idx], cfg);
 					} else if (configParts[idx].startsWith("feature")) {
 						parseDeviceFeature(configParts[idx], cfg);
+					} else if (configParts[idx].startsWith("display")) {
+						parseDeviceDisplay(configParts[idx], cfg);
 					}
 				}
 			} else {
@@ -178,6 +180,10 @@ public class MaxCulBindingConfigParser {
 				cfg.setFeature(MaxCulFeature.VALVE_POS);
 			} else if (configPart.equals("reset")) {
 				cfg.setFeature(MaxCulFeature.RESET);
+			} else if (configPart.equals("displaySetting")) {
+				cfg.setFeature(MaxCulFeature.DISPLAY);
+			} else {
+				logger.error("Unable to parse feature '"+configPart+"'");
 			}
 		}
 	}
@@ -217,6 +223,18 @@ public class MaxCulBindingConfigParser {
 		} else
 			throw new BindingConfigParseException(
 					"Format of association configuration is incorrect! must be 'association=<serialNum>[,<serialNum>,[...]]'");
+	}
+	
+	private static void parseDeviceDisplay(String configParts,
+			MaxCulBindingConfig cfg) throws BindingConfigParseException {
+		String[] configKeyValueSplit = configParts.split("=");
+		if (configKeyValueSplit.length == 2 && configKeyValueSplit[1].matches("setpoint")) {
+			cfg.setDisplayActualTemperature(false);
+		} else if (configKeyValueSplit.length == 2 && configKeyValueSplit[1].matches("actualTemp")) {
+			cfg.setDisplayActualTemperature(true);
+		} else
+			throw new BindingConfigParseException(
+					"Format of device display configuration is incorrect! Must be 'display=setpoint' or 'display=actualTemp' ");
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulFeature.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulFeature.java
@@ -15,5 +15,5 @@ package org.openhab.binding.maxcul.internal;
  * @since 1.6.0
  */
 public enum MaxCulFeature {
-	THERMOSTAT, TEMPERATURE, BATTERY, MODE, SWITCH, VALVE_POS, RESET, UNKNOWN;
+	THERMOSTAT, TEMPERATURE, BATTERY, MODE, SWITCH, VALVE_POS, RESET, DISPLAY, UNKNOWN;
 }

--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulMsgHandler.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulMsgHandler.java
@@ -29,6 +29,7 @@ import org.openhab.binding.maxcul.internal.messages.MaxCulMsgType;
 import org.openhab.binding.maxcul.internal.messages.PairPingMsg;
 import org.openhab.binding.maxcul.internal.messages.PairPongMsg;
 import org.openhab.binding.maxcul.internal.messages.ResetMsg;
+import org.openhab.binding.maxcul.internal.messages.SetDisplayActualTemperatureMsg;
 import org.openhab.binding.maxcul.internal.messages.SetGroupIdMsg;
 import org.openhab.binding.maxcul.internal.messages.SetTemperatureMsg;
 import org.openhab.binding.maxcul.internal.messages.ThermostatControlMode;
@@ -330,6 +331,9 @@ public class MaxCulMsgHandler implements CULListener {
 		case WALL_THERMOSTAT_STATE:
 			new WallThermostatStateMsg(data).printMessage();
 			break;
+		case SET_DISPLAY_ACTUAL_TEMP:
+			new SetDisplayActualTemperatureMsg(data).printMessage();
+			break;
 		case ADD_LINK_PARTNER:
 		case CONFIG_TEMPERATURES:
 		case CONFIG_VALVE:
@@ -338,8 +342,7 @@ public class MaxCulMsgHandler implements CULListener {
 		case REMOVE_GROUP_ID:
 		case REMOVE_LINK_PARTNER:
 		case RESET:
-		case SET_COMFORT_TEMPERATURE:
-		case SET_DISPLAY_ACTUAL_TEMP:
+		case SET_COMFORT_TEMPERATURE:		
 		case SET_ECO_TEMPERATURE:
 		case SHUTTER_CONTACT_STATE:
 		case UNKNOWN:
@@ -682,6 +685,24 @@ public class MaxCulMsgHandler implements CULListener {
 		ResetMsg resetMsg = new ResetMsg(getMessageCount(), (byte) 0, (byte) 0,
 				this.srcAddr, devAddr);
 		sendMessage(resetMsg);
+	}
+	
+	/**
+	 * Configure a device to display the actual measured temperature
+	 * 
+	 * @param devAddr
+	 * 			Address of device to config
+	 * @param msgSeq
+	 * 			Associated message sequencer
+	 * @param displayActualTemperature
+	 * 			True if the measure temperature is to be shown
+	 */
+	public void sendSetDisplayActualTemperature(String devAddr, MessageSequencer msgSeq,
+			boolean displayActualTemperature) {
+		SetDisplayActualTemperatureMsg dispActTempMsg = new SetDisplayActualTemperatureMsg(getMessageCount(), 
+				(byte) 0, this.srcAddr, devAddr, displayActualTemperature);
+		dispActTempMsg.setMessageSequencer(msgSeq);
+		sendMessage(dispActTempMsg);
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/messages/SetDisplayActualTemperatureMsg.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/messages/SetDisplayActualTemperatureMsg.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.maxcul.internal.messages;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SetGroupId Message
+ * 
+ * @author Paul Hampson (cyclingengineer)
+ * @since 1.8.0
+ */
+public class SetDisplayActualTemperatureMsg extends BaseMsg {
+
+	final private int SET_DISPLAY_ACTUAL_TEMPERATURE_PAYLOAD_LEN = 1;
+
+	private static final Logger logger = LoggerFactory
+			.getLogger(SetDisplayActualTemperatureMsg.class);
+
+	private boolean displayActualTemperature;
+
+	public SetDisplayActualTemperatureMsg(byte msgCount, byte msgFlag, String srcAddr,
+			String dstAddr, boolean displayActualTemperature) {
+		super(msgCount, msgFlag, MaxCulMsgType.SET_DISPLAY_ACTUAL_TEMP, (byte) 0x0,
+				srcAddr, dstAddr);
+
+		this.displayActualTemperature = displayActualTemperature;
+		byte[] payload = new byte[SET_DISPLAY_ACTUAL_TEMPERATURE_PAYLOAD_LEN];
+
+		payload[0] = (byte) (displayActualTemperature ? 0x4 : 0x0);
+
+		super.appendPayload(payload);
+	}
+
+	public SetDisplayActualTemperatureMsg(String rawmsg) {
+		super(rawmsg);
+		this.displayActualTemperature = (this.payload[0] == 0x4);
+	}
+
+	/**
+	 * Print output as decoded fields
+	 */
+	@Override
+	protected void printFormattedPayload() {
+		logger.debug("\t Display Actual Temp => " + this.displayActualTemperature);
+	}
+}

--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/messages/WallThermostatStateMsg.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/messages/WallThermostatStateMsg.java
@@ -189,5 +189,9 @@ public class WallThermostatStateMsg extends BaseMsg {
 	public ThermostatControlMode getControlMode() {
 		return ctrlMode;
 	}
+	
+	public boolean isDisplayMeasuredTemp() {
+		return displayMeasuredTemp;
+	}
 
 }


### PR DESCRIPTION
This allows you to change the wall stat display to either the current temperature or the current setpoint.

In theory this can be done at pairing time as well, but I've disabled that at the moment as it doesn't appear to work and it seems to stall the pairing process.

This also includes a refactoring of the pairing message sequence state machine to make it more understandable.

Tested on my local setup. Wiki documentation updated.
