### PR TITLE
Improved the reconnect behaviour of CULNetworkHandlerImpl

### DIFF
--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/CULLifecycleManager.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/CULLifecycleManager.java
@@ -69,6 +69,7 @@ public class CULLifecycleManager {
 
     public void open() {
         if (config == null || (cul != null && config.equals(cul.getConfig()))) {
+            logger.warn("CUL config is NULL, doing nothing");
             return;
         }
 

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
@@ -8,10 +8,6 @@
  */
 package org.openhab.io.transport.cul.internal;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
@@ -108,8 +104,6 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
 
     protected Queue<String> sendQueue = new ConcurrentLinkedQueue<String>();
     protected int credit10ms = 0;
-    protected BufferedReader br;
-    protected BufferedWriter bw;
 
     protected AbstractCULHandler(T config) {
         this.config = config;
@@ -157,6 +151,8 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
      * Close the connection to the hardware and clean up all resources.
      */
     protected abstract void closeHardware();
+
+    protected abstract void write(String command);
 
     @Override
     public void send(String command) {
@@ -210,45 +206,21 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
      * @throws CULCommunicationException
      *             if
      */
-    protected void processNextLine() throws CULCommunicationException {
-        String deviceName = config.getDeviceAddress();
-        try {
-            String data = br.readLine();
-            if (data == null) {
-                String msg = "EOF encountered for " + deviceName;
-                log.error(msg);
-                throw new CULCommunicationException(msg);
-            }
-
-            log.debug("Received raw message from CUL: " + data);
-            if ("EOB".equals(data)) {
-                log.warn("(EOB) End of Buffer. Last message lost. Try sending less messages per time slot to the CUL");
-                return;
-            } else if ("LOVF".equals(data)) {
-                log.warn(
-                        "(LOVF) Limit Overflow: Last message lost. You are using more than 1% transmitting time. Reduce the number of rf messages");
-                return;
-            } else if (data.matches("^\\d+\\s+\\d+")) {
-                processCreditReport(data);
-                return;
-            }
-            notifyDataReceived(data);
-            requestCreditReport();
-        } catch (SocketException e) {
-            try {
-                this.openHardware();
-            } catch (CULDeviceException e1) {
-                log.error("Exception while reading from CUL port " + deviceName, e);
-                notifyError(e);
-
-                throw new CULCommunicationException(e);
-            }
-        } catch (IOException e) {
-            log.error("Exception while reading from CUL port " + deviceName, e);
-            notifyError(e);
-
-            throw new CULCommunicationException(e);
+    protected void processNextLine(String data) {
+        log.debug("Received raw message from CUL: " + data);
+        if ("EOB".equals(data)) {
+            log.warn("(EOB) End of Buffer. Last message lost. Try sending less messages per time slot to the CUL");
+            return;
+        } else if ("LOVF".equals(data)) {
+            log.warn(
+                    "(LOVF) Limit Overflow: Last message lost. You are using more than 1% transmitting time. Reduce the number of rf messages");
+            return;
+        } else if (data.matches("^\\d+\\s+\\d+")) {
+            processCreditReport(data);
+            return;
         }
+        notifyDataReceived(data);
+        requestCreditReport();
     }
 
     /**
@@ -280,12 +252,7 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
     private void requestCreditReport() {
         /* this requests a report which provides credit10ms */
         log.debug("Requesting credit report");
-        try {
-            bw.write("X\r\n");
-            bw.flush();
-        } catch (IOException e) {
-            log.error("Can't write report command to CUL", e);
-        }
+        write("X\r\n");
     }
 
     /**
@@ -295,21 +262,8 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
      * @throws CULCommunicationException
      */
     private void writeMessage(String message) throws CULCommunicationException {
-        String deviceName = config.getDeviceAddress();
-        log.debug("Sending raw message to CUL " + deviceName + ":  '" + message + "'");
-        if (bw == null) {
-            log.error("Can't write message, BufferedWriter is NULL");
-        }
-        synchronized (bw) {
-            try {
-                bw.write(message);
-                bw.flush();
-            } catch (IOException e) {
-                log.error("Can't write to CUL " + deviceName, e);
-            }
-
-            requestCreditReport();
-        }
+        write(message);
+        requestCreditReport();
     }
 
     @Override

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/network/CULNetworkHandlerImpl.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/network/CULNetworkHandlerImpl.java
@@ -8,18 +8,24 @@
  */
 package org.openhab.io.transport.cul.internal.network;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.net.Socket;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.Charset;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.openhab.io.transport.cul.CULCommunicationException;
+import org.apache.commons.lang.StringUtils;
 import org.openhab.io.transport.cul.CULDeviceException;
 import org.openhab.io.transport.cul.internal.AbstractCULHandler;
 import org.openhab.io.transport.cul.internal.CULConfig;
@@ -31,58 +37,35 @@ import org.slf4j.LoggerFactory;
  * (CUN for example).
  *
  * @author Markus Heberling
+ * @author Till Klocke
  * @since 1.5.0
  */
-public class CULNetworkHandlerImpl extends AbstractCULHandler<CULNetworkConfig> {
+public class CULNetworkHandlerImpl extends AbstractCULHandler<CULNetworkConfig>implements Runnable {
 
     private static final int CUN_DEFAULT_PORT = 2323;
 
-    /**
-     * Thread which receives all data from the CUL.
-     *
-     * @author Markus Heberling
-     * @since 1.5.0
-     *
-     */
-    private class ReceiveThread extends Thread {
+    protected static final Logger logger = LoggerFactory.getLogger(CULNetworkHandlerImpl.class);
+    private static final long INITIAL_RECONNECT_INTERVAL = 500; // 500 ms.
+    private static final long MAXIMUM_RECONNECT_INTERVAL = 30000; // 30 sec.
+    private static final int READ_BUFFER_SIZE = 2048;
+    private static final int WRITE_BUFFER_SIZE = 2048;
 
-        private final Logger logger = LoggerFactory.getLogger(ReceiveThread.class);
+    private long reconnectInterval = INITIAL_RECONNECT_INTERVAL;
 
-        /**
-         * Mark this thread
-         */
-        ReceiveThread() {
-            super("CUL ReceiveThread");
-        }
+    private ByteBuffer readBuf = ByteBuffer.allocateDirect(READ_BUFFER_SIZE);
+    private ByteBuffer writeBuf = ByteBuffer.allocateDirect(WRITE_BUFFER_SIZE);
 
-        @Override
-        public void run() {
+    private final Thread thread = new Thread(this);
+    private SocketAddress address;
 
-            try {
-                while (!isInterrupted()) {
-                    processNextLine();
+    private Selector selector;
+    private SocketChannel channel;
 
-                    try {
-                        Thread.sleep(10);
-                    } catch (InterruptedException e) {
-                        logger.debug("Error while sleeping in ReceiveThread", e);
-                    }
-                }
-                logger.debug("ReceiveThread exiting.");
-            } catch (CULCommunicationException e) {
-                log.error("Connection to CUL broken, terminating receive thread for " + config.getDeviceAddress());
-            }
-        }
+    private final AtomicBoolean connected = new AtomicBoolean(false);
 
-    }
-
-    final static Logger log = LoggerFactory.getLogger(CULNetworkHandlerImpl.class);
-
-    private ReceiveThread receiveThread;
-
-    private Socket socket;
-    private InputStream is;
-    private OutputStream os;
+    private StringBuffer commandBuffer = new StringBuffer();
+    // Encoding for text based CUN protocol
+    private Charset cs = Charset.forName("ASCII");
 
     /**
      * Constructor including property map for specific configuration. Just for
@@ -97,57 +80,256 @@ public class CULNetworkHandlerImpl extends AbstractCULHandler<CULNetworkConfig> 
     @Override
     protected void openHardware() throws CULDeviceException {
         String deviceName = config.getDeviceAddress();
-        log.debug("Opening network CUL connection for " + deviceName);
+        logger.debug("Trying to open CUN with deviceName {}", deviceName);
+        URI uri;
         try {
-            URI uri = new URI("cul://" + deviceName);
+            uri = new URI("cul://" + deviceName);
             String host = uri.getHost();
             int port = uri.getPort() == -1 ? CUN_DEFAULT_PORT : uri.getPort();
 
             if (uri.getHost() == null || uri.getPort() == -1) {
                 throw new CULDeviceException("Could not parse host:port from " + deviceName);
             }
-            log.debug("Opening network CUL connection to " + host + ":" + port);
-            socket = new Socket(host, port);
-            log.info("Connected network CUL connection to " + host + ":" + port);
-            is = socket.getInputStream();
-            os = socket.getOutputStream();
-            br = new BufferedReader(new InputStreamReader(is));
-            bw = new BufferedWriter(new OutputStreamWriter(os));
-
-            log.debug("Starting network listener Thread");
-            receiveThread = new ReceiveThread();
-            receiveThread.start();
-        } catch (IOException e) {
-            throw new CULDeviceException(e);
+            this.address = new InetSocketAddress(host, port);
         } catch (URISyntaxException e) {
             throw new CULDeviceException("Could not parse host:port from " + deviceName, e);
         }
 
+        thread.start();
+        // Only return when we are connected, as soon as this method returns this Handler
+        // is considered ready.
+        while (!connected.get()) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+        }
     }
 
     @Override
     protected void closeHardware() {
-        receiveThread.interrupt();
+        thread.interrupt();
+    }
 
-        log.debug("Closing network device " + config.getDeviceAddress());
-
+    @Override
+    protected void write(String command) {
+        ByteBuffer buf = cs.encode(command);
         try {
-            if (br != null) {
-                br.close();
-            }
-            if (bw != null) {
-                bw.close();
-            }
+            send(buf);
+        } catch (InterruptedException e) {
+            logger.error("InterruptedException when sending command", e);
         } catch (IOException e) {
-            log.error("Can't close the input and output streams propberly", e);
-        } finally {
-            if (socket != null) {
-                try {
-                    socket.close();
-                } catch (IOException e) {
-                    log.error("Can't close the socket propberly", e);
+            logger.error("IOException when sending command", e);
+        }
+    }
+
+    private void send(ByteBuffer buffer) throws InterruptedException, IOException {
+        if (!connected.get()) {
+            throw new IOException("not connected");
+        }
+        synchronized (writeBuf) {
+            // try direct write of what's in the buffer to free up space
+            if (writeBuf.remaining() < buffer.remaining()) {
+                writeBuf.flip();
+                int bytesOp = 0, bytesTotal = 0;
+                while (writeBuf.hasRemaining() && (bytesOp = channel.write(writeBuf)) > 0) {
+                    bytesTotal += bytesOp;
+                }
+                writeBuf.compact();
+                logger.debug("Written {} bytes to the network", bytesTotal);
+            }
+
+            // if didn't help, wait till some space appears
+            if (Thread.currentThread().getId() != thread.getId()) {
+                while (writeBuf.remaining() < buffer.remaining()) {
+                    writeBuf.wait();
+                }
+            } else {
+                if (writeBuf.remaining() < buffer.remaining()) {
+                    throw new IOException("send buffer full"); // TODO: add reallocation or buffers chain
                 }
             }
+            writeBuf.put(buffer);
+
+            // try direct write to decrease the latency
+            writeBuf.flip();
+            int bytesOp = 0, bytesTotal = 0;
+            while (writeBuf.hasRemaining() && (bytesOp = channel.write(writeBuf)) > 0) {
+                bytesTotal += bytesOp;
+            }
+            writeBuf.compact();
+            logger.debug("Written {} bytes to the network", bytesTotal);
+
+            if (writeBuf.hasRemaining()) {
+                SelectionKey key = channel.keyFor(selector);
+                key.interestOps(key.interestOps() | SelectionKey.OP_WRITE);
+                selector.wakeup();
+            }
+        }
+    }
+
+    private void configureChannel(SocketChannel channel) throws IOException {
+        channel.configureBlocking(false);
+        channel.socket().setSendBufferSize(0x100000); // 1Mb
+        channel.socket().setReceiveBufferSize(0x100000); // 1Mb
+        channel.socket().setKeepAlive(true);
+        channel.socket().setReuseAddress(true);
+        channel.socket().setSoLinger(false, 0);
+        channel.socket().setSoTimeout(0);
+        channel.socket().setTcpNoDelay(true);
+    }
+
+    @Override
+    public void run() {
+        logger.info("event loop running");
+        try {
+            while (!Thread.interrupted()) { // reconnection loop
+                try {
+                    selector = Selector.open();
+                    channel = SocketChannel.open();
+                    configureChannel(channel);
+
+                    channel.connect(address);
+                    channel.register(selector, SelectionKey.OP_CONNECT);
+
+                    while (!thread.isInterrupted() && channel.isOpen()) { // events multiplexing loop
+                        if (selector.select() > 0) {
+                            processSelectedKeys(selector.selectedKeys());
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.error("exception", e);
+                } finally {
+                    connected.set(false);
+                    onDisconnected();
+                    writeBuf.clear();
+                    readBuf.clear();
+                    if (channel != null) {
+                        channel.close();
+                    }
+                    if (selector != null) {
+                        selector.close();
+                    }
+                    logger.info("connection closed");
+                }
+
+                try {
+                    Thread.sleep(reconnectInterval);
+                    if (reconnectInterval < MAXIMUM_RECONNECT_INTERVAL) {
+                        reconnectInterval *= 2;
+                    }
+                    logger.info("reconnecting to {}", address);
+                } catch (InterruptedException e) {
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            logger.error("unrecoverable error", e);
+        }
+
+        logger.info("event loop terminated");
+    }
+
+    private void onDisconnected() {
+        logger.info("Disconnected from {}", address);
+
+    }
+
+    private void processSelectedKeys(Set<SelectionKey> keys) throws Exception {
+        Iterator<SelectionKey> itr = keys.iterator();
+        while (itr.hasNext()) {
+            SelectionKey key = itr.next();
+            if (key.isReadable()) {
+                processRead(key);
+            }
+            if (key.isWritable()) {
+                processWrite(key);
+            }
+            if (key.isConnectable()) {
+                processConnect(key);
+            }
+            if (key.isAcceptable()) {
+                ;
+            }
+            itr.remove();
+        }
+    }
+
+    private void processConnect(SelectionKey key) throws Exception {
+        SocketChannel ch = (SocketChannel) key.channel();
+        if (ch.finishConnect()) {
+            key.interestOps(key.interestOps() ^ SelectionKey.OP_CONNECT);
+            key.interestOps(key.interestOps() | SelectionKey.OP_READ);
+            reconnectInterval = INITIAL_RECONNECT_INTERVAL;
+            connected.set(true);
+            onConnected();
+        }
+    }
+
+    private void onConnected() {
+        logger.info("Connected to CUN ({})", address);
+
+    }
+
+    private void processRead(SelectionKey key) throws Exception {
+        ReadableByteChannel ch = (ReadableByteChannel) key.channel();
+
+        int bytesOp = 0, bytesTotal = 0;
+        while (readBuf.hasRemaining() && (bytesOp = ch.read(readBuf)) > 0) {
+            bytesTotal += bytesOp;
+        }
+        logger.debug("Read {} bytes from network", bytesTotal);
+
+        if (bytesTotal > 0) {
+            readBuf.flip();
+            onRead(readBuf);
+            readBuf.compact();
+        } else if (bytesOp == -1) {
+            logger.info("peer closed read channel");
+            ch.close();
+        }
+    }
+
+    private void onRead(ByteBuffer readBuf) {
+        CharBuffer charBuf = cs.decode(readBuf);
+        while (charBuf.hasRemaining()) {
+            char currentChar = charBuf.get();
+            if (currentChar == '\r' || currentChar == '\n') {
+                String command = commandBuffer.toString();
+                if (!StringUtils.isEmpty(command)) {
+                    processNextLine(command);
+                }
+                commandBuffer = new StringBuffer();
+            } else {
+                commandBuffer.append(currentChar);
+            }
+        }
+    }
+
+    private void processWrite(SelectionKey key) throws IOException {
+        WritableByteChannel ch = (WritableByteChannel) key.channel();
+        synchronized (writeBuf) {
+            writeBuf.flip();
+
+            int bytesOp = 0, bytesTotal = 0;
+            while (writeBuf.hasRemaining() && (bytesOp = ch.write(writeBuf)) > 0) {
+                bytesTotal += bytesOp;
+            }
+            logger.debug("Written {} bytes to the network", bytesTotal);
+
+            if (writeBuf.remaining() == 0) {
+                key.interestOps(key.interestOps() ^ SelectionKey.OP_WRITE);
+            }
+
+            if (bytesTotal > 0) {
+                writeBuf.notify();
+            } else if (bytesOp == -1) {
+                logger.info("peer closed write channel");
+                ch.close();
+            }
+
+            writeBuf.compact();
         }
     }
 }

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/serial/CULSerialHandlerImpl.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/serial/CULSerialHandlerImpl.java
@@ -17,7 +17,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.TooManyListenersException;
 
-import org.openhab.io.transport.cul.CULCommunicationException;
 import org.openhab.io.transport.cul.CULDeviceException;
 import org.openhab.io.transport.cul.internal.AbstractCULHandler;
 import org.openhab.io.transport.cul.internal.CULConfig;
@@ -49,6 +48,9 @@ public class CULSerialHandlerImpl extends AbstractCULHandler<CULSerialConfig>imp
     private InputStream is;
     private OutputStream os;
 
+    private BufferedWriter bw;
+    private BufferedReader br;
+
     /**
      * Constructor including property map for specific configuration.
      *
@@ -63,9 +65,10 @@ public class CULSerialHandlerImpl extends AbstractCULHandler<CULSerialConfig>imp
     public void serialEvent(SerialPortEvent event) {
         if (event.getEventType() == SerialPortEvent.DATA_AVAILABLE) {
             try {
-                processNextLine();
-            } catch (CULCommunicationException e) {
-                log.error("Serial CUL connection read failed for " + config.getDeviceAddress());
+                String line = br.readLine();
+                processNextLine(line);
+            } catch (IOException e) {
+                log.error("Can't read from serial device {}", config.getDeviceName(), e);
             }
         }
     }
@@ -131,6 +134,16 @@ public class CULSerialHandlerImpl extends AbstractCULHandler<CULSerialConfig>imp
             }
         }
 
+    }
+
+    @Override
+    protected void write(String command) {
+        try {
+            bw.write(command);
+            bw.flush();
+        } catch (IOException e) {
+            log.error("Can't write to serial device {}", config.getDeviceName(), e);
+        }
     }
 
 }

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/serial/CULSerialHandlerImpl.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/serial/CULSerialHandlerImpl.java
@@ -45,8 +45,6 @@ public class CULSerialHandlerImpl extends AbstractCULHandler<CULSerialConfig>imp
     private final static Logger log = LoggerFactory.getLogger(CULSerialHandlerImpl.class);
 
     private SerialPort serialPort;
-    private InputStream is;
-    private OutputStream os;
 
     private BufferedWriter bw;
     private BufferedReader br;
@@ -91,8 +89,8 @@ public class CULSerialHandlerImpl extends AbstractCULHandler<CULSerialConfig>imp
 
             serialPort.setSerialPortParams(config.getBaudRate(), SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
                     config.getParityMode());
-            is = serialPort.getInputStream();
-            os = serialPort.getOutputStream();
+            InputStream is = serialPort.getInputStream();
+            OutputStream os = serialPort.getOutputStream();
             br = new BufferedReader(new InputStreamReader(is));
             bw = new BufferedWriter(new OutputStreamWriter(os));
 


### PR DESCRIPTION
This Pull Request addresses the issues described in #4035. I replaced the current implementation of CULNetworkHandlerImpl with a nio based one to simplify handling of connection errors. 
To enable this change slight changes in other components of the CUL transport were necessary. Mainly the responsibility of low level communication is now in the respective handler implementations and not in the AbstractCULHandler any more.
