### PR TITLE
Added Rapid Refresh delay as a optional configuration

### DIFF
--- a/bundles/binding/org.openhab.binding.myq/src/main/java/org/openhab/binding/myq/internal/MyqBinding.java
+++ b/bundles/binding/org.openhab.binding.myq/src/main/java/org/openhab/binding/myq/internal/MyqBinding.java
@@ -83,7 +83,7 @@ public class MyqBinding extends AbstractBinding<MyqBindingProvider> {
     /**
      * When polling quickly, how often do we poll
      */
-    private static int RAPID_REFRESH = 2000;
+    private int rapidRefresh = 2000;
 
     /**
      * Cap the time we poll rapidly to not overwhelm the servers with api
@@ -129,6 +129,11 @@ public class MyqBinding extends AbstractBinding<MyqBindingProvider> {
         String refreshIntervalString = Objects.toString(configuration.get("refresh"), null);
         if (StringUtils.isNotBlank(refreshIntervalString)) {
             refreshInterval = Long.parseLong(refreshIntervalString);
+        }
+
+        String quickrefreshIntervalString = Objects.toString(configuration.get("quickrefresh"), null);
+        if (StringUtils.isNotBlank(quickrefreshIntervalString)) {
+            rapidRefresh = Integer.parseInt(quickrefreshIntervalString);
         }
 
         // update the internal configuration accordingly
@@ -352,10 +357,10 @@ public class MyqBinding extends AbstractBinding<MyqBindingProvider> {
                     LampDevice lampModule = (LampDevice) device;
                     if (command.equals(OnOffType.ON)) {
                         myqOnlineData.executeMyQCommand(lampModule.getDeviceId(), "desiredlightstate", 1);
-                        beginRapidPoll(true);
+                        doFuturePoll(rapidRefresh);
                     } else if (command.equals(OnOffType.OFF)) {
                         myqOnlineData.executeMyQCommand(lampModule.getDeviceId(), "desiredlightstate", 0);
-                        beginRapidPoll(true);
+                        doFuturePoll(rapidRefresh);
                     } else {
                         logger.warn("Unknown command {}", command);
                     }
@@ -431,8 +436,22 @@ public class MyqBinding extends AbstractBinding<MyqBindingProvider> {
         }
 
         if (pollResetFuture == null || pollResetFuture.isCancelled()) {
-            schedulePoll(RAPID_REFRESH);
+            schedulePoll(rapidRefresh);
             scheduleFuturePollReset();
         }
+    }
+
+    /**
+     * schedule a Poll in the near future
+     */
+    private void doFuturePoll(long millis) {
+        //
+        pollResetFuture = pollService.schedule(new Runnable() {
+            @Override
+            public void run() {
+                logger.trace("do schedule poll");
+                poll();
+            }
+        }, millis, TimeUnit.MILLISECONDS);
     }
 }

--- a/features/openhab-addons-external/src/main/resources/conf/myq.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/myq.cfg
@@ -1,6 +1,9 @@
 # Data refresh interval in ms (optional, defaults to 60000)
 #refresh=60000
 
+# Data refresh interval after Event is trigger in ms (optional, defaults to 2000)
+#quickrefresh=2000
+
 # Timeout for HTTP requests (optional, defaults to 5000)
 #timeout=5000
 


### PR DESCRIPTION
Added Rapid Refresh delay as a optional configuration. Lamp devices will no longer do rapid refresh for an extended time like garage doors devices, it will just poll once now. This fixes MyQ server timeout issues. 

See forum topic below for more info:
https://community.openhab.org/t/chamberlain-myq-binding/4192/124