### PR TITLE
[Plugwise] Power measurement improvements

### DIFF
--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/Energy.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/Energy.java
@@ -22,9 +22,9 @@ public class Energy {
 
     private DateTime time;
     private long pulses;
-    private int interval;
+    private double interval;
 
-    public Energy(String logdate, long l, int interval) {
+    public Energy(String logdate, long l, double interval) {
 
         if (logdate.length() == 8) {
 
@@ -56,7 +56,7 @@ public class Energy {
 
     }
 
-    public Energy(DateTime logdate, long pulses, int interval) {
+    public Energy(DateTime logdate, long pulses, double interval) {
         time = logdate;
         this.interval = interval;
         this.pulses = pulses;
@@ -64,7 +64,7 @@ public class Energy {
 
     @Override
     public String toString() {
-        return time.toString() + "-" + Integer.toString(interval) + "-" + Long.toString(pulses);
+        return time.toString() + "-" + Double.toString(interval) + "-" + Long.toString(pulses);
     }
 
     public DateTime getTime() {
@@ -75,7 +75,7 @@ public class Energy {
         return pulses;
     }
 
-    public int getInterval() {
+    public double getInterval() {
         return interval;
     }
 

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBinding.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBinding.java
@@ -404,6 +404,8 @@ public class PlugwiseBinding extends AbstractActiveBinding<PlugwiseBindingProvid
         // the logic below covers all possible command types and value types
         if (typeClass == DecimalType.class && value instanceof Float) {
             return new DecimalType((Float) value);
+        } else if (typeClass == DecimalType.class && value instanceof Double) {
+            return new DecimalType((Double) value);
         } else if (typeClass == OnOffType.class && value instanceof Boolean) {
             return ((Boolean) value).booleanValue() ? OnOffType.ON : OnOffType.OFF;
         } else if (typeClass == DateTimeType.class && value instanceof Calendar) {

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/CalibrationResponseMessage.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/CalibrationResponseMessage.java
@@ -21,25 +21,25 @@ public class CalibrationResponseMessage extends Message {
 
     private static final Pattern RESPONSE_PATTERN = Pattern.compile("(\\w{16})(\\w{8})(\\w{8})(\\w{8})(\\w{8})");
 
-    private float gaina;
-    private float gainb;
-    private float offtot;
-    private float offruis;
+    private double gainA;
+    private double gainB;
+    private double offsetTotal;
+    private double offsetNoise;
 
-    public float getGaina() {
-        return gaina;
+    public double getGainA() {
+        return gainA;
     }
 
-    public float getGainb() {
-        return gainb;
+    public double getGainB() {
+        return gainB;
     }
 
-    public float getOfftot() {
-        return offtot;
+    public double getOffsetTotal() {
+        return offsetTotal;
     }
 
-    public float getOffruis() {
-        return offruis;
+    public double getOffsetNoise() {
+        return offsetNoise;
     }
 
     public CalibrationResponseMessage(int sequenceNumber, String payLoad) {
@@ -58,10 +58,10 @@ public class CalibrationResponseMessage extends Message {
         if (matcher.matches()) {
             MAC = matcher.group(1);
 
-            gaina = Float.intBitsToFloat((int) (Long.parseLong(matcher.group(2), 16)));
-            gainb = Float.intBitsToFloat((int) (Long.parseLong(matcher.group(3), 16)));
-            offtot = Float.intBitsToFloat((int) (Long.parseLong(matcher.group(4), 16)));
-            offruis = Float.intBitsToFloat((int) (Long.parseLong(matcher.group(5), 16)));
+            gainA = Float.intBitsToFloat((int) (Long.parseLong(matcher.group(2), 16)));
+            gainB = Float.intBitsToFloat((int) (Long.parseLong(matcher.group(3), 16)));
+            offsetTotal = Float.intBitsToFloat((int) (Long.parseLong(matcher.group(4), 16)));
+            offsetNoise = Float.intBitsToFloat((int) (Long.parseLong(matcher.group(5), 16)));
         } else {
             logger.debug("Plugwise protocol RoleCallResponseMessage error: {} does not match", payLoad);
         }

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/InformationResponseMessage.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/InformationResponseMessage.java
@@ -96,7 +96,7 @@ public class InformationResponseMessage extends Message {
             year = Integer.parseInt(matcher.group(2), 16) + 2000;
             month = Integer.parseInt(matcher.group(3), 16);
             minutes = Integer.parseInt(matcher.group(4), 16);
-            logAddress = (Integer.parseInt(matcher.group(5), 16) - 278528) / 8;
+            logAddress = (Integer.parseInt(matcher.group(5), 16) - 278528) / 32;
             powerState = (matcher.group(6).equals("01"));
             hertz = Integer.parseInt(matcher.group(7), 16);
             hardwareVersion = StringUtils.left(matcher.group(8), 4) + "-" + StringUtils.mid(matcher.group(8), 4, 4)

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/PowerBufferRequestMessage.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/PowerBufferRequestMessage.java
@@ -26,7 +26,7 @@ public class PowerBufferRequestMessage extends Message {
 
     @Override
     protected String payLoadToHexString() {
-        return String.format("%08X", (logAddress * 8 + 278528));
+        return String.format("%08X", (logAddress * 32 + 278528));
     }
 
     @Override

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/PowerBufferResponseMessage.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/PowerBufferResponseMessage.java
@@ -62,22 +62,22 @@ public class PowerBufferResponseMessage extends Message {
                 datapoints[0] = null;
             }
             if (!matcher.group(4).equals("FFFFFFFF")) {
-                datapoints[1] = new Energy(matcher.group(2), Long.parseLong(matcher.group(5), 16), 3600);
+                datapoints[1] = new Energy(matcher.group(4), Long.parseLong(matcher.group(5), 16), 3600);
             } else {
                 datapoints[1] = null;
             }
             if (!matcher.group(6).equals("FFFFFFFF")) {
-                datapoints[2] = new Energy(matcher.group(2), Long.parseLong(matcher.group(7), 16), 3600);
+                datapoints[2] = new Energy(matcher.group(6), Long.parseLong(matcher.group(7), 16), 3600);
             } else {
                 datapoints[2] = null;
             }
             if (!matcher.group(8).equals("FFFFFFFF")) {
-                datapoints[3] = new Energy(matcher.group(2), Long.parseLong(matcher.group(9), 16), 3600);
+                datapoints[3] = new Energy(matcher.group(8), Long.parseLong(matcher.group(9), 16), 3600);
             } else {
                 datapoints[3] = null;
             }
 
-            logAddress = (Integer.parseInt(matcher.group(10), 16) - 278528) / 8;
+            logAddress = (Integer.parseInt(matcher.group(10), 16) - 278528) / 32;
         } else {
             logger.debug("Plugwise protocol PowerBufferResponseMessage error: {} does not match", payLoad);
         }

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/PowerInformationResponseMessage.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/protocol/PowerInformationResponseMessage.java
@@ -24,17 +24,13 @@ import org.openhab.binding.plugwise.internal.Energy;
 public class PowerInformationResponseMessage extends Message {
 
     private static final Pattern RESPONSE_PATTERN = Pattern
-            .compile("(\\w{16})(\\w{4})(\\w{4})(\\w{8})(\\w{4})(\\w{4})(\\w{4})");
+            .compile("(\\w{16})(\\w{4})(\\w{4})(\\w{8})(\\w{8})(\\w{4})");
 
     private Energy oneSecond;
     private Energy eightSecond;
-    private Energy allSeconds;
-    @SuppressWarnings("unused")
-    private int unknown1;
-    @SuppressWarnings("unused")
-    private int unknown2;
-    @SuppressWarnings("unused")
-    private int unknown3;
+    private Energy oneHourConsumed;
+    private Energy oneHourProduced;
+    private double secondsCorrection;
 
     public PowerInformationResponseMessage(int sequenceNumber, String payLoad) {
         super(sequenceNumber, payLoad);
@@ -51,13 +47,11 @@ public class PowerInformationResponseMessage extends Message {
         Matcher matcher = RESPONSE_PATTERN.matcher(payLoad);
         if (matcher.matches()) {
             MAC = matcher.group(1);
-            oneSecond = new Energy(DateTime.now(), Integer.parseInt(matcher.group(2), 16), 1);
-            eightSecond = new Energy(DateTime.now(), Integer.parseInt(matcher.group(3), 16), 8);
-            allSeconds = new Energy(DateTime.now(), Integer.parseInt(matcher.group(4), 16), 0);
-            unknown1 = Integer.parseInt(matcher.group(5), 16);
-            unknown2 = Integer.parseInt(matcher.group(6), 16);
-            unknown3 = Integer.parseInt(matcher.group(7), 16);
-
+            secondsCorrection = Integer.parseInt(matcher.group(6), 16) / 46875.0;
+            oneSecond = new Energy(DateTime.now(), Integer.parseInt(matcher.group(2), 16), 1 + secondsCorrection);
+            eightSecond = new Energy(DateTime.now(), Integer.parseInt(matcher.group(3), 16), 8 + secondsCorrection);
+            oneHourConsumed = new Energy(DateTime.now(), Long.parseLong(matcher.group(4), 16), 3600);
+            oneHourProduced = new Energy(DateTime.now(), Long.parseLong(matcher.group(5), 16), 3600);
         } else {
             logger.debug("Plugwise protocol PowerInformationResponseMessage error: {} does not match", payLoad);
         }
@@ -71,7 +65,11 @@ public class PowerInformationResponseMessage extends Message {
         return eightSecond;
     }
 
-    public Energy getAllSeconds() {
-        return allSeconds;
+    public Energy getOneHourConsumed() {
+        return oneHourConsumed;
+    }
+
+    public Energy getOneHourProduced() {
+        return oneHourProduced;
     }
 }


### PR DESCRIPTION
This PR improves the Plugwise Circle/Stealth power measurements as follows:
* Increase precision by using `PULSES_PER_KW_SECOND = 468.9385193` which is also used by all other Plugwise implementations on the internet, instead of `PULSE_FACTOR = 2.1324759f` which is: `1/(468.9385193/1000)` but with loss of precision
* Increase precision by using doubles instead of floats in calculations
* Use seconds correction that is part of the `PowerInformationResponseMessage`
* Fix wrong `Energy` date/time values being used in `PowerBufferResponseMessage`
* Corrected log address calculations in `InformationResponseMessage`, `PowerBufferRequestMessage`, `PowerBufferResponseMessage` because the original address calculation would cause the same logs returned multiple times (inspired by [Plugwise-2-pi](https://github.com/SevenW/Plugwise-2-py))
* Make sure Circle/Stealth last hour power consumption is always the last hour (also after startup) and is updated only after calibration took place

Power measurements now exactly match the decimals found in the Plugwise Source database (though with more precision).