### PR TITLE
added support for zone tracking for Ademco panels where we do not get…

### DIFF
--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.alarmdecoder.internal;
+
+import org.openhab.binding.alarmdecoder.internal.model.ADZone;
+import java.util.ArrayList;
+import java.util.ListIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Track zone faults / restores by zone ID watching the alarm panel
+ * message stream
+ *
+ * @author Sean Mathews <coder@f34r.com>
+ * @since 1.6.0
+ */
+public class ADZoneTracker {
+
+    private static final Logger logger = LoggerFactory.getLogger(ADZoneTracker.class);
+
+    private ArrayList<ADZone> _zoneList;
+    private boolean _lastReady;
+    private int _lastZone = 0;
+
+    // TODO: zone timeout handling. zone list garbage collector.
+    long _currTime = 0;
+
+
+    ADZoneTracker() {
+        _zoneList = new ArrayList<ADZone>();
+        _lastReady = false;
+        _currTime = System.nanoTime();
+    }
+
+    /**
+     * get the state of a zone
+     *
+     * @param Zone - the zone
+     * @return return zone status or null if the zone is invalid
+     *     -1 = unknown
+     *      0 = restored
+     *      1 = faulted
+     */
+    public boolean getZoneState(int Zone) {
+
+        /** find the zone in our List */
+        ADZone f = new ADZone(Zone);
+        int z = _zoneList.indexOf(f);
+
+        if ( z > -1 ) {
+            f = _zoneList.get(z);
+        }
+
+        return f.getState();
+    }
+
+    /**
+     * set the state of a zone
+     *
+     * @param Zone  - the zone
+     * @param State - faulted or not boolean
+     * @return zone status
+     *     -1 = unknown
+     *      0 = restored
+     *      1 = faulted
+     */
+    public boolean setZoneState(int Zone, boolean State) {
+
+        /** find the zone in our List */
+        ADZone f = new ADZone(Zone);
+        int z = _zoneList.indexOf(f);
+
+        if ( z > -1 ) {
+            f.setState(State);
+            f = _zoneList.set(z,f);
+        } else {
+            f.setState(State);
+            _zoneList.add(f);
+        }
+
+        return f.getState();
+    }
+
+    /**
+     * Clear all tracked zones happens when we see a "READY" from the panel
+     *
+     */
+     public void clearAll() {
+         _zoneList.clear();
+         _lastZone = 0;
+         _lastReady = true;
+     }
+
+    /**
+     * Update a zone state from messages from panel. Must be in the
+     * correct sequence and not modified from what the panel provides
+     * to properly track zones
+     *
+     * @param Zone  - the zone
+     * @param State - the state
+     * @return ArrayList of zones effected
+     */
+     public ArrayList updateZone(int Zone, boolean State) {
+
+        /** return a list of update zones */
+        ArrayList<Integer> updateList =  new ArrayList<Integer>();
+
+        /** add this zone */
+        updateList.add(Zone);
+
+        /** our list iterator */
+        ListIterator litr = _zoneList.listIterator();
+
+        /** zone exists so check for any pruning */
+        if(_zoneList.contains(new ADZone(Zone))) {
+            /** go to our last zone updated */
+            ADZone f = new ADZone(_lastZone);
+            int z = _zoneList.indexOf(f);
+
+		    boolean bFoundLast = false;
+
+            /** look for any missing zones and clear them */
+            while ( !bFoundLast ) {
+               ADZone zn;
+
+                boolean bHasNext=litr.hasNext();
+                if ( bHasNext ) {
+                    zn = (ADZone) litr.next();
+                } else {
+                    break;
+                }
+
+                /** we found it so break out */
+                if( zn.getID() == _lastZone ) {
+	               bFoundLast = true;
+                }
+            }
+
+            /**
+             * Iterate through the rest till we reach the end or find our
+             * new fault adding everything we find as we go to our remove list
+             */
+            ArrayList<Integer> removeList =  new ArrayList<Integer>();
+            boolean bFoundNew = false;
+            while(litr.hasNext() && !bFoundNew) {
+                ADZone zn = (ADZone) litr.next();
+                if( zn.getID() == Zone ) {
+                    bFoundNew=true;
+                    break;
+                } else {
+                    removeList.add(zn.getID());
+                    updateList.add(zn.getID());
+                }
+            }
+
+            /**
+             * start over if we didnt find the end and remove
+             * everything we find till we do reach our current fault
+             */
+             if(!bFoundNew) {
+                 litr = _zoneList.listIterator();
+                 while(litr.hasNext() && !bFoundNew) {
+                     ADZone zn = (ADZone) litr.next();
+                     if( zn.getID() == Zone ) {
+                         bFoundNew=true;
+                         break;
+                     } else {
+                         removeList.add(zn.getID());
+                         updateList.add(zn.getID());
+                     }
+                 }
+             }
+
+             litr = removeList.listIterator();
+             while ( litr.hasNext() ) {
+                 Integer zid = (Integer)litr.next();
+                 ADZone zn = new ADZone(zid);
+                 _zoneList.remove(zn);
+             }
+
+         /** zone does not exist just get it into our list */
+         } else {
+
+             ADZone f = new ADZone(Zone);
+
+             boolean bInserted=false;
+             int offset=0;
+             litr = _zoneList.listIterator();
+             while(litr.hasNext()) {
+                 ADZone zn = (ADZone) litr.next();
+                 if( zn.getID() > Zone ) {
+                     _zoneList.add(offset, f);
+                     bInserted=true;
+                     break;
+                 }
+                 offset++;
+             }
+
+             /** just add it */
+             if ( !bInserted ) {
+                 _zoneList.add(f);
+             }
+         }
+
+         /** update our last touched zone */
+         _lastZone = Zone;
+
+         setZoneState(Zone,State);
+
+         return updateList;
+     }
+
+     /**
+      * Update panel Ready state clear zones if needed
+      *
+      * @parm State - the current panel READY state
+      * @return ArrayList of zones effected
+      */
+      public ArrayList updateReadyState(boolean State) {
+
+          ArrayList<Integer> updateList = new ArrayList<Integer>();
+
+          /** if we go ready clear all faults */
+          if ( State && _lastReady != State ) {
+              /** copy our zones to our update list */
+              for (ADZone tz : _zoneList) {
+                  updateList.add(tz.getID());
+              }
+              /** now clear the list */
+              clearAll();
+          }
+          _lastReady = State;
+
+          /** return a list of update zones */
+          return updateList;
+      }
+
+}

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
@@ -41,9 +41,9 @@ public class ADZoneTracker {
      *
      * @param zone - the zone
      * @return return zone status or null if the zone is invalid
-     *     -1 = unknown
-     *      0 = restored
-     *      1 = faulted
+     *         -1 = unknown
+     *         0 = restored
+     *         1 = faulted
      */
     public boolean getZoneState(int zone) {
 
@@ -51,7 +51,7 @@ public class ADZoneTracker {
         ADZone f = new ADZone(zone);
         int z = _zoneList.indexOf(f);
 
-        if ( z > -1 ) {
+        if (z > -1) {
             f = _zoneList.get(z);
         }
 
@@ -61,12 +61,12 @@ public class ADZoneTracker {
     /**
      * set the state of a zone
      *
-     * @param zone  - the zone
+     * @param zone - the zone
      * @param state - faulted or not boolean
      * @return zone status
-     *     -1 = unknown
-     *      0 = restored
-     *      1 = faulted
+     *         -1 = unknown
+     *         0 = restored
+     *         1 = faulted
      */
     public boolean setZoneState(int zone, boolean state) {
 
@@ -74,9 +74,9 @@ public class ADZoneTracker {
         ADZone f = new ADZone(zone);
         int z = _zoneList.indexOf(f);
 
-        if ( z > -1 ) {
+        if (z > -1) {
             f.setState(state);
-            f = _zoneList.set(z,f);
+            f = _zoneList.set(z, f);
         } else {
             f.setState(state);
             _zoneList.add(f);
@@ -89,25 +89,25 @@ public class ADZoneTracker {
      * Clear all tracked zones happens when we see a "READY" from the panel
      *
      */
-     public void clearAll() {
-         _zoneList.clear();
-         _lastZone = 0;
-         _lastReady = true;
-     }
+    public void clearAll() {
+        _zoneList.clear();
+        _lastZone = 0;
+        _lastReady = true;
+    }
 
     /**
      * Update a zone state from messages from panel. Must be in the
      * correct sequence and not modified from what the panel provides
      * to properly track zones
      *
-     * @param zone  - the zone
+     * @param zone - the zone
      * @param state - the state
      * @return ArrayList of zones effected
      */
-     public ArrayList updateZone(int zone, boolean state) {
+    public ArrayList updateZone(int zone, boolean state) {
 
         // return a list of update zones
-        ArrayList<Integer> updateList =  new ArrayList<Integer>();
+        ArrayList<Integer> updateList = new ArrayList<Integer>();
 
         // add this zone
         updateList.add(zone);
@@ -116,7 +116,7 @@ public class ADZoneTracker {
         ListIterator litr = _zoneList.listIterator();
 
         // zone exists so check for any pruning
-        if(_zoneList.contains(new ADZone(zone))) {
+        if (_zoneList.contains(new ADZone(zone))) {
             // go to our last zone updated
             ADZone f = new ADZone(_lastZone);
             int z = _zoneList.indexOf(f);
@@ -124,18 +124,18 @@ public class ADZoneTracker {
             boolean bFoundLast = false;
 
             // look for any missing zones and clear them
-            while ( !bFoundLast ) {
-               ADZone zn;
+            while (!bFoundLast) {
+                ADZone zn;
 
-                boolean bHasNext=litr.hasNext();
-                if ( bHasNext ) {
+                boolean bHasNext = litr.hasNext();
+                if (bHasNext) {
                     zn = (ADZone) litr.next();
                 } else {
                     break;
                 }
 
                 // we found it so break out
-                if( zn.getID() == _lastZone ) {
+                if (zn.getID() == _lastZone) {
                     bFoundLast = true;
                 }
             }
@@ -144,12 +144,12 @@ public class ADZoneTracker {
              * Iterate through the rest till we reach the end or find our
              * new fault adding everything we find as we go to our remove list
              */
-            ArrayList<Integer> removeList =  new ArrayList<Integer>();
+            ArrayList<Integer> removeList = new ArrayList<Integer>();
             boolean bFoundNew = false;
-            while(litr.hasNext() && !bFoundNew) {
+            while (litr.hasNext() && !bFoundNew) {
                 ADZone zn = (ADZone) litr.next();
-                if( zn.getID() == zone ) {
-                    bFoundNew=true;
+                if (zn.getID() == zone) {
+                    bFoundNew = true;
                     break;
                 } else {
                     removeList.add(zn.getID());
@@ -161,82 +161,82 @@ public class ADZoneTracker {
              * start over if we didnt find the end and remove
              * everything we find till we do reach our current fault
              */
-             if(!bFoundNew) {
-                 litr = _zoneList.listIterator();
-                 while(litr.hasNext() && !bFoundNew) {
-                     ADZone zn = (ADZone) litr.next();
-                     if( zn.getID() == zone ) {
-                         bFoundNew=true;
-                         break;
-                     } else {
-                         removeList.add(zn.getID());
-                         updateList.add(zn.getID());
-                     }
-                 }
-             }
+            if (!bFoundNew) {
+                litr = _zoneList.listIterator();
+                while (litr.hasNext() && !bFoundNew) {
+                    ADZone zn = (ADZone) litr.next();
+                    if (zn.getID() == zone) {
+                        bFoundNew = true;
+                        break;
+                    } else {
+                        removeList.add(zn.getID());
+                        updateList.add(zn.getID());
+                    }
+                }
+            }
 
-             litr = removeList.listIterator();
-             while ( litr.hasNext() ) {
-                 Integer zid = (Integer)litr.next();
-                 ADZone zn = new ADZone(zid);
-                 _zoneList.remove(zn);
-             }
+            litr = removeList.listIterator();
+            while (litr.hasNext()) {
+                Integer zid = (Integer) litr.next();
+                ADZone zn = new ADZone(zid);
+                _zoneList.remove(zn);
+            }
 
-         // zone does not exist just get it into our list
-         } else {
+            // zone does not exist just get it into our list
+        } else {
 
-             ADZone f = new ADZone(zone);
+            ADZone f = new ADZone(zone);
 
-             boolean bInserted=false;
-             int offset=0;
-             litr = _zoneList.listIterator();
-             while(litr.hasNext()) {
-                 ADZone zn = (ADZone) litr.next();
-                 if( zn.getID() > zone ) {
-                     _zoneList.add(offset, f);
-                     bInserted=true;
-                     break;
-                 }
-                 offset++;
-             }
+            boolean bInserted = false;
+            int offset = 0;
+            litr = _zoneList.listIterator();
+            while (litr.hasNext()) {
+                ADZone zn = (ADZone) litr.next();
+                if (zn.getID() > zone) {
+                    _zoneList.add(offset, f);
+                    bInserted = true;
+                    break;
+                }
+                offset++;
+            }
 
-             // just add it
-             if ( !bInserted ) {
-                 _zoneList.add(f);
-             }
-         }
+            // just add it
+            if (!bInserted) {
+                _zoneList.add(f);
+            }
+        }
 
-         // update our last touched zone
-         _lastZone = zone;
+        // update our last touched zone
+        _lastZone = zone;
 
-         setZoneState(zone,state);
+        setZoneState(zone, state);
 
-         return updateList;
-     }
+        return updateList;
+    }
 
-     /**
-      * Update panel Ready state clear zones if needed
-      *
-      * @parm state - the current panel READY state
-      * @return ArrayList of zones effected
-      */
-      public ArrayList<Integer> updateReadyState(boolean state) {
+    /**
+     * Update panel Ready state clear zones if needed
+     *
+     * @parm state - the current panel READY state
+     * @return ArrayList of zones effected
+     */
+    public ArrayList<Integer> updateReadyState(boolean state) {
 
-          ArrayList<Integer> updateList = new ArrayList<Integer>();
+        ArrayList<Integer> updateList = new ArrayList<Integer>();
 
-          // if we go ready clear all faults
-          if ( state && _lastReady != state ) {
-              // copy our zones to our update list
-              for (ADZone tz : _zoneList) {
-                  updateList.add(tz.getID());
-              }
-              // now clear the list
-              clearAll();
-          }
-          _lastReady = state;
+        // if we go ready clear all faults
+        if (state && _lastReady != state) {
+            // copy our zones to our update list
+            for (ADZone tz : _zoneList) {
+                updateList.add(tz.getID());
+            }
+            // now clear the list
+            clearAll();
+        }
+        _lastReady = state;
 
-          // return a list of update zones
-          return updateList;
-      }
+        // return a list of update zones
+        return updateList;
+    }
 
 }

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
@@ -30,13 +30,10 @@ public class ADZoneTracker {
     private int _lastZone = 0;
 
     // TODO: zone timeout handling. zone list garbage collector.
-    long _currTime = 0;
-
 
     ADZoneTracker() {
         _zoneList = new ArrayList<ADZone>();
         _lastReady = false;
-        _currTime = System.nanoTime();
     }
 
     /**

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
@@ -47,7 +47,7 @@ public class ADZoneTracker {
      */
     public boolean getZoneState(int zone) {
 
-        /** find the zone in our List */
+        // find the zone in our List
         ADZone f = new ADZone(zone);
         int z = _zoneList.indexOf(f);
 
@@ -70,7 +70,7 @@ public class ADZoneTracker {
      */
     public boolean setZoneState(int zone, boolean state) {
 
-        /** find the zone in our List */
+        // find the zone in our List
         ADZone f = new ADZone(zone);
         int z = _zoneList.indexOf(f);
 
@@ -106,24 +106,24 @@ public class ADZoneTracker {
      */
      public ArrayList updateZone(int zone, boolean state) {
 
-        /** return a list of update zones */
+        // return a list of update zones
         ArrayList<Integer> updateList =  new ArrayList<Integer>();
 
-        /** add this zone */
+        // add this zone
         updateList.add(zone);
 
-        /** our list iterator */
+        // our list iterator
         ListIterator litr = _zoneList.listIterator();
 
-        /** zone exists so check for any pruning */
+        // zone exists so check for any pruning
         if(_zoneList.contains(new ADZone(zone))) {
-            /** go to our last zone updated */
+            // go to our last zone updated
             ADZone f = new ADZone(_lastZone);
             int z = _zoneList.indexOf(f);
 
             boolean bFoundLast = false;
 
-            /** look for any missing zones and clear them */
+            // look for any missing zones and clear them
             while ( !bFoundLast ) {
                ADZone zn;
 
@@ -134,13 +134,13 @@ public class ADZoneTracker {
                     break;
                 }
 
-                /** we found it so break out */
+                // we found it so break out
                 if( zn.getID() == _lastZone ) {
                     bFoundLast = true;
                 }
             }
 
-            /**
+            /*
              * Iterate through the rest till we reach the end or find our
              * new fault adding everything we find as we go to our remove list
              */
@@ -157,7 +157,7 @@ public class ADZoneTracker {
                 }
             }
 
-            /**
+            /*
              * start over if we didnt find the end and remove
              * everything we find till we do reach our current fault
              */
@@ -182,7 +182,7 @@ public class ADZoneTracker {
                  _zoneList.remove(zn);
              }
 
-         /** zone does not exist just get it into our list */
+         // zone does not exist just get it into our list
          } else {
 
              ADZone f = new ADZone(zone);
@@ -200,13 +200,13 @@ public class ADZoneTracker {
                  offset++;
              }
 
-             /** just add it */
+             // just add it
              if ( !bInserted ) {
                  _zoneList.add(f);
              }
          }
 
-         /** update our last touched zone */
+         // update our last touched zone
          _lastZone = zone;
 
          setZoneState(zone,state);
@@ -224,18 +224,18 @@ public class ADZoneTracker {
 
           ArrayList<Integer> updateList = new ArrayList<Integer>();
 
-          /** if we go ready clear all faults */
+          // if we go ready clear all faults
           if ( state && _lastReady != state ) {
-              /** copy our zones to our update list */
+              // copy our zones to our update list
               for (ADZone tz : _zoneList) {
                   updateList.add(tz.getID());
               }
-              /** now clear the list */
+              // now clear the list
               clearAll();
           }
           _lastReady = state;
 
-          /** return a list of update zones */
+          // return a list of update zones
           return updateList;
       }
 

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
@@ -220,7 +220,7 @@ public class ADZoneTracker {
       * @parm state - the current panel READY state
       * @return ArrayList of zones effected
       */
-      public ArrayList updateReadyState(boolean state) {
+      public ArrayList<Integer> updateReadyState(boolean state) {
 
           ArrayList<Integer> updateList = new ArrayList<Integer>();
 

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/ADZoneTracker.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  * message stream
  *
  * @author Sean Mathews <coder@f34r.com>
- * @since 1.6.0
+ * @since 1.9.0
  */
 public class ADZoneTracker {
 
@@ -42,16 +42,16 @@ public class ADZoneTracker {
     /**
      * get the state of a zone
      *
-     * @param Zone - the zone
+     * @param zone - the zone
      * @return return zone status or null if the zone is invalid
      *     -1 = unknown
      *      0 = restored
      *      1 = faulted
      */
-    public boolean getZoneState(int Zone) {
+    public boolean getZoneState(int zone) {
 
         /** find the zone in our List */
-        ADZone f = new ADZone(Zone);
+        ADZone f = new ADZone(zone);
         int z = _zoneList.indexOf(f);
 
         if ( z > -1 ) {
@@ -64,24 +64,24 @@ public class ADZoneTracker {
     /**
      * set the state of a zone
      *
-     * @param Zone  - the zone
-     * @param State - faulted or not boolean
+     * @param zone  - the zone
+     * @param state - faulted or not boolean
      * @return zone status
      *     -1 = unknown
      *      0 = restored
      *      1 = faulted
      */
-    public boolean setZoneState(int Zone, boolean State) {
+    public boolean setZoneState(int zone, boolean state) {
 
         /** find the zone in our List */
-        ADZone f = new ADZone(Zone);
+        ADZone f = new ADZone(zone);
         int z = _zoneList.indexOf(f);
 
         if ( z > -1 ) {
-            f.setState(State);
+            f.setState(state);
             f = _zoneList.set(z,f);
         } else {
-            f.setState(State);
+            f.setState(state);
             _zoneList.add(f);
         }
 
@@ -103,28 +103,28 @@ public class ADZoneTracker {
      * correct sequence and not modified from what the panel provides
      * to properly track zones
      *
-     * @param Zone  - the zone
-     * @param State - the state
+     * @param zone  - the zone
+     * @param state - the state
      * @return ArrayList of zones effected
      */
-     public ArrayList updateZone(int Zone, boolean State) {
+     public ArrayList updateZone(int zone, boolean state) {
 
         /** return a list of update zones */
         ArrayList<Integer> updateList =  new ArrayList<Integer>();
 
         /** add this zone */
-        updateList.add(Zone);
+        updateList.add(zone);
 
         /** our list iterator */
         ListIterator litr = _zoneList.listIterator();
 
         /** zone exists so check for any pruning */
-        if(_zoneList.contains(new ADZone(Zone))) {
+        if(_zoneList.contains(new ADZone(zone))) {
             /** go to our last zone updated */
             ADZone f = new ADZone(_lastZone);
             int z = _zoneList.indexOf(f);
 
-		    boolean bFoundLast = false;
+            boolean bFoundLast = false;
 
             /** look for any missing zones and clear them */
             while ( !bFoundLast ) {
@@ -139,7 +139,7 @@ public class ADZoneTracker {
 
                 /** we found it so break out */
                 if( zn.getID() == _lastZone ) {
-	               bFoundLast = true;
+                    bFoundLast = true;
                 }
             }
 
@@ -151,7 +151,7 @@ public class ADZoneTracker {
             boolean bFoundNew = false;
             while(litr.hasNext() && !bFoundNew) {
                 ADZone zn = (ADZone) litr.next();
-                if( zn.getID() == Zone ) {
+                if( zn.getID() == zone ) {
                     bFoundNew=true;
                     break;
                 } else {
@@ -168,7 +168,7 @@ public class ADZoneTracker {
                  litr = _zoneList.listIterator();
                  while(litr.hasNext() && !bFoundNew) {
                      ADZone zn = (ADZone) litr.next();
-                     if( zn.getID() == Zone ) {
+                     if( zn.getID() == zone ) {
                          bFoundNew=true;
                          break;
                      } else {
@@ -188,14 +188,14 @@ public class ADZoneTracker {
          /** zone does not exist just get it into our list */
          } else {
 
-             ADZone f = new ADZone(Zone);
+             ADZone f = new ADZone(zone);
 
              boolean bInserted=false;
              int offset=0;
              litr = _zoneList.listIterator();
              while(litr.hasNext()) {
                  ADZone zn = (ADZone) litr.next();
-                 if( zn.getID() > Zone ) {
+                 if( zn.getID() > zone ) {
                      _zoneList.add(offset, f);
                      bInserted=true;
                      break;
@@ -210,9 +210,9 @@ public class ADZoneTracker {
          }
 
          /** update our last touched zone */
-         _lastZone = Zone;
+         _lastZone = zone;
 
-         setZoneState(Zone,State);
+         setZoneState(zone,state);
 
          return updateList;
      }
@@ -220,15 +220,15 @@ public class ADZoneTracker {
      /**
       * Update panel Ready state clear zones if needed
       *
-      * @parm State - the current panel READY state
+      * @parm state - the current panel READY state
       * @return ArrayList of zones effected
       */
-      public ArrayList updateReadyState(boolean State) {
+      public ArrayList updateReadyState(boolean state) {
 
           ArrayList<Integer> updateList = new ArrayList<Integer>();
 
           /** if we go ready clear all faults */
-          if ( State && _lastReady != State ) {
+          if ( state && _lastReady != state ) {
               /** copy our zones to our update list */
               for (ADZone tz : _zoneList) {
                   updateList.add(tz.getID());
@@ -236,7 +236,7 @@ public class ADZoneTracker {
               /** now clear the list */
               clearAll();
           }
-          _lastReady = State;
+          _lastReady = state;
 
           /** return a list of update zones */
           return updateList;

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
@@ -85,6 +85,9 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
     // items have been updated. But where else to put per-item state?
     private HashMap<String, AlarmDecoderBindingConfig> m_unupdatedItems = new HashMap<String, AlarmDecoderBindingConfig>();
 
+    // zone state tracking ( zonetracker ) needed for Ademco panels to track onboard zones
+    private ADZoneTracker zoneTracker = new ADZoneTracker();
+
     @Override
     protected String getName() {
         return "AlarmDecoder binding";
@@ -270,7 +273,10 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
                     logger.error("{} has no mapping for command {}!", itemName, param);
                 } else {
                     String s = sendStr.replace("POUND", "#");
-                    m_writer.write(s);
+                    /** send out a \r\n every time to prevent AD2* from getting into a "greedy" char mode
+                     * such as with the 'L' command
+                     */
+                    m_writer.write(s + "\r\n");
                     m_writer.flush();
                 }
             }
@@ -453,11 +459,77 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
             int nbeeps = Integer.parseInt(parts.get(0).substring(6, 7));
             int lower = Integer.parseInt(parts.get(0).substring(7, 17), 2);
             int status = ((upper & 0x1F) << 13) | ((nbeeps & 0x3) << 10) | lower;
+
+            /**
+             *  if its a FAULT update our zone tracking for the zone.
+             *   TODO: Someone needs to send a * to the panel when it shows
+             *  "Press * for faults". If OpenHAB is connecting to an Ad2Pi
+             *  appliance running AlarmDecoders pre-done Linux Image
+             *  this is already done for you. If not we need to send a *
+             *  when we see "Hit * for faults" This will trigger the Ademco
+             *  panel to send a sequence of faults in order that we can track
+             *  for changes. For DSC alarms where we have all zones tied to EXP
+             *  messages this is not necessary but "should" still work.
+             */
+            if (parts.get(3).startsWith("FAULT",1) | parts.get(3).startsWith("CHECK",1)) {
+
+                /** must maintain sequene of FAULT messages from panel */
+                ArrayList updates = zoneTracker.updateZone(numeric,true);
+
+                /** update all bindings that match this exact zone 'XX' left padded with 0's */
+                for (Object temp : updates) {
+                    Integer i = (Integer)temp;
+
+                    /** skip updating zone 00. This can be used to track the last numeric zone */
+                    if( i > 0 ) {
+                        String dig2Zone = String.format("%02d", i);
+                        ArrayList<AlarmDecoderBindingConfig> bclt = getItems(ADMsgType.KPM, dig2Zone, "contact");
+                        for (AlarmDecoderBindingConfig ct : bclt) {
+                            logger.info("parseKeypadMessage:update({})", dig2Zone);
+
+                            /** get zone state or -1 if not existing */
+                            boolean bzs = zoneTracker.getZoneState(i);
+                            updateItem(ct, bzs == true ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                        }
+                    }
+                }
+            }
+
+            /** alarm panel READY bit tracking for zonetracking
+             * zone tracker state machine needs to know if we went "READY"
+             */
+            int readyBit = (status >> 17) & 0x1;
+            ArrayList updates = zoneTracker.updateReadyState( (readyBit>0) ); // boolean
+
+            /** update all bindings that match this exact zone 'XX' left padded with 0's */
+            for (Object temp : updates) {
+                Integer i = (Integer)temp;
+
+                /** skip updating zone 00. This can be used to track the last numeric zone */
+                if( i > 0 ) {
+                    String dig2Zone = String.format("%02d", i);
+                    ArrayList<AlarmDecoderBindingConfig> bclt = getItems(ADMsgType.KPM, dig2Zone, "contact");
+                    for (AlarmDecoderBindingConfig ct : bclt) {
+                        logger.info("parseKeypadMessage:update({})", dig2Zone);
+
+                        /** get zone state or -1 if not existing */
+                        boolean bzs = zoneTracker.getZoneState(i);
+                        updateItem(ct, bzs == true ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                    }
+                }
+            }
+
+
+            /** go over all KPM bindings and update them */
             ArrayList<AlarmDecoderBindingConfig> bcl = getItems(ADMsgType.KPM, null, null);
+
             for (AlarmDecoderBindingConfig c : bcl) {
-                if (c.hasFeature("zone")) {
+
+                /** update our last zone ID binding at address 00 only all other zones done above */
+                if (c.hasFeature("zone") && c.getAddress().equals("00") ) {
                     updateItem(c, new DecimalType(numeric));
                 } else if (c.hasFeature("text")) {
+                    /** update our "text" binding if we have one */
                     updateItem(c, new StringType(parts.get(3)));
                 } else if (c.hasFeature("beeps")) {
                     updateItem(c, new DecimalType(nbeeps));

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
@@ -273,7 +273,7 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
                     logger.error("{} has no mapping for command {}!", itemName, param);
                 } else {
                     String s = sendStr.replace("POUND", "#");
-                    /** send out a \r\n every time to prevent AD2* from getting into a "greedy" char mode
+                    /* send out a \r\n every time to prevent AD2* from getting into a "greedy" char mode
                      * such as with the 'L' command
                      */
                     m_writer.write(s + "\r\n");
@@ -460,7 +460,7 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
             int lower = Integer.parseInt(parts.get(0).substring(7, 17), 2);
             int status = ((upper & 0x1F) << 13) | ((nbeeps & 0x3) << 10) | lower;
 
-            /**
+            /*
              *  if its a FAULT update our zone tracking for the zone.
              *   TODO: Someone needs to send a * to the panel when it shows
              *  "Press * for faults". If OpenHAB is connecting to an Ad2Pi
@@ -473,21 +473,21 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
              */
             if (parts.get(3).startsWith("FAULT",1) | parts.get(3).startsWith("CHECK",1)) {
 
-                /** must maintain sequene of FAULT messages from panel */
+                // must maintain sequene of FAULT messages from panel
                 ArrayList updates = zoneTracker.updateZone(numeric,true);
 
-                /** update all bindings that match this exact zone 'XX' left padded with 0's */
+                // update all bindings that match this exact zone 'XX' left padded with 0's
                 for (Object temp : updates) {
                     Integer i = (Integer)temp;
 
-                    /** skip updating zone 00. This can be used to track the last numeric zone */
+                    // skip updating zone 00. This can be used to track the last numeric zone
                     if( i > 0 ) {
                         String dig2Zone = String.format("%02d", i);
                         ArrayList<AlarmDecoderBindingConfig> bclt = getItems(ADMsgType.KPM, dig2Zone, "contact");
                         for (AlarmDecoderBindingConfig ct : bclt) {
                             logger.info("parseKeypadMessage:update({})", dig2Zone);
 
-                            /** get zone state or -1 if not existing */
+                            // get zone state or -1 if not existing
                             boolean bzs = zoneTracker.getZoneState(i);
                             updateItem(ct, bzs == true ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
                         }
@@ -495,24 +495,24 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
                 }
             }
 
-            /** alarm panel READY bit tracking for zonetracking
+            /* alarm panel READY bit tracking for zonetracking
              * zone tracker state machine needs to know if we went "READY"
              */
             int readyBit = (status >> 17) & 0x1;
             ArrayList updates = zoneTracker.updateReadyState( (readyBit>0) ); // boolean
 
-            /** update all bindings that match this exact zone 'XX' left padded with 0's */
+            // update all bindings that match this exact zone 'XX' left padded with 0's
             for (Object temp : updates) {
                 Integer i = (Integer)temp;
 
-                /** skip updating zone 00. This can be used to track the last numeric zone */
+                // skip updating zone 00. This can be used to track the last numeric zone
                 if( i > 0 ) {
                     String dig2Zone = String.format("%02d", i);
                     ArrayList<AlarmDecoderBindingConfig> bclt = getItems(ADMsgType.KPM, dig2Zone, "contact");
                     for (AlarmDecoderBindingConfig ct : bclt) {
                         logger.info("parseKeypadMessage:update({})", dig2Zone);
 
-                        /** get zone state or -1 if not existing */
+                        // get zone state or -1 if not existing
                         boolean bzs = zoneTracker.getZoneState(i);
                         updateItem(ct, bzs == true ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
                     }
@@ -520,16 +520,15 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
             }
 
 
-            /** go over all KPM bindings and update them */
+            // go over all KPM bindings and update them
             ArrayList<AlarmDecoderBindingConfig> bcl = getItems(ADMsgType.KPM, null, null);
 
             for (AlarmDecoderBindingConfig c : bcl) {
 
-                /** update our last zone ID binding at address 00 only all other zones done above */
+                // update our last zone ID binding at address 00 only all other zones done above
                 if (c.hasFeature("zone") && c.getAddress().equals("00") ) {
                     updateItem(c, new DecimalType(numeric));
                 } else if (c.hasFeature("text")) {
-                    /** update our "text" binding if we have one */
                     updateItem(c, new StringType(parts.get(3)));
                 } else if (c.hasFeature("beeps")) {
                     updateItem(c, new DecimalType(nbeeps));

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
@@ -474,11 +474,10 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
             if (parts.get(3).startsWith("FAULT",1) | parts.get(3).startsWith("CHECK",1)) {
 
                 // must maintain sequene of FAULT messages from panel
-                ArrayList updates = zoneTracker.updateZone(numeric,true);
+                ArrayList<Integer> updates = zoneTracker.updateZone(numeric,true);
 
                 // update all bindings that match this exact zone 'XX' left padded with 0's
-                for (Object temp : updates) {
-                    Integer i = (Integer)temp;
+                for (Integer i : updates) {
 
                     // skip updating zone 00. This can be used to track the last numeric zone
                     if( i > 0 ) {

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
@@ -273,7 +273,8 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
                     logger.error("{} has no mapping for command {}!", itemName, param);
                 } else {
                     String s = sendStr.replace("POUND", "#");
-                    /* send out a \r\n every time to prevent AD2* from getting into a "greedy" char mode
+                    /*
+                     * send out a \r\n every time to prevent AD2* from getting into a "greedy" char mode
                      * such as with the 'L' command
                      */
                     m_writer.write(s + "\r\n");
@@ -461,26 +462,26 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
             int status = ((upper & 0x1F) << 13) | ((nbeeps & 0x3) << 10) | lower;
 
             /*
-             *  if its a FAULT update our zone tracking for the zone.
-             *   TODO: Someone needs to send a * to the panel when it shows
-             *  "Press * for faults". If OpenHAB is connecting to an Ad2Pi
-             *  appliance running AlarmDecoders pre-done Linux Image
-             *  this is already done for you. If not we need to send a *
-             *  when we see "Hit * for faults" This will trigger the Ademco
-             *  panel to send a sequence of faults in order that we can track
-             *  for changes. For DSC alarms where we have all zones tied to EXP
-             *  messages this is not necessary but "should" still work.
+             * if its a FAULT update our zone tracking for the zone.
+             * TODO: Someone needs to send a * to the panel when it shows
+             * "Press * for faults". If OpenHAB is connecting to an Ad2Pi
+             * appliance running AlarmDecoders pre-done Linux Image
+             * this is already done for you. If not we need to send a *
+             * when we see "Hit * for faults" This will trigger the Ademco
+             * panel to send a sequence of faults in order that we can track
+             * for changes. For DSC alarms where we have all zones tied to EXP
+             * messages this is not necessary but "should" still work.
              */
-            if (parts.get(3).startsWith("FAULT",1) | parts.get(3).startsWith("CHECK",1)) {
+            if (parts.get(3).startsWith("FAULT", 1) | parts.get(3).startsWith("CHECK", 1)) {
 
                 // must maintain sequene of FAULT messages from panel
-                ArrayList<Integer> updates = zoneTracker.updateZone(numeric,true);
+                ArrayList<Integer> updates = zoneTracker.updateZone(numeric, true);
 
                 // update all bindings that match this exact zone 'XX' left padded with 0's
                 for (Integer i : updates) {
 
                     // skip updating zone 00. This can be used to track the last numeric zone
-                    if( i > 0 ) {
+                    if (i > 0) {
                         String dig2Zone = String.format("%02d", i);
                         ArrayList<AlarmDecoderBindingConfig> bclt = getItems(ADMsgType.KPM, dig2Zone, "contact");
                         for (AlarmDecoderBindingConfig ct : bclt) {
@@ -494,18 +495,19 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
                 }
             }
 
-            /* alarm panel READY bit tracking for zonetracking
+            /*
+             * alarm panel READY bit tracking for zonetracking
              * zone tracker state machine needs to know if we went "READY"
              */
             int readyBit = (status >> 17) & 0x1;
-            ArrayList updates = zoneTracker.updateReadyState( (readyBit>0) ); // boolean
+            ArrayList updates = zoneTracker.updateReadyState((readyBit > 0)); // boolean
 
             // update all bindings that match this exact zone 'XX' left padded with 0's
             for (Object temp : updates) {
-                Integer i = (Integer)temp;
+                Integer i = (Integer) temp;
 
                 // skip updating zone 00. This can be used to track the last numeric zone
-                if( i > 0 ) {
+                if (i > 0) {
                     String dig2Zone = String.format("%02d", i);
                     ArrayList<AlarmDecoderBindingConfig> bclt = getItems(ADMsgType.KPM, dig2Zone, "contact");
                     for (AlarmDecoderBindingConfig ct : bclt) {
@@ -518,14 +520,13 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
                 }
             }
 
-
             // go over all KPM bindings and update them
             ArrayList<AlarmDecoderBindingConfig> bcl = getItems(ADMsgType.KPM, null, null);
 
             for (AlarmDecoderBindingConfig c : bcl) {
 
                 // update our last zone ID binding at address 00 only all other zones done above
-                if (c.hasFeature("zone") && c.getAddress().equals("00") ) {
+                if (c.hasFeature("zone") && c.getAddress().equals("00")) {
                     updateItem(c, new DecimalType(numeric));
                 } else if (c.hasFeature("text")) {
                     updateItem(c, new StringType(parts.get(3)));

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.alarmdecoder.internal.model;
+
+/**
+ * A class to hold our zone state
+ *
+ * @author Sean Mathews <coder@f34r.com>
+ * @since 1.6.0
+ */
+
+public class ADZone {
+
+    private int _id = 0;
+    private double _ts = 0;
+    private boolean _state = false;
+
+    /**
+     * Constructor
+     *
+     * @param id - the zone id int type;
+     */
+    public ADZone(int id) {
+        _id = id;
+        _state = false;
+        _ts = System.nanoTime();
+    }
+
+    public void updateTime() {
+        _ts = System.nanoTime();
+    }
+
+    /**
+     * return diff of zone time and provided time in seconds.
+     * time is stored in nanoseconds
+     *
+     * @param ts
+     * @return double the time difference
+     */
+    public double timeDiff(double ts) {
+        return (ts - _ts) / 1000000000;
+    }
+
+    /**
+     * return zone state
+     *
+     * @return boolean - state of zone
+     */
+    public boolean getState() {
+        return _state;
+    }
+
+    /**
+     * set zone state
+     *
+     * @param state - new state
+     */
+    public void setState(boolean state) {
+        _state = state;
+    }
+
+    /**
+     * return zone ID
+     *
+     * @return int - state of zone
+     */
+    public int getID() {
+        return _id;
+    }
+
+
+    /**
+     * return diff of zone time and provided time in seconds.
+     * time is stored in nanoseconds
+     *
+     * @param Object to search
+     * @return double the time difference
+     */
+    @Override
+    public boolean equals(Object object) {
+        boolean equals = false;
+
+        if (object != null && object instanceof ADZone)
+        {
+            equals = this._id == ((ADZone) object)._id;
+        }
+
+        return equals;
+    }
+}

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
@@ -13,12 +13,13 @@ package org.openhab.binding.alarmdecoder.internal.model;
  *
  * @author Sean Mathews <coder@f34r.com>
  * @since 1.9.0
+ *
+ * TODO: add timeouts
  */
 
 public class ADZone {
 
     private int _id = 0;
-    private long _ts = 0;
     private boolean _state = false;
 
     /**
@@ -29,22 +30,6 @@ public class ADZone {
     public ADZone(int id) {
         _id = id;
         _state = false;
-        _ts = System.nanoTime();
-    }
-
-    public void updateTime() {
-        _ts = System.nanoTime();
-    }
-
-    /**
-     * return diff of zone time and provided time in seconds.
-     * time is stored in nanoseconds
-     *
-     * @param ts
-     * @return double the time difference
-     */
-    public double timeDiff(double ts) {
-        return (ts - _ts) / 1000000000;
     }
 
     /**
@@ -76,11 +61,9 @@ public class ADZone {
 
 
     /**
-     * return diff of zone time and provided time in seconds.
-     * time is stored in nanoseconds
+     * return true if this object equals another based upon ID
      *
-     * @param Object to search
-     * @return double the time difference
+     * @param Object to compare
      */
     @Override
     public boolean equals(Object object) {

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
@@ -14,7 +14,7 @@ package org.openhab.binding.alarmdecoder.internal.model;
  * @author Sean Mathews <coder@f34r.com>
  * @since 1.9.0
  *
- * TODO: add timeouts
+ *        TODO: add timeouts
  */
 
 public class ADZone {
@@ -59,7 +59,6 @@ public class ADZone {
         return _id;
     }
 
-
     /**
      * return true if this object equals another based upon ID
      *
@@ -69,8 +68,7 @@ public class ADZone {
     public boolean equals(Object object) {
         boolean equals = false;
 
-        if (object != null && object instanceof ADZone)
-        {
+        if (object != null && object instanceof ADZone) {
             equals = this._id == ((ADZone) object)._id;
         }
 

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
@@ -12,7 +12,7 @@ package org.openhab.binding.alarmdecoder.internal.model;
  * A class to hold our zone state
  *
  * @author Sean Mathews <coder@f34r.com>
- * @since 1.6.0
+ * @since 1.9.0
  */
 
 public class ADZone {

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/model/ADZone.java
@@ -18,7 +18,7 @@ package org.openhab.binding.alarmdecoder.internal.model;
 public class ADZone {
 
     private int _id = 0;
-    private double _ts = 0;
+    private long _ts = 0;
     private boolean _state = false;
 
     /**


### PR DESCRIPTION
I added support for zone tracking for Ademco panels where we do not get RESTORE messages. Not needed with DSC where all zone faults eject EXP messages. This expects something is sending a \* to the panel if we see 'Hit \* for faults'. A rule will do this just be sure only one system does. The AlarmDecoder web app also sends the \* so if you are connecting over ser2sock to an AD2 appliance no rule would be needed. I suppose someone could also go to a real keypad and just press \* :)
When \* is pressed on an Ademco panel it will dump a zone fault list in a consistent order allowing to watch for zones "disappearing" from the fault and thus being restored. Did some testing but it could use more I am sure.

This also allows for more advanced features such as Virtual Zones on your panel where you can have the alarm panel use an external sensor as its own.

1001 will send a "L331" faulting virtual zone 33 and 1002 will send a L330 to the AD2\* to restore the zone.

Number alarmPanelL33X "" (gPanel)   {alarmdecoder="SEND#1001=L331,1002=L330", autoupdate="false"}

only supports Contact types at this time. The ZONE 00 still works to track the last NUMERIC/ZONE ID but using a real zone number like 03 and 24 in this example.
Contact ZONE03_FAULT      "zone fault: [%d]" (gPanel)      {alarmdecoder="KPM:03#zone"}
Contact ZONE24_FAULT      "zone fault: [%d]" (gPanel)      {alarmdecoder="KPM:24#zone"}

Enjoy!
