### PR TITLE
[DSCAlarm] Bug Fix: DSC Alarm Command 060 Not Working

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
@@ -321,14 +321,15 @@ public class API {
             case CommandOutputControl: /* 020 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
                     logger.error(
-                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: "
-                                    + apiData[0]);
+                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
+                            apiData[0]);
                     break;
                 }
 
                 if (apiData[1] == null || !apiData[1].matches("[1-4]")) {
-                    logger.error("sendCommand(): Output number must be a single character string from 1 to 4, it was: "
-                            + apiData[1]);
+                    logger.error(
+                            "sendCommand(): Output number must be a single character string from 1 to 4, it was: {}",
+                            apiData[1]);
                     break;
                 }
 

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
@@ -239,7 +239,8 @@ public class API {
             logger.error("open(): Unable to Make API Connection!");
         }
 
-        logger.debug("open(): Connected = {}, Connection Type: {}, Interface Type: {}", connected ? true : false, connectorType, interfaceType);
+        logger.debug("open(): Connected = {}, Connection Type: {}, Interface Type: {}", connected ? true : false,
+                connectorType, interfaceType);
 
         return connected;
     }
@@ -319,12 +320,15 @@ public class API {
                 break;
             case CommandOutputControl: /* 020 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: " + apiData[0]);
+                    logger.error(
+                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: "
+                                    + apiData[0]);
                     break;
                 }
 
                 if (apiData[1] == null || !apiData[1].matches("[1-4]")) {
-                    logger.error("sendCommand(): Output number must be a single character string from 1 to 4, it was: " + apiData[1]);
+                    logger.error("sendCommand(): Output number must be a single character string from 1 to 4, it was: "
+                            + apiData[1]);
                     break;
                 }
 
@@ -339,7 +343,9 @@ public class API {
             case PartitionArmControlStay: /* 031 */
             case PartitionArmControlZeroEntryDelay: /* 032 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
+                    logger.error(
+                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
+                            apiData[0]);
                     break;
                 }
                 data = apiData[0];
@@ -348,12 +354,15 @@ public class API {
             case PartitionArmControlWithUserCode: /* 033 */
             case PartitionDisarmControl: /* 040 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
+                    logger.error(
+                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
+                            apiData[0]);
                     break;
                 }
 
                 if (dscAlarmUserCode == null || dscAlarmUserCode.length() < 4 || dscAlarmUserCode.length() > 6) {
-                    logger.error("sendCommand(): User Code is invalid, must be between 4 and 6 chars: {}", dscAlarmUserCode);
+                    logger.error("sendCommand(): User Code is invalid, must be between 4 and 6 chars: {}",
+                            dscAlarmUserCode);
                     break;
                 }
 
@@ -379,27 +388,28 @@ public class API {
                 validCommand = true;
                 break;
             case TriggerPanicAlarm: /* 060 */
-                if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
+                if (apiData[0] == null || !apiData[0].matches("[1-3]")) {
+                    logger.error("sendCommand(): FAPcode must be a single character string from 1 to 3, it was: {}",
+                            apiData[0]);
                     break;
                 }
-
-                if (apiData[1] == null || !apiData[1].matches("[1-3]")) {
-                    logger.error("sendCommand(): FAPcode must be a single character string from 1 to 3, it was: {}", apiData[1]);
-                    break;
-                }
-                data = apiData[0] + apiData[1];
+                data = apiData[0];
                 validCommand = true;
                 break;
             case KeyStroke: /* 070 */
                 if (interfaceType.equals(DSCAlarmInterfaceType.ENVISALINK)) {
                     if (apiData[0] == null || apiData[0].length() != 1 || !apiData[0].matches("[0-9]|A|\\*|#")) {
-                        logger.error("sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, or A, it was: {}", apiData[0]);
+                        logger.error(
+                                "sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, or A, it was: {}",
+                                apiData[0]);
                         break;
                     }
                 } else if (interfaceType.equals(DSCAlarmInterfaceType.IT100)) {
-                    if (apiData[0] == null || apiData[0].length() != 1 || !apiData[0].matches("[0-9]|\\*|#|F|A|P|[a-e]|<|>|=|\\^|L")) {
-                        logger.error("sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, F, A, P, a to e, <, >, =, or ^, it was: {}", apiData[0]);
+                    if (apiData[0] == null || apiData[0].length() != 1
+                            || !apiData[0].matches("[0-9]|\\*|#|F|A|P|[a-e]|<|>|=|\\^|L")) {
+                        logger.error(
+                                "sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, F, A, P, a to e, <, >, =, or ^, it was: {}",
+                                apiData[0]);
                         break;
                     } else if (apiData[0].equals("L")) { /* Long Key Press */
                         try {
@@ -425,7 +435,9 @@ public class API {
                 }
 
                 if (apiData[0] == null || apiData[0].length() > 6 || !apiData[0].matches("(\\d|#|\\*)+")) {
-                    logger.error("sendCommand(): \'keysequence\' must be a string of up to 6 characters consiting of 0 to 9, *, or #, it was: {}", apiData[0]);
+                    logger.error(
+                            "sendCommand(): \'keysequence\' must be a string of up to 6 characters consiting of 0 to 9, *, or #, it was: {}",
+                            apiData[0]);
                     break;
                 }
                 data = apiData[0];
@@ -433,7 +445,8 @@ public class API {
                 break;
             case CodeSend: /* 200 */
                 if (dscAlarmUserCode == null || dscAlarmUserCode.length() < 4 || dscAlarmUserCode.length() > 6) {
-                    logger.error("sendCommand(): Access Code is invalid, must be between 4 and 6 chars: {}", apiData[0]);
+                    logger.error("sendCommand(): Access Code is invalid, must be between 4 and 6 chars: {}",
+                            apiData[0]);
                     break;
                 }
                 data = dscAlarmUserCode;


### PR DESCRIPTION
The DSC Alarm command was not working correctly.  The binding was
erroneously checking for a partition number which is not required by
this command.  This has been tested as seen [here](https://community.openhab.org/t/dsc-alarm-binding-sending-code-for-the-panic-button/23314/2), and found to be working correctly.

Signed-off by: Russell Stephens rsstephens@gmail.com (github:@RSStephens)