### PR TITLE
[ZWave] Support ZD2102 from Zipato

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -3418,6 +3418,15 @@
             <Label lang="en">RGBW bulb</Label>
             <ConfigFile>zipato/rgbwe27.xml</ConfigFile>
         </Product>
+        <Product>
+            <Reference>
+                <Type>2001</Type>
+                <Id>0106</Id>
+            </Reference>
+            <Model>ZD2102</Model>
+            <Label lang="en">Door Window Sensor</Label>
+            <ConfigFile>vision/zd2102.xml</ConfigFile>
+        </Product>
     </Manufacturer>
     <Manufacturer>
         <Id>0138</Id>


### PR DESCRIPTION
Hi,

Following this thread https://community.openhab.org/t/vision-zipato-zd2102-not-recognized/20083.
Windows sensor Vision Security ZD2102 is also available from Zipato manufacturer. It is exactly the same product, but the manufacturer ID is not the same.