### PR TITLE
[jdbc] Update sqlite to latest version

### DIFF
--- a/bundles/persistence/org.openhab.persistence.jdbc/README.md
+++ b/bundles/persistence/org.openhab.persistence.jdbc/README.md
@@ -12,7 +12,7 @@ The generic design makes it relatively easy for developers to integrate other da
 | [MariaDB](https://mariadb.org/)              | [mariadb-java-client-1.4.6.jar](http://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client) |
 | [MySQL](https://www.mysql.com/)              | [mysql-connector-java-5.1.39.jar](http://mvnrepository.com/artifact/mysql/mysql-connector-java) |
 | [PostgreSQL](http://www.postgresql.org/)     | [postgresql-9.4.1209.jre7.jar](http://mvnrepository.com/artifact/org.postgresql/postgresql) |
-| [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.8.11.2.jar](http://mvnrepository.com/artifact/org.xerial/sqlite-jdbc) |
+| [SQLite](https://www.sqlite.org/)            | [sqlite-jdbc-3.16.1.jar](http://mvnrepository.com/artifact/org.xerial/sqlite-jdbc) |
 
 ## Table of Contents
 

--- a/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -297,7 +297,7 @@ public class JdbcConfiguration {
             } else if (serviceName.equals("postgresql")) {
                 warn += "\tPostgreSQL:version >= 9.4.1208 from    http://mvnrepository.com/artifact/org.postgresql/postgresql\n";
             } else if (serviceName.equals("sqlite")) {
-                warn += "\tSQLite:    version >= 3.8.11.2 from           http://mvnrepository.com/artifact/org.xerial/sqlite-jdbc\n";
+                warn += "\tSQLite:    version >= 3.16.1 from           http://mvnrepository.com/artifact/org.xerial/sqlite-jdbc\n";
             }
             logger.warn(warn, serviceName);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<mariadb.version>1.3.5</mariadb.version>
 		<mysql.version>5.1.38</mysql.version>
 		<postgresql.version>9.4.1212</postgresql.version>
-		<sqlite.version>3.8.11.2</sqlite.version>
+		<sqlite.version>3.16.1</sqlite.version>
 
     </properties>
 


### PR DESCRIPTION
fixes crash on startup in raspberry pi, 3.8.11.2 does not work with armhf proc.

[Forum discussion](https://community.openhab.org/t/openhab2-jdbc-persistence-sqlite/16088/9)

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGILL (0x4) at pc=0xa5c38cb0, pid=14062, tid=0xab273460
#
# JRE version: Java(TM) SE Runtime Environment (8.0_121-b13) (build 1.8.0_121-b13)
# Java VM: Java HotSpot(TM) Client VM (25.121-b13 mixed mode linux-arm )
# Problematic frame:
# C  [sqlite-3.8.11.2-5a76de3a-1d60-4101-b599-a9158d4ca28f-libsqlitejdbc.so+0x5cb0]
#
# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#

Stack: [0xab224000,0xab274000],  sp=0xab26f900,  free space=302k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [sqlite-3.8.11.2-5a76de3a-1d60-4101-b599-a9158d4ca28f-libsqlitejdbc.so+0x5cb0]

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  java.lang.ClassLoader$NativeLibrary.load(Ljava/lang/String;Z)V+0
j  java.lang.ClassLoader.loadLibrary0(Ljava/lang/Class;Ljava/io/File;)Z+328
j  java.lang.ClassLoader.loadLibrary(Ljava/lang/Class;Ljava/lang/String;Z)V+48
j  java.lang.Runtime.load0(Ljava/lang/Class;Ljava/lang/String;)V+57
j  java.lang.System.load(Ljava/lang/String;)V+7
j  org.sqlite.SQLiteJDBCLoader.loadNativeLibrary(Ljava/lang/String;Ljava/lang/String;)Z+29
j  org.sqlite.SQLiteJDBCLoader.extractAndLoadLibraryFile(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z+308
j  org.sqlite.SQLiteJDBCLoader.loadSQLiteNativeLibrary()V+224
j  org.sqlite.SQLiteJDBCLoader.initialize()Z+0
j  org.sqlite.core.NativeDB.load()Z+19

```