### PR TITLE
bugfix: padding of temperature control hex string

### DIFF
--- a/bundles/binding/org.openhab.binding.fht/src/main/java/org/openhab/binding/fht/internal/FHTBinding.java
+++ b/bundles/binding/org.openhab.binding.fht/src/main/java/org/openhab/binding/fht/internal/FHTBinding.java
@@ -246,7 +246,7 @@ public class FHTBinding extends AbstractActiveBinding<FHTBindingProvider> implem
 			int temp = (int) (temperature * 2.0);
 
 			FHTDesiredTemperatureCommand commandItem = new FHTDesiredTemperatureCommand(config.getFullAddress(), "41"
-					+ Integer.toHexString(temp));
+					+ String.format("%02X", temp));
 			logger.debug("Queuing new desired temperature");
 			temperatureCommandQueue.put(config.getFullAddress(), commandItem);
 		} else {


### PR DESCRIPTION
The FHT binding would not send correct control commands for low temperature values.

(
Presumably, this bug was hidden for quite a long time, since virtually nobody sets low temperatures to heat their homes :-)
)

**Detailed bug description**
Temperature control command are hex strings following the "FHT80b syntax: THHHHCCAA" given in http://culfw.de/commandref.html#cmd_T. (Note: Temp commands can only be sent to FHT80b devices, i.e. the buggy method setDesiredTemperature(...) will not be called for commands requiring other syntax.)

Low temp values were converted to one-digit hex strings, whereas two-digit hex-strings are required, cf. the trailing AA part of the command string.

**Question**
This bug also exists in the 1.9 branch and in master. How to proceed? (It seems that the FHT binding does not yet exist in openhab2-addons, hence openhab2-addons can be ignored for now.)