### PR TITLE
Corrected parameter 10 for Qubino devices

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhaa.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhaa.xml
@@ -72,7 +72,7 @@
 			<Index>10</Index>
 			<Type>list</Type>
 			<Default>255</Default>
-			<Size>1</Size>
+			<Size>2</Size>
 			<Label lang="en">Activate / deactivate functions ALL ON/ALL OFF</Label>			
 			<Item>
 				<Value>255</Value>

--- a/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhad.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhad.xml
@@ -72,7 +72,7 @@
 			<Index>10</Index>
 			<Type>list</Type>
 			<Default>255</Default>
-			<Size>1</Size>
+			<Size>2</Size>
 			<Label lang="en">Activate / deactivate functions ALL ON/ALL OFF</Label>			
 			<Item>
 				<Value>255</Value>

--- a/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhba.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhba.xml
@@ -69,7 +69,7 @@
 			<Index>10</Index>
 			<Type>list</Type>
 			<Default>255</Default>
-			<Size>1</Size>
+			<Size>2</Size>
 			<Label lang="en">Activate / deactivate functions ALL ON/ALL OFF</Label>			
 			<Item>
 				<Value>255</Value>

--- a/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhda.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhda.xml
@@ -75,7 +75,7 @@
 			<Index>10</Index>
 			<Type>list</Type>
 			<Default>255</Default>
-			<Size>1</Size>
+			<Size>2</Size>
 			<Label lang="en">Activate / deactivate functions ALL ON/ALL OFF</Label>			
 			<Item>
 				<Value>255</Value>

--- a/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhia.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhia.xml
@@ -104,7 +104,7 @@
 			<Index>10</Index>
 			<Type>list</Type>
 			<Default>255</Default>
-			<Size>1</Size>
+			<Size>2</Size>
 			<Label lang="en">Activate / deactivate functions ALL ON/ALL OFF</Label>			
 			<Item>
 				<Value>255</Value>

--- a/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhla.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhla.xml
@@ -138,7 +138,7 @@
 			<Index>10</Index>
 			<Type>list</Type>
 			<Default>255</Default>
-			<Size>1</Size>
+			<Size>2</Size>
 			<Label lang="en">Activate / deactivate functions ALL ON/ALL OFF
 			</Label>
 			<Item>

--- a/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhnd.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/qubino/zmnhnd.xml
@@ -55,7 +55,7 @@
 			<Index>10</Index>
 			<Type>list</Type>
 			<Default>255</Default>
-			<Size>1</Size>
+			<Size>2</Size>
 			<Label lang="en">Activate / deactivate functions ALL ON/ALL OFF</Label>			
 			<Item>
 				<Value>255</Value>
@@ -268,11 +268,6 @@ state and reflecting its state)</Label>
 			<Maximum>16</Maximum>
 			<Label lang="en">Binary Sensor (triggered at change of the input I2 
 state and reflecting its state)</Label>
-		</Group>
-		<Group>
-			<Index>9</Index>
-			<Maximum>16</Maximum>
-			<Label lang="en">Multilevel Sensor report (triggered at change of temperature sensor)</Label>
 		</Group>
 	</Associations>
 </Product>


### PR DESCRIPTION
Update of configuration parameter 10 from 1 byte to 2 byte according to Qubino documentation. (Verified by Qubino support.)
Answer from Qubino support:
"According z-wave standards 1 Byte DEC is used for range -127 to +127, so as parameter 10 is using values up to 255, it is correct to be 2 Byte DEC."
