### PR TITLE
New Binding: Girahomeserver Co-Binding

### DIFF
--- a/bundles/binding/org.openhab.binding.girahomeserver/.classpath
+++ b/bundles/binding/org.openhab.binding.girahomeserver/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/binding/org.openhab.binding.girahomeserver/.project
+++ b/bundles/binding/org.openhab.binding.girahomeserver/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.girahomeserver</name>
+	<comment>This is the GiraHomeServer binding of the open Home Automation Bus (openHAB)</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/binding/org.openhab.binding.girahomeserver/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.girahomeserver/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB GiraHomeServer Binding
 Bundle-SymbolicName: org.openhab.binding.girahomeserver
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.8.0-SNAPSHOT.qualifier
+Bundle-Version: 1.9.0.qualifier
+Bundle-Activator: org.openhab.binding.girahomeserver.internal.GiraHomeServerActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the GiraHomeServer binding of the open Home Aut
  omation Bus (openHAB)
@@ -18,9 +19,11 @@ Import-Package: org.apache.commons.lang,
  org.openhab.core.types,
  org.openhab.model.item.binding,
  org.osgi.framework,
+ org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.event,
  org.slf4j
+Bundle-SymbolicName: org.openhab.binding.girahomeserver
 Export-Package: org.openhab.binding.girahomeserver
 Bundle-DocURL: http://www.openhab.org
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/bundles/binding/org.openhab.binding.girahomeserver/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.girahomeserver/META-INF/MANIFEST.MF
@@ -1,0 +1,28 @@
+Manifest-Version: 1.0
+Private-Package: org.openhab.binding.girahomeserver.internal
+Ignore-Package: org.openhab.binding.girahomeserver.internal
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-Name: openHAB GiraHomeServer Binding
+Bundle-SymbolicName: org.openhab.binding.girahomeserver
+Bundle-Vendor: openHAB.org
+Bundle-Version: 1.8.0-SNAPSHOT.qualifier
+Bundle-ManifestVersion: 2
+Bundle-Description: This is the GiraHomeServer binding of the open Home Aut
+ omation Bus (openHAB)
+Import-Package: org.apache.commons.lang,
+ org.openhab.core.binding,
+ org.openhab.core.events,
+ org.openhab.core.items,
+ org.openhab.core.library.items,
+ org.openhab.core.library.types,
+ org.openhab.core.types,
+ org.openhab.model.item.binding,
+ org.osgi.framework,
+ org.osgi.service.component,
+ org.osgi.service.event,
+ org.slf4j
+Export-Package: org.openhab.binding.girahomeserver
+Bundle-DocURL: http://www.openhab.org
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Service-Component: OSGI-INF/binding.xml, OSGI-INF/genericbindingprovider.xml
+Bundle-ClassPath: .

--- a/bundles/binding/org.openhab.binding.girahomeserver/OSGI-INF/binding.xml
+++ b/bundles/binding/org.openhab.binding.girahomeserver/OSGI-INF/binding.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010-2015, openHAB.org and others.
+    Copyright (c) 2016, openHAB.org and others.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -9,18 +9,22 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" modified="modified" deactivate="deactivate" name="org.openhab.binding.girahomeserver.binding" immediate="true" configuration-pid="org.openhab.girahomeserver" configuration-policy="optional">
-	<implementation class="org.openhab.binding.girahomeserver.internal.GiraHomeServerBinding" />
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" modified="modified" deactivate="deactivate" name="org.openhab.binding.girahomeserver" 
+        immediate="true" configuration-pid="org.openhab.girahomeserver" configuration-policy="optional">
+	<implementation class="org.openhab.binding.girahomeserver.internal.GiraHomeServerBinding" ></implementation>
 
 	<service>
-		<provide interface="org.osgi.service.event.EventHandler" />
+	   <provide interface="org.osgi.service.cm.ManagedService"/> 
+	   <provide interface="org.osgi.service.event.EventHandler" /> 
 	</service>
 
-	<property name="event.topics" type="String" value="openhab/command/*" />
+    <property name="service.pid" type="String" value="org.openhab.girahomeserver" />
+	<property name="event.topics" type="String" value="openhab/*"/>
 
 	<reference bind="setEventPublisher" cardinality="1..1"
 		interface="org.openhab.core.events.EventPublisher" name="EventPublisher"
 		policy="dynamic" unbind="unsetEventPublisher" />
+		
 	<reference bind="addBindingProvider" cardinality="1..n"
 		interface="org.openhab.binding.girahomeserver.GiraHomeServerBindingProvider" name="GiraHomeServerBindingProvider"
 		policy="dynamic" unbind="removeBindingProvider" />

--- a/bundles/binding/org.openhab.binding.girahomeserver/OSGI-INF/binding.xml
+++ b/bundles/binding/org.openhab.binding.girahomeserver/OSGI-INF/binding.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2015, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" modified="modified" deactivate="deactivate" name="org.openhab.binding.girahomeserver.binding" immediate="true" configuration-pid="org.openhab.girahomeserver" configuration-policy="optional">
+	<implementation class="org.openhab.binding.girahomeserver.internal.GiraHomeServerBinding" />
+
+	<service>
+		<provide interface="org.osgi.service.event.EventHandler" />
+	</service>
+
+	<property name="event.topics" type="String" value="openhab/command/*" />
+
+	<reference bind="setEventPublisher" cardinality="1..1"
+		interface="org.openhab.core.events.EventPublisher" name="EventPublisher"
+		policy="dynamic" unbind="unsetEventPublisher" />
+	<reference bind="addBindingProvider" cardinality="1..n"
+		interface="org.openhab.binding.girahomeserver.GiraHomeServerBindingProvider" name="GiraHomeServerBindingProvider"
+		policy="dynamic" unbind="removeBindingProvider" />
+	
+</scr:component>

--- a/bundles/binding/org.openhab.binding.girahomeserver/OSGI-INF/genericbindingprovider.xml
+++ b/bundles/binding/org.openhab.binding.girahomeserver/OSGI-INF/genericbindingprovider.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2015, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.binding.girahomeserver.genericbindingprovider">
+   <implementation class="org.openhab.binding.girahomeserver.internal.GiraHomeServerGenericBindingProvider"/>
+   
+   <service>
+      <provide interface="org.openhab.model.item.binding.BindingConfigReader"/>
+      <provide interface="org.openhab.binding.girahomeserver.GiraHomeServerBindingProvider"/>
+   </service>
+   
+</scr:component>

--- a/bundles/binding/org.openhab.binding.girahomeserver/OSGI-INF/genericbindingprovider.xml
+++ b/bundles/binding/org.openhab.binding.girahomeserver/OSGI-INF/genericbindingprovider.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010-2015, openHAB.org and others.
+    Copyright (c) 2016, openHAB.org and others.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.girahomeserver/build.properties
+++ b/bundles/binding/org.openhab.binding.girahomeserver/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/,\
+           src/main/resources/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/
+output.. = target/classes/

--- a/bundles/binding/org.openhab.binding.girahomeserver/pom.xml
+++ b/bundles/binding/org.openhab.binding.girahomeserver/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.openhab.bundles</groupId>
+		<artifactId>binding</artifactId>
+		<version>1.8.0-SNAPSHOT-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<bundle.symbolicName>org.openhab.binding.girahomeserver</bundle.symbolicName>
+		<bundle.namespace>org.openhab.binding.girahomeserver</bundle.namespace>
+		<deb.name>openhab-addon-binding-GiraHomeServer</deb.name>
+		<deb.description>${project.name}</deb.description>
+	</properties>
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openhab.binding</groupId>
+	<artifactId>org.openhab.binding.girahomeserver</artifactId>
+
+	<name>openHAB GiraHomeServer Binding</name>
+
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.vafer</groupId>
+				<artifactId>jdeb</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bundles/binding/org.openhab.binding.girahomeserver/pom.xml
+++ b/bundles/binding/org.openhab.binding.girahomeserver/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.8.0-SNAPSHOT-SNAPSHOT</version>
+		<version>1.9.0</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/GiraHomeServerBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/GiraHomeServerBindingProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2015, openHAB.org and others.
+ * Copyright (c) 2010-2016, openHAB.org and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/GiraHomeServerBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/GiraHomeServerBindingProvider.java
@@ -9,11 +9,24 @@
 package org.openhab.binding.girahomeserver;
 
 import org.openhab.core.binding.BindingProvider;
+import org.openhab.core.types.Type;
 
 /**
  * @author Jochen Mattes
- * @since 1.8.0-SNAPSHOT
+ * @since 1.9.0
  */
 public interface GiraHomeServerBindingProvider extends BindingProvider {
 
+    /**
+     * Returns the outbound communicationObject to write according to <code>itemName</code>.
+     *
+     * @param itemName
+     *            the item for which to find a commandLine
+     *
+     * @return the matching communicationObject or <code>null</code> if no matching
+     *         communicationObject could be found.
+     */
+    String getOutboundCommunicationObject(String itemName, Type value);
+
+    String[] getItemNames(String communicationObject);
 }

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/GiraHomeServerBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/GiraHomeServerBindingProvider.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.girahomeserver;
+
+import org.openhab.core.binding.BindingProvider;
+
+/**
+ * @author Jochen Mattes
+ * @since 1.8.0-SNAPSHOT
+ */
+public interface GiraHomeServerBindingProvider extends BindingProvider {
+
+}

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerActivator.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerActivator.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.girahomeserver.internal;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extension of the default OSGi bundle activator
+ *
+ * @author Jochen Mattes
+ * @since 1.9.0
+ */
+public final class GiraHomeServerActivator implements BundleActivator {
+
+    private static Logger logger = LoggerFactory.getLogger(GiraHomeServerActivator.class);
+
+    private static BundleContext context;
+
+    /**
+     * Called whenever the OSGi framework starts our bundle
+     */
+    @Override
+    public void start(BundleContext bc) throws Exception {
+        context = bc;
+        logger.info("GiraHomeServerBinding binding has been started.");
+    }
+
+    /**
+     * Called whenever the OSGi framework stops our bundle
+     */
+    @Override
+    public void stop(BundleContext bc) throws Exception {
+        context = null;
+        logger.info("GiraHomeServerBinding binding has been stopped.");
+    }
+
+    /**
+     * Returns the bundle context of this bundle
+     *
+     * @return the bundle context
+     */
+    public static BundleContext getContext() {
+        return context;
+    }
+}

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerBinding.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerBinding.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2015, openHAB.org and others.
+ * Copyright (c) 2010-2016, openHAB.org and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerBinding.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerBinding.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.girahomeserver.internal;
+
+import java.util.Map;
+
+import org.openhab.binding.girahomeserver.GiraHomeServerBindingProvider;
+
+import org.apache.commons.lang.StringUtils;
+import org.openhab.core.binding.AbstractActiveBinding;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+	
+
+/**
+ * Implement this class if you are going create an actively polling service
+ * like querying a Website/Device.
+ * 
+ * @author Jochen Mattes
+ * @since 1.8.0-SNAPSHOT
+ */
+public class GiraHomeServerBinding extends AbstractActiveBinding<GiraHomeServerBindingProvider> {
+
+	private static final Logger logger = 
+		LoggerFactory.getLogger(GiraHomeServerBinding.class);
+
+	/**
+	 * The BundleContext. This is only valid when the bundle is ACTIVE. It is set in the activate()
+	 * method and must not be accessed anymore once the deactivate() method was called or before activate()
+	 * was called.
+	 */
+	private BundleContext bundleContext;
+
+	
+	/** 
+	 * the refresh interval which is used to poll values from the GiraHomeServer
+	 * server (optional, defaults to 60000ms)
+	 */
+	private long refreshInterval = 60000;
+	
+	
+	public GiraHomeServerBinding() {
+	}
+		
+	
+	/**
+	 * Called by the SCR to activate the component with its configuration read from CAS
+	 * 
+	 * @param bundleContext BundleContext of the Bundle that defines this component
+	 * @param configuration Configuration properties for this component obtained from the ConfigAdmin service
+	 */
+	public void activate(final BundleContext bundleContext, final Map<String, Object> configuration) {
+		this.bundleContext = bundleContext;
+
+		// the configuration is guaranteed not to be null, because the component definition has the
+		// configuration-policy set to require. If set to 'optional' then the configuration may be null
+		
+			
+		// to override the default refresh interval one has to add a 
+		// parameter to openhab.cfg like <bindingName>:refresh=<intervalInMs>
+		String refreshIntervalString = (String) configuration.get("refresh");
+		if (StringUtils.isNotBlank(refreshIntervalString)) {
+			refreshInterval = Long.parseLong(refreshIntervalString);
+		}
+
+		// read further config parameters here ...
+
+		setProperlyConfigured(true);
+	}
+	
+	/**
+	 * Called by the SCR when the configuration of a binding has been changed through the ConfigAdmin service.
+	 * @param configuration Updated configuration properties
+	 */
+	public void modified(final Map<String, Object> configuration) {
+		// update the internal configuration accordingly
+	}
+	
+	/**
+	 * Called by the SCR to deactivate the component when either the configuration is removed or
+	 * mandatory references are no longer satisfied or the component has simply been stopped.
+	 * @param reason Reason code for the deactivation:<br>
+	 * <ul>
+	 * <li> 0 – Unspecified
+     * <li> 1 – The component was disabled
+     * <li> 2 – A reference became unsatisfied
+     * <li> 3 – A configuration was changed
+     * <li> 4 – A configuration was deleted
+     * <li> 5 – The component was disposed
+     * <li> 6 – The bundle was stopped
+     * </ul>
+	 */
+	public void deactivate(final int reason) {
+		this.bundleContext = null;
+		// deallocate resources here that are no longer needed and 
+		// should be reset when activating this binding again
+	}
+
+	
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected long getRefreshInterval() {
+		return refreshInterval;
+	}
+
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected String getName() {
+		return "GiraHomeServer Refresh Service";
+	}
+	
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected void execute() {
+		// the frequently executed code (polling) goes here ...
+		logger.debug("execute() method is called!");
+	}
+
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected void internalReceiveCommand(String itemName, Command command) {
+		// the code being executed when a command was sent on the openHAB
+		// event bus goes here. This method is only called if one of the 
+		// BindingProviders provide a binding for the given 'itemName'.
+		logger.debug("internalReceiveCommand({},{}) is called!", itemName, command);
+	}
+	
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected void internalReceiveUpdate(String itemName, State newState) {
+		// the code being executed when a state was sent on the openHAB
+		// event bus goes here. This method is only called if one of the 
+		// BindingProviders provide a binding for the given 'itemName'.
+		logger.debug("internalReceiveUpdate({},{}) is called!", itemName, newState);
+	}
+
+}

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerBinding.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerBinding.java
@@ -8,149 +8,255 @@
  */
 package org.openhab.binding.girahomeserver.internal;
 
+import static org.apache.commons.lang.StringUtils.*;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.openhab.binding.girahomeserver.GiraHomeServerBindingProvider;
-
-import org.apache.commons.lang.StringUtils;
 import org.openhab.core.binding.AbstractActiveBinding;
+import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-	
 
 /**
  * Implement this class if you are going create an actively polling service
  * like querying a Website/Device.
- * 
+ *
  * @author Jochen Mattes
- * @since 1.8.0-SNAPSHOT
+ * @since 1.9.0
  */
-public class GiraHomeServerBinding extends AbstractActiveBinding<GiraHomeServerBindingProvider> {
+public class GiraHomeServerBinding extends AbstractActiveBinding<GiraHomeServerBindingProvider>
+        implements ManagedService {
 
-	private static final Logger logger = 
-		LoggerFactory.getLogger(GiraHomeServerBinding.class);
+    private static final Logger logger = LoggerFactory.getLogger(GiraHomeServerBinding.class);
 
-	/**
-	 * The BundleContext. This is only valid when the bundle is ACTIVE. It is set in the activate()
-	 * method and must not be accessed anymore once the deactivate() method was called or before activate()
-	 * was called.
-	 */
-	private BundleContext bundleContext;
+    private static final int DEFAULT_PORT = 7003;
+    private static final long DEFAULT_REFRESH_INTERVAL = 1000L;
 
-	
-	/** 
-	 * the refresh interval which is used to poll values from the GiraHomeServer
-	 * server (optional, defaults to 60000ms)
-	 */
-	private long refreshInterval = 60000;
-	
-	
-	public GiraHomeServerBinding() {
-	}
-		
-	
-	/**
-	 * Called by the SCR to activate the component with its configuration read from CAS
-	 * 
-	 * @param bundleContext BundleContext of the Bundle that defines this component
-	 * @param configuration Configuration properties for this component obtained from the ConfigAdmin service
-	 */
-	public void activate(final BundleContext bundleContext, final Map<String, Object> configuration) {
-		this.bundleContext = bundleContext;
+    /**
+     * The BundleContext. This is only valid when the bundle is ACTIVE. It is set in the activate()
+     * method and must not be accessed anymore once the deactivate() method was called or before activate()
+     * was called.
+     */
+    private BundleContext bundleContext;
 
-		// the configuration is guaranteed not to be null, because the component definition has the
-		// configuration-policy set to require. If set to 'optional' then the configuration may be null
-		
-			
-		// to override the default refresh interval one has to add a 
-		// parameter to openhab.cfg like <bindingName>:refresh=<intervalInMs>
-		String refreshIntervalString = (String) configuration.get("refresh");
-		if (StringUtils.isNotBlank(refreshIntervalString)) {
-			refreshInterval = Long.parseLong(refreshIntervalString);
-		}
+    /** ip address of the girahomeserver */
+    protected static String ip;
 
-		// read further config parameters here ...
+    /** port of the girahomeserver */
+    protected static int port = DEFAULT_PORT;
 
-		setProperlyConfigured(true);
-	}
-	
-	/**
-	 * Called by the SCR when the configuration of a binding has been changed through the ConfigAdmin service.
-	 * @param configuration Updated configuration properties
-	 */
-	public void modified(final Map<String, Object> configuration) {
-		// update the internal configuration accordingly
-	}
-	
-	/**
-	 * Called by the SCR to deactivate the component when either the configuration is removed or
-	 * mandatory references are no longer satisfied or the component has simply been stopped.
-	 * @param reason Reason code for the deactivation:<br>
-	 * <ul>
-	 * <li> 0 – Unspecified
-     * <li> 1 – The component was disabled
-     * <li> 2 – A reference became unsatisfied
-     * <li> 3 – A configuration was changed
-     * <li> 4 – A configuration was deleted
-     * <li> 5 – The component was disposed
-     * <li> 6 – The bundle was stopped
-     * </ul>
-	 */
-	public void deactivate(final int reason) {
-		this.bundleContext = null;
-		// deallocate resources here that are no longer needed and 
-		// should be reset when activating this binding again
-	}
+    /** password of the girahomeserver */
+    protected static String password;
 
-	
-	/**
-	 * @{inheritDoc}
-	 */
-	@Override
-	protected long getRefreshInterval() {
-		return refreshInterval;
-	}
+    /**
+     * the refresh interval which is used to poll values from the GiraHomeServer
+     * server (optional, defaults to 60000ms)
+     */
+    private long refreshInterval = DEFAULT_REFRESH_INTERVAL;
 
-	/**
-	 * @{inheritDoc}
-	 */
-	@Override
-	protected String getName() {
-		return "GiraHomeServer Refresh Service";
-	}
-	
-	/**
-	 * @{inheritDoc}
-	 */
-	@Override
-	protected void execute() {
-		// the frequently executed code (polling) goes here ...
-		logger.debug("execute() method is called!");
-	}
+    private static HashMap<String, Type> updatedParams = new HashMap<String, Type>();
+    private final Lock updatedParamsLock = new ReentrantLock();
 
-	/**
-	 * @{inheritDoc}
-	 */
-	@Override
-	protected void internalReceiveCommand(String itemName, Command command) {
-		// the code being executed when a command was sent on the openHAB
-		// event bus goes here. This method is only called if one of the 
-		// BindingProviders provide a binding for the given 'itemName'.
-		logger.debug("internalReceiveCommand({},{}) is called!", itemName, command);
-	}
-	
-	/**
-	 * @{inheritDoc}
-	 */
-	@Override
-	protected void internalReceiveUpdate(String itemName, State newState) {
-		// the code being executed when a state was sent on the openHAB
-		// event bus goes here. This method is only called if one of the 
-		// BindingProviders provide a binding for the given 'itemName'.
-		logger.debug("internalReceiveUpdate({},{}) is called!", itemName, newState);
-	}
+    public GiraHomeServerBinding() {
+    }
 
+    /**
+     * Called by the SCR to activate the component with its configuration read from CAS
+     *
+     * @param bundleContext BundleContext of the Bundle that defines this component
+     * @param configuration Configuration properties for this component obtained from the ConfigAdmin service
+     */
+    @Override
+    @SuppressWarnings("rawtypes")
+    public void updated(Dictionary configuration) throws ConfigurationException {
+        logger.warn("Girahomeserver updated");
+
+        boolean properlyConfigured = true;
+
+        long refreshInterval = DEFAULT_REFRESH_INTERVAL;
+        int port = DEFAULT_PORT;
+        String ip = null;
+        String password = null;
+        try {
+            String refreshIntervalString = (String) configuration.get("refresh"); //$NON-NLS-1$
+            refreshInterval = isNotBlank(refreshIntervalString) ? Long.parseLong(refreshIntervalString)
+                    : DEFAULT_REFRESH_INTERVAL;
+
+            ip = (String) configuration.get("server"); //$NON-NLS-1$
+            properlyConfigured = properlyConfigured && isNotBlank(ip);
+
+            String portString = (String) configuration.get("port"); //$NON-NLS-1$
+            port = isNumeric(portString) ? Integer.parseInt(portString) : DEFAULT_PORT;
+
+            password = (String) configuration.get("password");
+            properlyConfigured = properlyConfigured && isNotBlank(password);
+        } catch (NumberFormatException ex) {
+            properlyConfigured = false;
+        }
+
+        if (properlyConfigured) {
+            this.refreshInterval = refreshInterval;
+            GiraHomeServerBinding.ip = ip;
+            GiraHomeServerBinding.port = port;
+            GiraHomeServerBinding.password = password;
+        }
+        setProperlyConfigured(properlyConfigured);
+
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    protected long getRefreshInterval() {
+        return refreshInterval;
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    protected String getName() {
+        return "GiraHomeServer Refresh Service";
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    public void execute() {
+        if (!bindingsExist()) {
+            logger.warn("There is no existing Girahomeserver binding configuration => refresh cycle aborted!");
+            return;
+        }
+
+        // establish the connection
+        GiraHomeServerConnector connector = new GiraHomeServerConnector(ip, port, password);
+
+        try {
+            connector.connect();
+
+            // read all available values
+            readValuesFromGirahomeserver(connector);
+
+            // write the updates
+            flushValuesToGirahomeserver(connector);
+
+        } catch (UnknownHostException e) {
+            logger.warn("the given hostname '{}' of the Gira Home Server is unknown", ip);
+
+        } catch (IOException e) {
+            logger.warn("couldn't establish network connection [host '{}']", ip);
+
+        } finally {
+            if (connector != null) {
+                connector.disconnect();
+            }
+        }
+
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    protected void internalReceiveCommand(String itemName, Command command) {
+        writeToGiraHomeServerBuffered(itemName, command);
+    }
+
+    /**
+     * Get the updated values through the connector and update the local states
+     *
+     * @param connector
+     * @throws IOException
+     */
+    protected void readValuesFromGirahomeserver(GiraHomeServerConnector connector) throws IOException {
+        HashMap<String, String> giraValues = connector.getValues();
+        if (!giraValues.isEmpty()) {
+            for (Map.Entry<String, String> entry : giraValues.entrySet()) {
+                for (GiraHomeServerBindingProvider provider : providers) {
+                    for (String itemName : provider.getItemNames(entry.getKey())) {
+                        // TODO: implement Strings
+                        Type type = new DecimalType(entry.getValue());
+                        eventPublisher.postCommand(itemName, (Command) type);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Flush the accumulated changes to the Girahomeserver
+     *
+     * @param connector
+     * @throws IOException
+     */
+    protected void flushValuesToGirahomeserver(GiraHomeServerConnector connector) throws IOException {
+        updatedParamsLock.lock();
+        for (Map.Entry<String, Type> entry : updatedParams.entrySet()) {
+            String itemName = entry.getKey();
+            Type value = entry.getValue();
+
+            GiraHomeServerBindingProvider provider = findFirstMatchingBindingProvider(itemName, value);
+            String communicationObject = provider.getOutboundCommunicationObject(itemName, value);
+            if (communicationObject != null && !communicationObject.isEmpty()) {
+                connector.setParam(communicationObject, value);
+            }
+        }
+        // flush
+        updatedParams = new HashMap<String, Type>();
+        updatedParamsLock.unlock();
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    protected void internalReceiveUpdate(String itemName, State newState) {
+        writeToGiraHomeServerBuffered(itemName, newState);
+    }
+
+    /**
+     * Update the item state in the output buffer
+     *
+     * @param itemName
+     * @param value
+     */
+    protected void writeToGiraHomeServerBuffered(String itemName, Type value) {
+        updatedParamsLock.lock();
+        GiraHomeServerBinding.updatedParams.put(itemName, value);
+        updatedParamsLock.unlock();
+    }
+
+    /**
+     * Find the first matching binding provider
+     *
+     * @param itemName
+     * @param value
+     * @return
+     */
+    private GiraHomeServerBindingProvider findFirstMatchingBindingProvider(String itemName, Type value) {
+        GiraHomeServerBindingProvider firstMatchingProvider = null;
+        for (GiraHomeServerBindingProvider provider : this.providers) {
+            String communicationObject = provider.getOutboundCommunicationObject(itemName, value);
+            if (communicationObject != null) {
+                firstMatchingProvider = provider;
+                break;
+            }
+        }
+        return firstMatchingProvider;
+    }
 }

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerBinding.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerBinding.java
@@ -185,15 +185,24 @@ public class GiraHomeServerBinding extends AbstractActiveBinding<GiraHomeServerB
      * @throws IOException
      */
     protected void readValuesFromGirahomeserver(GiraHomeServerConnector connector) throws IOException {
+
+        // get the values from the girahomeserver
         HashMap<String, String> giraValues = connector.getValues();
-        if (!giraValues.isEmpty()) {
-            for (Map.Entry<String, String> entry : giraValues.entrySet()) {
-                for (GiraHomeServerBindingProvider provider : providers) {
-                    for (String itemName : provider.getItemNames(entry.getKey())) {
-                        // TODO: implement Strings
-                        Type type = new DecimalType(entry.getValue());
-                        eventPublisher.postCommand(itemName, (Command) type);
-                    }
+
+        // ignore empty updates
+        if (giraValues.isEmpty()) {
+            return;
+        }
+
+        // update the openhab items through the first provider
+        for (Map.Entry<String, String> entry : giraValues.entrySet()) {
+
+            // send update
+            for (GiraHomeServerBindingProvider provider : providers) {
+                for (String itemName : provider.getItemNames(entry.getKey())) {
+                    // TODO: implement Strings
+                    Type type = new DecimalType(entry.getValue());
+                    eventPublisher.postCommand(itemName, (Command) type);
                 }
             }
         }

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerConnector.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerConnector.java
@@ -140,10 +140,10 @@ public class GiraHomeServerConnector {
 
             if (records.length == 2) {
                 // ignore uninitialized values
-                String address = decodeCommunicationObjectAddress(records[1]);
                 continue;
 
             } else if (records.length == 3) {
+                // decode initialized values
                 String address = decodeCommunicationObjectAddress(records[1]);
                 String value = records[2];
                 values.put(address, value);

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerConnector.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerConnector.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.girahomeserver.internal;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import org.openhab.core.types.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gira HomeServer connector
+ *
+ * @author Jochen Mattes
+ * @since 1.0.0
+ */
+public class GiraHomeServerConnector {
+
+    static final Logger logger = LoggerFactory.getLogger(GiraHomeServerConnector.class);
+
+    private static final String TELEGRAM_RAW = "1|%s|%s"; // + '\0';
+
+    private static final int MAX_READ_RETRIES = 5;
+    private static final int RECONNECTION_TIMEOUT = 1000;
+
+    /** socket */
+    private Socket socket = null;
+
+    /** socket output buffer */
+    private PrintWriter dataout = null;
+
+    /** socket input buffer */
+    private BufferedReader datain = null;
+
+    /** ip of girahomeserver */
+    private String serverIp;
+
+    /** port of girahomeserver */
+    private int serverPort;
+
+    /** password of girahomeserver */
+    private String serverPassword;
+
+    public GiraHomeServerConnector(String serverIp, int serverPort, String serverPassword) {
+        this.serverIp = serverIp;
+        this.serverPort = serverPort;
+        this.serverPassword = serverPassword;
+    }
+
+    public void connect() throws UnknownHostException, IOException {
+        // connect
+        socket = new Socket(serverIp, serverPort);
+        dataout = new PrintWriter(socket.getOutputStream(), false);
+
+        datain = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+
+        // send password
+        dataout.print(serverPassword + '\0');
+        dataout.flush();
+    }
+
+    /**
+     * update the value of a communication object
+     *
+     * @param param
+     * @param value
+     * @return
+     * @throws IOException
+     */
+    public void setParam(String communicationObject, Type value) throws IOException {
+        String telegram = String.format(TELEGRAM_RAW, encodeCommunicationObjectAddres(communicationObject), value);
+        dataout.print(telegram + '\0');
+        dataout.flush();
+    }
+
+    /**
+     * read the value of communication objects from the girahomeserver.
+     * Initialize the number of tries with zero
+     *
+     * @return a array with updates of the communication objects
+     * @throws IOException indicate that no data can be read from the girahomeserver
+     */
+    public HashMap<String, String> getValues() throws IOException {
+        return getValues(0);
+    }
+
+    /**
+     * read the values of communication objects from the girahomeserver
+     *
+     * @param tries
+     * @return
+     * @throws IOException
+     */
+    public HashMap<String, String> getValues(int tries) throws IOException {
+
+        // fetch the data from the socket
+        String data;
+        try {
+            char[] rawData = new char[1024];
+            datain.read(rawData);
+            data = new String(rawData);
+        } catch (IOException e) {
+            if (tries > MAX_READ_RETRIES) {
+                throw e;
+            } else {
+                this.reconnect();
+                return getValues(tries + 1);
+            }
+        }
+
+        // Extract the individual values of the communication objects
+        // Each of the fields has the format
+        // '2|<CO address as int>|<value as text>'
+        // They are separated by 0x0 values. The last field is empty.
+        HashMap<String, String> values = new HashMap<String, String>();
+        String[] elements = data.split("\0");
+        if (elements.length == 0) {
+            return values;
+        }
+
+        // remove the last element (always empty)
+        elements = Arrays.copyOfRange(elements, 0, elements.length - 1);
+
+        // translate elements to values
+        for (String e : elements) {
+            String[] records = e.split("\\|");
+
+            if (records.length == 2) {
+                // ignore uninitialized values
+                String address = decodeCommunicationObjectAddress(records[1]);
+                continue;
+
+            } else if (records.length == 3) {
+                String address = decodeCommunicationObjectAddress(records[1]);
+                String value = records[2];
+                values.put(address, value);
+
+            } else {
+                logger.warn("Communication object cannot be parsed correctly: {}", e);
+                continue;
+            }
+        }
+        return values;
+    }
+
+    /**
+     * decode the communication object's group address
+     *
+     * @param encodedAddress
+     * @return
+     */
+    private String decodeCommunicationObjectAddress(String encodedAddress) {
+        int addr = Integer.valueOf(encodedAddress);
+        int x = addr / 2048;
+        int y = (addr - 2048 * x) / 256;
+        int z = addr % 256;
+        return String.format("%d/%d/%d", x, y, z);
+    }
+
+    /**
+     * encode the communication object's group address
+     *
+     * @param address
+     * @return
+     */
+    private int encodeCommunicationObjectAddres(String address) {
+        String[] parts = address.split("/");
+        return 2048 * Integer.parseInt(parts[0]) + 256 * Integer.parseInt(parts[1]) + Integer.parseInt(parts[2]);
+    }
+
+    /**
+     * disconnect from girahomserver
+     */
+    public void disconnect() {
+        try {
+            datain.close();
+        } catch (IOException e) {
+            logger.error("can't close datain", e);
+        }
+        dataout.close();
+    }
+
+    /**
+     * reconnect to the girahomeserver
+     */
+    public void reconnect() {
+
+        try {
+            this.disconnect();
+            Thread.sleep(RECONNECTION_TIMEOUT);
+            this.connect();
+        } catch (InterruptedException e) {
+            // do nothing
+            e.printStackTrace();
+        } catch (UnknownHostException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerGenericBindingProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2015, openHAB.org and others.
+ * Copyright (c) 2010-2016, openHAB.org and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerGenericBindingProvider.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.girahomeserver.internal;
+
+import org.openhab.binding.girahomeserver.GiraHomeServerBindingProvider;
+import org.openhab.core.binding.BindingConfig;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.items.DimmerItem;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.model.item.binding.AbstractGenericBindingProvider;
+import org.openhab.model.item.binding.BindingConfigParseException;
+
+
+/**
+ * This class is responsible for parsing the binding configuration.
+ * 
+ * @author Jochen Mattes
+ * @since 1.8.0-SNAPSHOT
+ */
+public class GiraHomeServerGenericBindingProvider extends AbstractGenericBindingProvider implements GiraHomeServerBindingProvider {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getBindingType() {
+		return "girahomeserver";
+	}
+
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
+		//if (!(item instanceof SwitchItem || item instanceof DimmerItem)) {
+		//	throw new BindingConfigParseException("item '" + item.getName()
+		//			+ "' is of type '" + item.getClass().getSimpleName()
+		//			+ "', only Switch- and DimmerItems are allowed - please check your *.items configuration");
+		//}
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
+		super.processBindingConfiguration(context, item, bindingConfig);
+		GiraHomeServerBindingConfig config = new GiraHomeServerBindingConfig();
+		
+		//parse bindingconfig here ...
+		
+		addBindingConfig(item, config);		
+	}
+	
+	
+	/**
+	 * This is a helper class holding binding specific configuration details
+	 * 
+	 * @author Jochen Mattes
+	 * @since 1.8.0-SNAPSHOT
+	 */
+	class GiraHomeServerBindingConfig implements BindingConfig {
+		// put member fields here which holds the parsed values
+	}
+	
+	
+}

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/java/org/openhab/binding/girahomeserver/internal/GiraHomeServerGenericBindingProvider.java
@@ -8,65 +8,199 @@
  */
 package org.openhab.binding.girahomeserver.internal;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.openhab.binding.girahomeserver.GiraHomeServerBindingProvider;
 import org.openhab.core.binding.BindingConfig;
 import org.openhab.core.items.Item;
-import org.openhab.core.library.items.DimmerItem;
-import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.Type;
 import org.openhab.model.item.binding.AbstractGenericBindingProvider;
 import org.openhab.model.item.binding.BindingConfigParseException;
 
-
 /**
  * This class is responsible for parsing the binding configuration.
- * 
+ *
  * @author Jochen Mattes
- * @since 1.8.0-SNAPSHOT
+ * @since 1.9.0
  */
-public class GiraHomeServerGenericBindingProvider extends AbstractGenericBindingProvider implements GiraHomeServerBindingProvider {
+public class GiraHomeServerGenericBindingProvider extends AbstractGenericBindingProvider
+        implements GiraHomeServerBindingProvider {
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public String getBindingType() {
-		return "girahomeserver";
-	}
+    /**
+     * This is an internal data structure to store information from the binding
+     * config strings and use it to answer the requests to the girahomeserver
+     * binding provider.
+     */
+    static class GiraHomeServerBindingConfig extends HashMap<Command, GiraHomeServerBindingConfigElement>
+            implements BindingConfig {
 
-	/**
-	 * @{inheritDoc}
-	 */
-	@Override
-	public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
-		//if (!(item instanceof SwitchItem || item instanceof DimmerItem)) {
-		//	throw new BindingConfigParseException("item '" + item.getName()
-		//			+ "' is of type '" + item.getClass().getSimpleName()
-		//			+ "', only Switch- and DimmerItems are allowed - please check your *.items configuration");
-		//}
-	}
-	
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
-		super.processBindingConfiguration(context, item, bindingConfig);
-		GiraHomeServerBindingConfig config = new GiraHomeServerBindingConfig();
-		
-		//parse bindingconfig here ...
-		
-		addBindingConfig(item, config);		
-	}
-	
-	
-	/**
-	 * This is a helper class holding binding specific configuration details
-	 * 
-	 * @author Jochen Mattes
-	 * @since 1.8.0-SNAPSHOT
-	 */
-	class GiraHomeServerBindingConfig implements BindingConfig {
-		// put member fields here which holds the parsed values
-	}
-	
-	
+        /** generated serialVersion UID */
+        private static final long serialVersionUID = -8421879251490268240L;
+
+    }
+
+    /**
+     * This is an internal data structure to store information from the binding
+     * config strings and use it to answer the requests to the girahomeserver binding
+     * provider.
+     */
+    static class GiraHomeServerBindingConfigElement implements BindingConfig {
+
+        public String communicationObject = null;
+        int refreshInterval = 0;
+        String transformation = null;
+
+        @Override
+        public String toString() {
+            return "ExecBindingConfigElement [co=" + communicationObject + ", refreshInterval=" + refreshInterval
+                    + ", transformation=" + transformation + "]";
+        }
+
+    }
+
+    /** {@link Pattern} which matches a binding configuration part */
+    private static final Pattern BASE_CONFIG_PATTERN = Pattern.compile("(<|>|)([0-9/]+)(\\s|$)");
+
+    protected static final Command BIDIRECTIONAL_BINDING_KEY = StringType.valueOf("BIDIRECTIONAL_BINDING");
+
+    /**
+     * Artificial command for the exec-in configuration (which has no command
+     * part by definition). Because we use this artificial command we can reuse
+     * the {@link ExecBindingConfig} for both in- and out-configuration.
+     */
+    protected static final Command IN_BINDING_KEY = StringType.valueOf("IN_BINDING");
+
+    protected static final Command OUT_BINDING_KEY = StringType.valueOf("OUT_BINDING");
+
+    protected GiraHomeServerBindingConfig createBindingConfig(Item item, Command command, String bindingConfig,
+            GiraHomeServerBindingConfig config) throws BindingConfigParseException {
+
+        GiraHomeServerBindingConfigElement configElement;
+        configElement = new GiraHomeServerBindingConfigElement();
+        configElement.communicationObject = bindingConfig;
+        config.put(command, configElement);
+
+        return config;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getBindingType() {
+        return "girahomeserver";
+    }
+
+    /**
+     * get the communication object for inbound updates
+     *
+     * @param itemName
+     * @param value
+     * @return
+     */
+    @Override
+    public String getOutboundCommunicationObject(String itemName, Type value) {
+        return getCommunicationObject(OUT_BINDING_KEY, itemName, value);
+    }
+
+    /**
+     * get the revelant communication object
+     *
+     * @param direction
+     * @param itemName
+     * @param value
+     * @return
+     */
+    private String getCommunicationObject(Command direction, String itemName, Type value) {
+        try {
+            GiraHomeServerBindingConfig config = (GiraHomeServerBindingConfig) bindingConfigs.get(itemName);
+            if (config == null) {
+                return null;
+            }
+
+            if (config.get(direction) != null) {
+                return config.get(direction).communicationObject;
+            }
+
+            // fallback
+            if (config.get(BIDIRECTIONAL_BINDING_KEY) != null) {
+                return config.get(BIDIRECTIONAL_BINDING_KEY).communicationObject;
+            }
+
+            // no item found
+            return null;
+
+        } catch (NullPointerException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String[] getItemNames(String communicationObject) {
+        Set<String> itemNames = new HashSet<String>();
+        for (Entry<String, BindingConfig> entry : bindingConfigs.entrySet()) {
+            GiraHomeServerBindingConfig config = (GiraHomeServerBindingConfig) entry.getValue();
+            if (config.get(BIDIRECTIONAL_BINDING_KEY).communicationObject.equals(communicationObject)) {
+                itemNames.add(entry.getKey());
+            }
+        }
+        return itemNames.toArray(new String[itemNames.size()]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void processBindingConfiguration(String context, Item item, String bindingConfig)
+            throws BindingConfigParseException {
+
+        super.processBindingConfiguration(context, item, bindingConfig);
+        GiraHomeServerBindingConfig config = new GiraHomeServerBindingConfig();
+
+        // test pattern
+        Matcher matcher = BASE_CONFIG_PATTERN.matcher(bindingConfig);
+        if (!matcher.matches()) {
+            throw new BindingConfigParseException("Binding configuration has invalid format ");
+
+        } else {
+            matcher.reset();
+
+            // extract configurations
+            while (matcher.find()) {
+                String direction = matcher.group(1);
+                String bindingConfigPart = matcher.group(2);
+
+                // parse command
+                Command command;
+                switch (direction) {
+                    case "<":
+                        command = IN_BINDING_KEY;
+                    case ">":
+                        command = OUT_BINDING_KEY;
+                    default:
+                        command = BIDIRECTIONAL_BINDING_KEY;
+                }
+
+                // parse item
+                config = createBindingConfig(item, command, bindingConfigPart, config);
+            }
+        }
+        addBindingConfig(item, config);
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
+        // al types of items are accepted
+    }
+
 }

--- a/bundles/binding/org.openhab.binding.girahomeserver/src/main/resources/readme.txt
+++ b/bundles/binding/org.openhab.binding.girahomeserver/src/main/resources/readme.txt
@@ -1,0 +1,1 @@
+Bundle resources go in here!


### PR DESCRIPTION
The girahomeserver has an internal CO-Gateway that allows to share communication objects, without having to rely on KNX. This is especially handy for sharing long strings or communication objects / items that are updated frequently.

The interface is documented here: http://www.dacom-ha.de/hshelp/v2_6/en/proj_cogw.html

The implementation follows the example here (python): https://github.com/okohlbacher/pyHSgw

It requires two configuration settings:
girahomeserver:server=192.168.xxx.xxx
girahomeserver:password=xxx
girahomeserver:refresh=1000
