### PR TITLE
[Squeeze] Fix playing time error

### DIFF
--- a/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeboxBinding.java
+++ b/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeboxBinding.java
@@ -154,7 +154,7 @@ public class SqueezeboxBinding extends AbstractBinding<SqueezeboxBindingProvider
                         logger.warn("Unsupported command type '{}'", bindingConfig.getCommandType());
                 }
             } catch (Exception e) {
-                logger.warn("Error executing command type '" + bindingConfig.getCommandType() + "'", e);
+                logger.warn("Error executing command type '{}'", bindingConfig.getCommandType(), e);
             }
         }
     }
@@ -171,12 +171,12 @@ public class SqueezeboxBinding extends AbstractBinding<SqueezeboxBindingProvider
 
     @Override
     public void volumeChangeEvent(PlayerEvent event) {
-        numberChangeEvent(event.getPlayerId(), CommandType.VOLUME, event.getPlayer().getVolume());
+        percentChangeEvent(event.getPlayerId(), CommandType.VOLUME, event.getPlayer().getVolume());
     }
 
     @Override
     public void currentPlaylistIndexEvent(PlayerEvent event) {
-        numberChangeEvent(event.getPlayerId(), CommandType.CURRTRACK, event.getPlayer().getCurrentPlaylistIndex());
+        percentChangeEvent(event.getPlayerId(), CommandType.CURRTRACK, event.getPlayer().getCurrentPlaylistIndex());
     }
 
     @Override
@@ -186,17 +186,17 @@ public class SqueezeboxBinding extends AbstractBinding<SqueezeboxBindingProvider
 
     @Override
     public void numberPlaylistTracksEvent(PlayerEvent event) {
-        numberChangeEvent(event.getPlayerId(), CommandType.NUMTRACKS, event.getPlayer().getNumberPlaylistTracks());
+        percentChangeEvent(event.getPlayerId(), CommandType.NUMTRACKS, event.getPlayer().getNumberPlaylistTracks());
     }
 
     @Override
     public void currentPlaylistShuffleEvent(PlayerEvent event) {
-        numberChangeEvent(event.getPlayerId(), CommandType.SHUFFLE, event.getPlayer().getCurrentPlaylistShuffle());
+        percentChangeEvent(event.getPlayerId(), CommandType.SHUFFLE, event.getPlayer().getCurrentPlaylistShuffle());
     }
 
     @Override
     public void currentPlaylistRepeatEvent(PlayerEvent event) {
-        numberChangeEvent(event.getPlayerId(), CommandType.REPEAT, event.getPlayer().getCurrentPlaylistRepeat());
+        percentChangeEvent(event.getPlayerId(), CommandType.REPEAT, event.getPlayer().getCurrentPlaylistRepeat());
     }
 
     @Override
@@ -247,23 +247,28 @@ public class SqueezeboxBinding extends AbstractBinding<SqueezeboxBindingProvider
     }
 
     private void stringChangeEvent(String playerId, CommandType commandType, String newState) {
-        logger.debug("SqueezePlayer " + playerId + " -> " + commandType.getCommand() + ": " + newState);
+        logger.debug("SqueezePlayer {} -> {}: {}", playerId, commandType.getCommand(), newState);
         for (String itemName : getItemNames(playerId, commandType)) {
             eventPublisher.postUpdate(itemName, StringType.valueOf(newState));
         }
     }
 
-    private void numberChangeEvent(String playerId, CommandType commandType, int newState) {
-        logger.debug(
-                "SqueezePlayer " + playerId + " -> " + commandType.getCommand() + ": " + Integer.toString(newState));
+    private void percentChangeEvent(String playerId, CommandType commandType, int newState) {
+        logger.debug("SqueezePlayer {} -> {}: {}", playerId, commandType.getCommand(), newState);
         for (String itemName : getItemNames(playerId, commandType)) {
             eventPublisher.postUpdate(itemName, new PercentType(newState));
         }
     }
 
+    private void numberChangeEvent(String playerId, CommandType commandType, int newState) {
+        logger.debug("SqueezePlayer {} -> {}: {}", playerId, commandType.getCommand(), newState);
+        for (String itemName : getItemNames(playerId, commandType)) {
+            eventPublisher.postUpdate(itemName, new DecimalType(newState));
+        }
+    }
+
     private void booleanChangeEvent(String playerId, CommandType commandType, boolean newState) {
-        logger.debug(
-                "SqueezePlayer " + playerId + " -> " + commandType.getCommand() + ": " + Boolean.toString(newState));
+        logger.debug("SqueezePlayer {} -> {}: {}", playerId, commandType.getCommand(), newState);
         for (String itemName : getItemNames(playerId, commandType)) {
             if (newState) {
                 eventPublisher.postUpdate(itemName, OnOffType.ON);

--- a/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeboxBinding.java
+++ b/bundles/binding/org.openhab.binding.squeezebox/src/main/java/org/openhab/binding/squeezebox/internal/SqueezeboxBinding.java
@@ -176,7 +176,7 @@ public class SqueezeboxBinding extends AbstractBinding<SqueezeboxBindingProvider
 
     @Override
     public void currentPlaylistIndexEvent(PlayerEvent event) {
-        percentChangeEvent(event.getPlayerId(), CommandType.CURRTRACK, event.getPlayer().getCurrentPlaylistIndex());
+        numberChangeEvent(event.getPlayerId(), CommandType.CURRTRACK, event.getPlayer().getCurrentPlaylistIndex());
     }
 
     @Override
@@ -186,17 +186,17 @@ public class SqueezeboxBinding extends AbstractBinding<SqueezeboxBindingProvider
 
     @Override
     public void numberPlaylistTracksEvent(PlayerEvent event) {
-        percentChangeEvent(event.getPlayerId(), CommandType.NUMTRACKS, event.getPlayer().getNumberPlaylistTracks());
+        numberChangeEvent(event.getPlayerId(), CommandType.NUMTRACKS, event.getPlayer().getNumberPlaylistTracks());
     }
 
     @Override
     public void currentPlaylistShuffleEvent(PlayerEvent event) {
-        percentChangeEvent(event.getPlayerId(), CommandType.SHUFFLE, event.getPlayer().getCurrentPlaylistShuffle());
+        numberChangeEvent(event.getPlayerId(), CommandType.SHUFFLE, event.getPlayer().getCurrentPlaylistShuffle());
     }
 
     @Override
     public void currentPlaylistRepeatEvent(PlayerEvent event) {
-        percentChangeEvent(event.getPlayerId(), CommandType.REPEAT, event.getPlayer().getCurrentPlaylistRepeat());
+        numberChangeEvent(event.getPlayerId(), CommandType.REPEAT, event.getPlayer().getCurrentPlaylistRepeat());
     }
 
     @Override


### PR DESCRIPTION
Fix the playing time to use a number and not a percent.

Rename the numberChangeEvent() method to percentChangeEvent().
Add a new numberChangeEvent() method that uses DecimalType instead of PercentType.

Fixes #3542.