### PR TITLE
Fixed incorrect gcal test

### DIFF
--- a/bundles/io/org.openhab.io.gcal.test/src/test/java/org/openhab/io/gcal/internal/util/ExecuteCommandJobTest.java
+++ b/bundles/io/org.openhab.io.gcal.test/src/test/java/org/openhab/io/gcal/internal/util/ExecuteCommandJobTest.java
@@ -47,7 +47,7 @@ public class ExecuteCommandJobTest {
         content = commandJob.parseCommand("send ItemName 125");
         Assert.assertEquals("send", content[0]);
         Assert.assertEquals("ItemName", content[1]);
-        Assert.assertEquals("125.0", content[2]);
+        Assert.assertEquals("125", content[2]);
 
         content = commandJob.parseCommand("> say(\"Hello\")");
         Assert.assertEquals(">", content[0]);


### PR DESCRIPTION
Test was expecting the incorrect ".0" in the parse result.  See #5039 