### PR TITLE
temporarily removed dynamodb persistence as it breaks the build

### DIFF
--- a/bundles/persistence/pom.xml
+++ b/bundles/persistence/pom.xml
@@ -19,8 +19,8 @@
     <module>org.openhab.persistence.caldav</module>    
     <module>org.openhab.persistence.db4o</module>
     <module>org.openhab.persistence.db4o.test</module>
-    <module>org.openhab.persistence.dynamodb</module>
-    <module>org.openhab.persistence.dynamodb.test</module>
+<!--    <module>org.openhab.persistence.dynamodb</module>
+    <module>org.openhab.persistence.dynamodb.test</module>-->
     <module>org.openhab.persistence.logging</module>
     <module>org.openhab.persistence.sense</module>
     <module>org.openhab.persistence.rrd4j</module>


### PR DESCRIPTION
See https://openhab.ci.cloudbees.com/job/openHAB1-Addons/1404/console

Signed-off-by: Kai Kreuzer <kai@openhab.org>