### PR TITLE
[gcal] Ensure number updates and commands survive round trip

### DIFF
--- a/bundles/io/org.openhab.io.gcal/src/main/java/org/openhab/io/gcal/internal/util/ExecuteCommandJob.java
+++ b/bundles/io/org.openhab.io.gcal/src/main/java/org/openhab/io/gcal/internal/util/ExecuteCommandJob.java
@@ -177,9 +177,12 @@ public class ExecuteCommandJob implements Job {
         }
 
         StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(command));
-        tokenizer.wordChars('_', '_');
-        tokenizer.wordChars('-', '-');
-        tokenizer.wordChars('.', '.');
+        // treat all characters as ordinary, including digits, so we never
+        // have to deal with doubles
+        tokenizer.resetSyntax();
+        tokenizer.wordChars(0x23, 0xFF);
+        tokenizer.whitespaceChars(0x00, 0x20);
+        tokenizer.quoteChar('"');
 
         List<String> tokens = new ArrayList<String>();
         try {
@@ -191,9 +194,6 @@ public class ExecuteCommandJob implements Job {
                     case StreamTokenizer.TT_WORD:
                     case 34 /* quoted String */:
                         token = tokenizer.sval;
-                        break;
-                    case StreamTokenizer.TT_NUMBER:
-                        token = String.valueOf(tokenizer.nval);
                         break;
                 }
                 tokens.add(token);


### PR DESCRIPTION
The Google Calendar Scheduler is instructed to send a whole number for a PercentType like 50, but was sending 50.0 because the StreamTokenizer was identifying a number (TT_NUMBER) which means it gives a `double`, whose string representation of whole numbers ends in ".0".  This change causes TT_NUMBER tokens to never happen, so numbers are always their string representation, which can be dealt with

[Forum discussion](https://community.openhab.org/t/presence-simulation-with-google-calendar-scheduler/19281/19?u=watou)

Signed-off-by: John Cocula <john@cocula.com>