### PR TITLE
[denon] allow config of Telnet and HTTP ports

### DIFF
--- a/bundles/binding/org.openhab.binding.denon/src/main/java/org/openhab/binding/denon/internal/DenonBinding.java
+++ b/bundles/binding/org.openhab.binding.denon/src/main/java/org/openhab/binding/denon/internal/DenonBinding.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Jeroen Idserda
  * @since 1.7.0
  */
-public class DenonBinding extends AbstractActiveBinding<DenonBindingProvider>implements ManagedService {
+public class DenonBinding extends AbstractActiveBinding<DenonBindingProvider> implements ManagedService {
 
     private static final String CONFIG_REFRESH = "refresh";
 
@@ -46,6 +46,10 @@ public class DenonBinding extends AbstractActiveBinding<DenonBindingProvider>imp
     private static final String CONFIG_UPDATE_TYPE_TELNET = "telnet";
 
     private static final String CONFIG_SERVICE_PID = "service.pid";
+
+    private static final String CONFIG_TELNET_PORT = "telnetPort";
+
+    private static final String CONFIG_HTTP_PORT = "httpPort";
 
     private static final String SWITCH_INPUT = "SI";
 
@@ -178,6 +182,10 @@ public class DenonBinding extends AbstractActiveBinding<DenonBindingProvider>imp
                         if (!value.equals(CONFIG_UPDATE_TYPE_TELNET) && !value.equals(CONFIG_UPDATE_TYPE_HTTP)) {
                             logger.warn("Invalid connection type {} for instance {}, using default", value, instance);
                         }
+                    } else if (CONFIG_TELNET_PORT.equals(option)) {
+                        connection.setTelnetPort(Integer.parseInt(value));
+                    } else if (CONFIG_HTTP_PORT.equals(option)) {
+                        connection.setHttpPort(Integer.parseInt(value));
                     }
                 }
             }

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -2181,6 +2181,14 @@ tcp:refreshinterval=250
 # you have any other app using the telnet connection. Default = telnet
 #denon:avr2000.update=telnet
 
+# Optional, if you are using telnet, you can change the default port from 23 to
+# the port your receiver or serial gateway is listening on
+#denon:avr2000.telnetPort=4999
+
+# Optional, if you are using http, you can change the default port from 80 to
+# the port your receiver is listening on
+#denon:avr2000.httpPort=8080
+
 # Optional, this sets the refresh interval (in milliseconds) for all instances
 # if you're using the http connection method. Default = 5000
 #denon:refresh=5000

--- a/features/openhab-addons-external/src/main/resources/conf/denon.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/denon.cfg
@@ -8,6 +8,14 @@
 # you have any other app using the telnet connection. Default = telnet
 #avr2000.update=http
 
+# Optional, if you are using telnet, you can change the default port from 23 to
+# the port your receiver or serial gateway is listening on
+#avr2000.telnetPort=4999
+
+# Optional, if you are using http, you can change the default port from 80 to
+# the port your receiver is listening on
+#avr2000.httpPort=8080
+
 # Optional, this sets the refresh interval (in milliseconds) for all instances 
 # if you're using the http connection method. Default = 5000 
 #refresh=5000


### PR DESCRIPTION
Fixes #4601 

Please install the [test JAR](https://dl.dropboxusercontent.com/u/4286376/denon-ports/org.openhab.binding.denon-1.9.0-SNAPSHOT.jar) and let me know if it works.

You will have to add the optional 

```
<instance>.telnetPort=23
<instance>.httpPort=80
```

to your denon.cfg and change 23 and 80 to the values you want to use.

Signed-off-by: John Cocula john@cocula.com
