### PR TITLE
[CalDAV] Various configuration fixes

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
@@ -239,7 +239,8 @@ public class API {
             logger.error("open(): Unable to Make API Connection!");
         }
 
-        logger.debug("open(): Connected = {}, Connection Type: {}, Interface Type: {}", connected ? true : false, connectorType, interfaceType);
+        logger.debug("open(): Connected = {}, Connection Type: {}, Interface Type: {}", connected ? true : false,
+                connectorType, interfaceType);
 
         return connected;
     }
@@ -319,12 +320,16 @@ public class API {
                 break;
             case CommandOutputControl: /* 020 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: " + apiData[0]);
+                    logger.error(
+                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
+                            apiData[0]);
                     break;
                 }
 
                 if (apiData[1] == null || !apiData[1].matches("[1-4]")) {
-                    logger.error("sendCommand(): Output number must be a single character string from 1 to 4, it was: " + apiData[1]);
+                    logger.error(
+                            "sendCommand(): Output number must be a single character string from 1 to 4, it was: {}",
+                            apiData[1]);
                     break;
                 }
 
@@ -339,7 +344,9 @@ public class API {
             case PartitionArmControlStay: /* 031 */
             case PartitionArmControlZeroEntryDelay: /* 032 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
+                    logger.error(
+                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
+                            apiData[0]);
                     break;
                 }
                 data = apiData[0];
@@ -348,12 +355,15 @@ public class API {
             case PartitionArmControlWithUserCode: /* 033 */
             case PartitionDisarmControl: /* 040 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
+                    logger.error(
+                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
+                            apiData[0]);
                     break;
                 }
 
                 if (dscAlarmUserCode == null || dscAlarmUserCode.length() < 4 || dscAlarmUserCode.length() > 6) {
-                    logger.error("sendCommand(): User Code is invalid, must be between 4 and 6 chars: {}", dscAlarmUserCode);
+                    logger.error("sendCommand(): User Code is invalid, must be between 4 and 6 chars: {}",
+                            dscAlarmUserCode);
                     break;
                 }
 
@@ -379,27 +389,28 @@ public class API {
                 validCommand = true;
                 break;
             case TriggerPanicAlarm: /* 060 */
-                if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
+                if (apiData[0] == null || !apiData[0].matches("[1-3]")) {
+                    logger.error("sendCommand(): FAPcode must be a single character string from 1 to 3, it was: {}",
+                            apiData[0]);
                     break;
                 }
-
-                if (apiData[1] == null || !apiData[1].matches("[1-3]")) {
-                    logger.error("sendCommand(): FAPcode must be a single character string from 1 to 3, it was: {}", apiData[1]);
-                    break;
-                }
-                data = apiData[0] + apiData[1];
+                data = apiData[0];
                 validCommand = true;
                 break;
             case KeyStroke: /* 070 */
                 if (interfaceType.equals(DSCAlarmInterfaceType.ENVISALINK)) {
                     if (apiData[0] == null || apiData[0].length() != 1 || !apiData[0].matches("[0-9]|A|\\*|#")) {
-                        logger.error("sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, or A, it was: {}", apiData[0]);
+                        logger.error(
+                                "sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, or A, it was: {}",
+                                apiData[0]);
                         break;
                     }
                 } else if (interfaceType.equals(DSCAlarmInterfaceType.IT100)) {
-                    if (apiData[0] == null || apiData[0].length() != 1 || !apiData[0].matches("[0-9]|\\*|#|F|A|P|[a-e]|<|>|=|\\^|L")) {
-                        logger.error("sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, F, A, P, a to e, <, >, =, or ^, it was: {}", apiData[0]);
+                    if (apiData[0] == null || apiData[0].length() != 1
+                            || !apiData[0].matches("[0-9]|\\*|#|F|A|P|[a-e]|<|>|=|\\^|L")) {
+                        logger.error(
+                                "sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, F, A, P, a to e, <, >, =, or ^, it was: {}",
+                                apiData[0]);
                         break;
                     } else if (apiData[0].equals("L")) { /* Long Key Press */
                         try {
@@ -425,7 +436,9 @@ public class API {
                 }
 
                 if (apiData[0] == null || apiData[0].length() > 6 || !apiData[0].matches("(\\d|#|\\*)+")) {
-                    logger.error("sendCommand(): \'keysequence\' must be a string of up to 6 characters consiting of 0 to 9, *, or #, it was: {}", apiData[0]);
+                    logger.error(
+                            "sendCommand(): \'keysequence\' must be a string of up to 6 characters consiting of 0 to 9, *, or #, it was: {}",
+                            apiData[0]);
                     break;
                 }
                 data = apiData[0];
@@ -433,7 +446,8 @@ public class API {
                 break;
             case CodeSend: /* 200 */
                 if (dscAlarmUserCode == null || dscAlarmUserCode.length() < 4 || dscAlarmUserCode.length() > 6) {
-                    logger.error("sendCommand(): Access Code is invalid, must be between 4 and 6 chars: {}", apiData[0]);
+                    logger.error("sendCommand(): Access Code is invalid, must be between 4 and 6 chars: {}",
+                            apiData[0]);
                     break;
                 }
                 data = dscAlarmUserCode;

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.tcp.Direction;
 import org.openhab.binding.tcp.protocol.ProtocolBindingProvider;
@@ -61,9 +60,9 @@ abstract class ProtocolGenericBindingProvider extends AbstractGenericBindingProv
     private static final Pattern ACTION_CONFIG_PATTERN = Pattern
             .compile("(<|>)\\[(.*?):(.*?):(.*?):(?:'(.*)'|(.*))\\]");
     private static final Pattern STATUS_CONFIG_PATTERN = Pattern.compile("(<|>)\\[(.*?):(.*?):(?:'(.*)'|(.*))\\]");
-    
+
     private static final Command WILDCARD_COMMAND_KEY = StringType.valueOf("*");
-    
+
     static int counter = 0;
 
     @Override
@@ -273,7 +272,7 @@ abstract class ProtocolGenericBindingProvider extends AbstractGenericBindingProv
      * {@link ProtocolBindingConfigElement }. There will be map like
      * <code>ON->ProtocolBindingConfigElement</code>
      */
-    static class ProtocolBindingConfig extends HashMap<Command, ProtocolBindingConfigElement>implements BindingConfig {
+    static class ProtocolBindingConfig extends HashMap<Command, ProtocolBindingConfigElement> implements BindingConfig {
 
         private static final long serialVersionUID = 6363085986521089771L;
 

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.tcp.Direction;
 import org.openhab.binding.tcp.protocol.ProtocolBindingProvider;
@@ -60,9 +61,9 @@ abstract class ProtocolGenericBindingProvider extends AbstractGenericBindingProv
     private static final Pattern ACTION_CONFIG_PATTERN = Pattern
             .compile("(<|>)\\[(.*?):(.*?):(.*?):(?:'(.*)'|(.*))\\]");
     private static final Pattern STATUS_CONFIG_PATTERN = Pattern.compile("(<|>)\\[(.*?):(.*?):(?:'(.*)'|(.*))\\]");
-
+    
     private static final Command WILDCARD_COMMAND_KEY = StringType.valueOf("*");
-
+    
     static int counter = 0;
 
     @Override
@@ -272,7 +273,7 @@ abstract class ProtocolGenericBindingProvider extends AbstractGenericBindingProv
      * {@link ProtocolBindingConfigElement }. There will be map like
      * <code>ON->ProtocolBindingConfigElement</code>
      */
-    static class ProtocolBindingConfig extends HashMap<Command, ProtocolBindingConfigElement> implements BindingConfig {
+    static class ProtocolBindingConfig extends HashMap<Command, ProtocolBindingConfigElement>implements BindingConfig {
 
         private static final long serialVersionUID = 6363085986521089771L;
 

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.tcp.protocol.internal;
 
-import java.net.InetAddress; 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.tcp.protocol.internal;
 
-import java.net.InetAddress;
+import java.net.InetAddress; 
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2016 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,13 +33,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * UDPBinding is an implementation of a UDP based ASCII protocol. It sends and receives
+ * UDPBinding is most "simple" implementation of a UDP based ASCII protocol. It sends and received
  * data as ASCII strings. Data sent out is padded with a CR/LF. This should be sufficient for a lot
  * of home automation devices that take simple ASCII based control commands, or that send back
- * text based status messages.
+ * text based status messages
+ *
  *
  * @author Karel Goderis
  * @since 1.1.0
+ *
  */
 public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvider> implements ManagedService {
 
@@ -67,66 +69,69 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
 
         ProtocolBindingProvider provider = findFirstMatchingBindingProvider(itemName);
 
-        if (command == null) {
-            return false;
-        }
+        if (command != null) {
 
-        String transformedMessage = transformResponse(provider.getProtocolCommand(itemName, command), commandAsString);
-        String UDPCommandName = preAmble + transformedMessage + postAmble;
+            String transformedMessage = transformResponse(provider.getProtocolCommand(itemName, command),
+                    commandAsString);
+            String UDPCommandName = preAmble + transformedMessage + postAmble;
 
-        ByteBuffer outputBuffer = null;
-        try {
-            outputBuffer = ByteBuffer.allocate(UDPCommandName.getBytes(charset).length);
-            outputBuffer.put(UDPCommandName.getBytes(charset));
-        } catch (UnsupportedEncodingException e) {
-            logger.warn("Data for output buffer appears to be using an unsupported encoding");
-        }
-
-        // send the buffer in an asynchronous way
-        ByteBuffer result = null;
-        try {
-            result = writeBuffer(outputBuffer, sChannel, blocking, timeOut);
-        } catch (Exception e) {
-            logger.warn("An exception occurred while writing a buffer to a channel", e);
-        }
-
-        if (result != null && blocking) {
-            String resultString = "";
+            ByteBuffer outputBuffer = null;
             try {
-                resultString = new String(result.array(), charset);
+                outputBuffer = ByteBuffer.allocate(UDPCommandName.getBytes(charset).length);
+                outputBuffer.put(UDPCommandName.getBytes(charset));
             } catch (UnsupportedEncodingException e) {
-                logger.warn("Data received from write operation appears to be using an unsupported encoding");
+                logger.warn("Exception while attempting an unsupported encoding scheme");
             }
 
-            logger.info("Received {} from the remote end {}", resultString, sChannel.toString());
-            String transformedResponse = transformResponse(provider.getProtocolCommand(itemName, command),
-                    resultString);
+            // send the buffer in an asynchronous way
+            ByteBuffer result = null;
+            try {
+                result = writeBuffer(outputBuffer, sChannel, blocking, timeOut);
+            } catch (Exception e) {
+                logger.error("An exception occurred while writing a buffer to a channel: {}", e.getMessage());
+            }
 
-            // if the remote-end does not send a reply in response to the string we just sent, then the
-            // abstract superclass will update the openhab status of the item for us. If it does reply,
-            // then an additional update is done via parseBuffer.
-            // since this binding does not know about the specific protocol, there might be two state
-            // updates (the command, and if the case, the reply from the remote-end)
-
-            if (updateWithResponse) {
-
-                List<Class<? extends State>> stateTypeList = provider.getAcceptedDataTypes(itemName, command);
-                State newState = createStateFromString(stateTypeList, transformedResponse);
-
-                if (newState != null) {
-                    eventPublisher.postUpdate(itemName, newState);
-                } else {
-                    logger.warn("Can not parse transformed input {} to match command {} on item {}",
-                            transformedResponse, command, itemName);
+            if (result != null && blocking) {
+                String resultString = "";
+                try {
+                    resultString = new String(result.array(), charset);
+                } catch (UnsupportedEncodingException e) {
+                    logger.warn("Exception while attempting an unsupported encoding scheme");
                 }
 
-                return false;
+                logger.info("Received {} from the remote end {}", resultString, sChannel.toString());
+                String transformedResponse = transformResponse(provider.getProtocolCommand(itemName, command),
+                        resultString);
+
+                // if the remote-end does not send a reply in response to the string we just sent, then the abstract
+                // superclass will update
+                // the openhab status of the item for us. If it does reply, then an additional update is done via
+                // parseBuffer.
+                // since this TCP binding does not know about the specific protocol, there might be two state updates
+                // (the command, and if
+                // the case, the reply from the remote-end)
+
+                if (updateWithResponse) {
+
+                    List<Class<? extends State>> stateTypeList = provider.getAcceptedDataTypes(itemName, command);
+                    State newState = createStateFromString(stateTypeList, transformedResponse);
+
+                    if (newState != null) {
+                        eventPublisher.postUpdate(itemName, newState);
+                    } else {
+                        logger.warn("Can not parse transformed input " + transformedResponse
+                                + " to match command {} on item {}  ", command, itemName);
+                    }
+
+                    return false;
+                } else {
+                    return true;
+                }
             } else {
                 return true;
             }
-        } else {
-            return true;
         }
+        return false;
     }
 
     /**
@@ -142,16 +147,11 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
         String theUpdate = "";
         try {
             theUpdate = new String(byteBuffer.array(), charset);
-            logger.debug("parseBuffer constructed update: '{}'", theUpdate);
         } catch (UnsupportedEncodingException e) {
             logger.warn("Exception while attempting an unsupported encoding scheme");
         }
 
         ProtocolBindingProvider provider = findFirstMatchingBindingProvider(itemName);
-        if (provider == null) {
-            logger.warn("No provider could be found for the item '{}'", itemName);
-            return;
-        }
 
         List<Class<? extends State>> stateTypeList = provider.getAcceptedDataTypes(itemName, aCommand);
 
@@ -161,7 +161,7 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
         if (newState != null) {
             eventPublisher.postUpdate(itemName, newState);
         } else {
-            logger.warn("Cannot parse input {} to match command {} on item {}", theUpdate, aCommand, itemName);
+            logger.warn("Can not parse input " + theUpdate + " to match command {} on item {}  ", aCommand, itemName);
         }
     }
 
@@ -179,62 +179,63 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
 
         super.updated(config);
 
-        if (config == null) {
-            return;
-        }
+        if (config != null) {
 
-        String timeOutString = Objects.toString(config.get("buffersize"), null);
-        if (isNotBlank(timeOutString)) {
-            timeOut = Integer.parseInt(timeOutString);
-        } else {
-            logger.info("The maximum timeout for blocking write operations will be set to the default value of {}",
-                    timeOut);
-        }
-
-        String blockingString = Objects.toString(config.get("retryinterval"), null);
-        if (isNotBlank(blockingString)) {
-            blocking = Boolean.parseBoolean(blockingString);
-        } else {
-            logger.info("The blocking nature of read/write operations will be set to the default value of {}",
-                    blocking);
-        }
-
-        String preambleString = Objects.toString(config.get("preamble"), null);
-        if (isNotBlank(preambleString)) {
-            try {
-                preAmble = preambleString.replaceAll("\\\\", "\\");
-            } catch (Exception e) {
-                preAmble = preambleString;
+            String timeOutString = (String) config.get("buffersize");
+            if (isNotBlank(timeOutString)) {
+                timeOut = Integer.parseInt((timeOutString));
+            } else {
+                logger.info("The maximum time out for blocking write operations will be set to the default value of {}",
+                        timeOut);
             }
-        } else {
-            logger.info("The preamble for all write operations will be set to the default value of {}", preAmble);
-        }
 
-        String postambleString = Objects.toString(config.get("postamble"), null);
-        if (isNotBlank(postambleString)) {
-            try {
-                postAmble = postambleString.replaceAll("\\\\", "\\");
-            } catch (Exception e) {
-                postAmble = postambleString;
+            String blockingString = (String) config.get("retryinterval");
+            if (isNotBlank(blockingString)) {
+                blocking = Boolean.parseBoolean((blockingString));
+            } else {
+                logger.info("The blocking nature of read/write operations will be set to the default value of {}",
+                        blocking);
             }
-        } else {
-            logger.info("The postamble for all write operations will be set to the default value of {}", postAmble);
+
+            String preambleString = (String) config.get("preamble");
+            if (isNotBlank(preambleString)) {
+                try {
+                    preAmble = preambleString.replaceAll("\\\\", "\\");
+                } catch (Exception e) {
+                    preAmble = preambleString;
+                }
+            } else {
+                logger.info("The preamble for all write operations will be set to the default value of {}", preAmble);
+            }
+
+            String postambleString = (String) config.get("postamble");
+            if (isNotBlank(postambleString)) {
+                try {
+                    postAmble = postambleString.replaceAll("\\\\", "\\");
+                } catch (Exception e) {
+                    postAmble = postambleString;
+                }
+            } else {
+                logger.info("The postamble for all write operations will be set to the default value of {}", postAmble);
+            }
+
+            String updatewithresponseString = (String) config.get("updatewithresponse");
+            if (isNotBlank(updatewithresponseString)) {
+                updateWithResponse = Boolean.parseBoolean((updatewithresponseString));
+            } else {
+                logger.info("Updating states with returned values will be set to the default value of {}",
+                        updateWithResponse);
+            }
+
+            String charsetString = (String) config.get("charset");
+            if (isNotBlank(charsetString)) {
+                charset = charsetString;
+            } else {
+                logger.info("The characterset will be set to the default value of {}", charset);
+            }
+
         }
 
-        String updateWithResponseString = Objects.toString(config.get("updatewithresponse"), null);
-        if (isNotBlank(updateWithResponseString)) {
-            updateWithResponse = Boolean.parseBoolean(updateWithResponseString);
-        } else {
-            logger.info("Updating states with returned values will be set to the default value of {}",
-                    updateWithResponse);
-        }
-
-        String charsetString = Objects.toString(config.get("charset"), null);
-        if (isNotBlank(charsetString)) {
-            charset = charsetString;
-        } else {
-            logger.info("The character set will be set to the default value of {}", charset);
-        }
     }
 
     @Override
@@ -245,36 +246,36 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
         String transformedResponse;
 
         if (isEmpty(transformation) || transformation.equalsIgnoreCase("default")) {
-            logger.debug("transformed response is '{}'", response);
-            return response;
-        }
-
-        Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);
-        if (matcher.matches()) {
-            matcher.reset();
-            matcher.find();
-            String transformationServiceName = matcher.group(1);
-            String transformationServiceParam = matcher.group(2);
-            try {
-                TransformationService transformationService = TransformationHelper
-                        .getTransformationService(TCPActivator.getContext(), transformationServiceName);
-                if (transformationService != null) {
-                    transformedResponse = transformationService.transform(transformationServiceParam, response);
-                } else {
-                    transformedResponse = response;
-                    logger.warn("couldn't transform response because transformationService of type '{}' is unavailable",
-                            transformationServiceName);
-                }
-            } catch (Exception te) {
-                logger.warn("Transformation threw an exception. [transformation={}, response={}]", transformation,
-                        response, te);
-
-                // in case of an error we return the response without any
-                // transformation
-                transformedResponse = response;
-            }
+            transformedResponse = response;
         } else {
-            transformedResponse = transformation;
+            Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);
+            if (matcher.matches()) {
+                matcher.reset();
+                matcher.find();
+                String transformationServiceName = matcher.group(1);
+                String transformationServiceParam = matcher.group(2);
+                try {
+                    TransformationService transformationService = TransformationHelper
+                            .getTransformationService(TCPActivator.getContext(), transformationServiceName);
+                    if (transformationService != null) {
+                        transformedResponse = transformationService.transform(transformationServiceParam, response);
+                    } else {
+                        transformedResponse = response;
+                        logger.warn(
+                                "couldn't transform response because transformationService of type '{}' is unavailable",
+                                transformationServiceName);
+                    }
+                } catch (Exception te) {
+                    logger.error("transformation throws exception [transformation={}, response={}]", transformation,
+                            response, te);
+
+                    // in case of an error we return the response without any
+                    // transformation
+                    transformedResponse = response;
+                }
+            } else {
+                transformedResponse = transformation;
+            }
         }
 
         logger.debug("transformed response is '{}'", transformedResponse);
@@ -289,4 +290,5 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
     protected String getName() {
         return "UDP Refresh Service";
     }
+
 }

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
@@ -15,6 +15,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.util.Dictionary;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,15 +33,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * UDPBinding is most "simple" implementation of a UDP based ASCII protocol. It sends and received
+ * UDPBinding is an implementation of a UDP based ASCII protocol. It sends and receives
  * data as ASCII strings. Data sent out is padded with a CR/LF. This should be sufficient for a lot
  * of home automation devices that take simple ASCII based control commands, or that send back
- * text based status messages
- *
+ * text based status messages.
  *
  * @author Karel Goderis
  * @since 1.1.0
- *
  */
 public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvider> implements ManagedService {
 
@@ -69,69 +67,66 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
 
         ProtocolBindingProvider provider = findFirstMatchingBindingProvider(itemName);
 
-        if (command != null) {
+        if (command == null) {
+            return false;
+        }
 
-            String transformedMessage = transformResponse(provider.getProtocolCommand(itemName, command),
-                    commandAsString);
-            String UDPCommandName = preAmble + transformedMessage + postAmble;
+        String transformedMessage = transformResponse(provider.getProtocolCommand(itemName, command), commandAsString);
+        String UDPCommandName = preAmble + transformedMessage + postAmble;
 
-            ByteBuffer outputBuffer = null;
+        ByteBuffer outputBuffer = null;
+        try {
+            outputBuffer = ByteBuffer.allocate(UDPCommandName.getBytes(charset).length);
+            outputBuffer.put(UDPCommandName.getBytes(charset));
+        } catch (UnsupportedEncodingException e) {
+            logger.warn("Data for output buffer appears to be using an unsupported encoding");
+        }
+
+        // send the buffer in an asynchronous way
+        ByteBuffer result = null;
+        try {
+            result = writeBuffer(outputBuffer, sChannel, blocking, timeOut);
+        } catch (Exception e) {
+            logger.warn("An exception occurred while writing a buffer to a channel", e);
+        }
+
+        if (result != null && blocking) {
+            String resultString = "";
             try {
-                outputBuffer = ByteBuffer.allocate(UDPCommandName.getBytes(charset).length);
-                outputBuffer.put(UDPCommandName.getBytes(charset));
+                resultString = new String(result.array(), charset);
             } catch (UnsupportedEncodingException e) {
-                logger.warn("Exception while attempting an unsupported encoding scheme");
+                logger.warn("Data received from write operation appears to be using an unsupported encoding");
             }
 
-            // send the buffer in an asynchronous way
-            ByteBuffer result = null;
-            try {
-                result = writeBuffer(outputBuffer, sChannel, blocking, timeOut);
-            } catch (Exception e) {
-                logger.error("An exception occurred while writing a buffer to a channel: {}", e.getMessage());
-            }
+            logger.info("Received {} from the remote end {}", resultString, sChannel.toString());
+            String transformedResponse = transformResponse(provider.getProtocolCommand(itemName, command),
+                    resultString);
 
-            if (result != null && blocking) {
-                String resultString = "";
-                try {
-                    resultString = new String(result.array(), charset);
-                } catch (UnsupportedEncodingException e) {
-                    logger.warn("Exception while attempting an unsupported encoding scheme");
-                }
+            // if the remote-end does not send a reply in response to the string we just sent, then the
+            // abstract superclass will update the openhab status of the item for us. If it does reply,
+            // then an additional update is done via parseBuffer.
+            // since this binding does not know about the specific protocol, there might be two state
+            // updates (the command, and if the case, the reply from the remote-end)
 
-                logger.info("Received {} from the remote end {}", resultString, sChannel.toString());
-                String transformedResponse = transformResponse(provider.getProtocolCommand(itemName, command),
-                        resultString);
+            if (updateWithResponse) {
 
-                // if the remote-end does not send a reply in response to the string we just sent, then the abstract
-                // superclass will update
-                // the openhab status of the item for us. If it does reply, then an additional update is done via
-                // parseBuffer.
-                // since this TCP binding does not know about the specific protocol, there might be two state updates
-                // (the command, and if
-                // the case, the reply from the remote-end)
+                List<Class<? extends State>> stateTypeList = provider.getAcceptedDataTypes(itemName, command);
+                State newState = createStateFromString(stateTypeList, transformedResponse);
 
-                if (updateWithResponse) {
-
-                    List<Class<? extends State>> stateTypeList = provider.getAcceptedDataTypes(itemName, command);
-                    State newState = createStateFromString(stateTypeList, transformedResponse);
-
-                    if (newState != null) {
-                        eventPublisher.postUpdate(itemName, newState);
-                    } else {
-                        logger.warn("Can not parse transformed input " + transformedResponse
-                                + " to match command {} on item {}  ", command, itemName);
-                    }
-
-                    return false;
+                if (newState != null) {
+                    eventPublisher.postUpdate(itemName, newState);
                 } else {
-                    return true;
+                    logger.warn("Can not parse transformed input {} to match command {} on item {}",
+                            transformedResponse, command, itemName);
                 }
+
+                return false;
             } else {
                 return true;
             }
+        } else {
+            return true;
         }
-        return false;
     }
 
     /**
@@ -147,11 +142,16 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
         String theUpdate = "";
         try {
             theUpdate = new String(byteBuffer.array(), charset);
+            logger.debug("parseBuffer constructed update: '{}'", theUpdate);
         } catch (UnsupportedEncodingException e) {
             logger.warn("Exception while attempting an unsupported encoding scheme");
         }
 
         ProtocolBindingProvider provider = findFirstMatchingBindingProvider(itemName);
+        if (provider == null) {
+            logger.warn("No provider could be found for the item '{}'", itemName);
+            return;
+        }
 
         List<Class<? extends State>> stateTypeList = provider.getAcceptedDataTypes(itemName, aCommand);
 
@@ -161,7 +161,7 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
         if (newState != null) {
             eventPublisher.postUpdate(itemName, newState);
         } else {
-            logger.warn("Can not parse input " + theUpdate + " to match command {} on item {}  ", aCommand, itemName);
+            logger.warn("Cannot parse input {} to match command {} on item {}", theUpdate, aCommand, itemName);
         }
     }
 
@@ -179,63 +179,62 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
 
         super.updated(config);
 
-        if (config != null) {
-
-            String timeOutString = (String) config.get("buffersize");
-            if (isNotBlank(timeOutString)) {
-                timeOut = Integer.parseInt((timeOutString));
-            } else {
-                logger.info("The maximum time out for blocking write operations will be set to the default value of {}",
-                        timeOut);
-            }
-
-            String blockingString = (String) config.get("retryinterval");
-            if (isNotBlank(blockingString)) {
-                blocking = Boolean.parseBoolean((blockingString));
-            } else {
-                logger.info("The blocking nature of read/write operations will be set to the default value of {}",
-                        blocking);
-            }
-
-            String preambleString = (String) config.get("preamble");
-            if (isNotBlank(preambleString)) {
-                try {
-                    preAmble = preambleString.replaceAll("\\\\", "\\");
-                } catch (Exception e) {
-                    preAmble = preambleString;
-                }
-            } else {
-                logger.info("The preamble for all write operations will be set to the default value of {}", preAmble);
-            }
-
-            String postambleString = (String) config.get("postamble");
-            if (isNotBlank(postambleString)) {
-                try {
-                    postAmble = postambleString.replaceAll("\\\\", "\\");
-                } catch (Exception e) {
-                    postAmble = postambleString;
-                }
-            } else {
-                logger.info("The postamble for all write operations will be set to the default value of {}", postAmble);
-            }
-
-            String updatewithresponseString = (String) config.get("updatewithresponse");
-            if (isNotBlank(updatewithresponseString)) {
-                updateWithResponse = Boolean.parseBoolean((updatewithresponseString));
-            } else {
-                logger.info("Updating states with returned values will be set to the default value of {}",
-                        updateWithResponse);
-            }
-
-            String charsetString = (String) config.get("charset");
-            if (isNotBlank(charsetString)) {
-                charset = charsetString;
-            } else {
-                logger.info("The characterset will be set to the default value of {}", charset);
-            }
-
+        if (config == null) {
+            return;
         }
 
+        String timeOutString = Objects.toString(config.get("buffersize"), null);
+        if (isNotBlank(timeOutString)) {
+            timeOut = Integer.parseInt(timeOutString);
+        } else {
+            logger.info("The maximum timeout for blocking write operations will be set to the default value of {}",
+                    timeOut);
+        }
+
+        String blockingString = Objects.toString(config.get("retryinterval"), null);
+        if (isNotBlank(blockingString)) {
+            blocking = Boolean.parseBoolean(blockingString);
+        } else {
+            logger.info("The blocking nature of read/write operations will be set to the default value of {}",
+                    blocking);
+        }
+
+        String preambleString = Objects.toString(config.get("preamble"), null);
+        if (isNotBlank(preambleString)) {
+            try {
+                preAmble = preambleString.replaceAll("\\\\", "\\");
+            } catch (Exception e) {
+                preAmble = preambleString;
+            }
+        } else {
+            logger.info("The preamble for all write operations will be set to the default value of {}", preAmble);
+        }
+
+        String postambleString = Objects.toString(config.get("postamble"), null);
+        if (isNotBlank(postambleString)) {
+            try {
+                postAmble = postambleString.replaceAll("\\\\", "\\");
+            } catch (Exception e) {
+                postAmble = postambleString;
+            }
+        } else {
+            logger.info("The postamble for all write operations will be set to the default value of {}", postAmble);
+        }
+
+        String updateWithResponseString = Objects.toString(config.get("updatewithresponse"), null);
+        if (isNotBlank(updateWithResponseString)) {
+            updateWithResponse = Boolean.parseBoolean(updateWithResponseString);
+        } else {
+            logger.info("Updating states with returned values will be set to the default value of {}",
+                    updateWithResponse);
+        }
+
+        String charsetString = Objects.toString(config.get("charset"), null);
+        if (isNotBlank(charsetString)) {
+            charset = charsetString;
+        } else {
+            logger.info("The character set will be set to the default value of {}", charset);
+        }
     }
 
     @Override
@@ -246,36 +245,36 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
         String transformedResponse;
 
         if (isEmpty(transformation) || transformation.equalsIgnoreCase("default")) {
-            transformedResponse = response;
-        } else {
-            Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);
-            if (matcher.matches()) {
-                matcher.reset();
-                matcher.find();
-                String transformationServiceName = matcher.group(1);
-                String transformationServiceParam = matcher.group(2);
-                try {
-                    TransformationService transformationService = TransformationHelper
-                            .getTransformationService(TCPActivator.getContext(), transformationServiceName);
-                    if (transformationService != null) {
-                        transformedResponse = transformationService.transform(transformationServiceParam, response);
-                    } else {
-                        transformedResponse = response;
-                        logger.warn(
-                                "couldn't transform response because transformationService of type '{}' is unavailable",
-                                transformationServiceName);
-                    }
-                } catch (Exception te) {
-                    logger.error("transformation throws exception [transformation={}, response={}]", transformation,
-                            response, te);
+            logger.debug("transformed response is '{}'", response);
+            return response;
+        }
 
-                    // in case of an error we return the response without any
-                    // transformation
+        Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);
+        if (matcher.matches()) {
+            matcher.reset();
+            matcher.find();
+            String transformationServiceName = matcher.group(1);
+            String transformationServiceParam = matcher.group(2);
+            try {
+                TransformationService transformationService = TransformationHelper
+                        .getTransformationService(TCPActivator.getContext(), transformationServiceName);
+                if (transformationService != null) {
+                    transformedResponse = transformationService.transform(transformationServiceParam, response);
+                } else {
                     transformedResponse = response;
+                    logger.warn("couldn't transform response because transformationService of type '{}' is unavailable",
+                            transformationServiceName);
                 }
-            } else {
-                transformedResponse = transformation;
+            } catch (Exception te) {
+                logger.warn("Transformation threw an exception. [transformation={}, response={}]", transformation,
+                        response, te);
+
+                // in case of an error we return the response without any
+                // transformation
+                transformedResponse = response;
             }
+        } else {
+            transformedResponse = transformation;
         }
 
         logger.debug("transformed response is '{}'", transformedResponse);
@@ -290,5 +289,4 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
     protected String getName() {
         return "UDP Refresh Service";
     }
-
 }

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
@@ -15,7 +15,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.util.Dictionary;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/CalDavQuery.java
+++ b/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/CalDavQuery.java
@@ -108,7 +108,7 @@ public class CalDavQuery {
     public void setFilterName(String filterName) {
         this.filterName = filterName;
     }
-    
+
     public List<String> getFilterCategory() {
         return filterCategory;
     }
@@ -119,11 +119,9 @@ public class CalDavQuery {
 
     @Override
     public String toString() {
-        return "CalDavQuery [calendarIds=" + calendarIds + ", from=" + from
-                + ", to=" + to + ", sort=" + sort + ", filterName=" + filterName + "]";
+        return "CalDavQuery [calendarIds=" + calendarIds + ", from=" + from + ", to=" + to + ", sort=" + sort
+                + ", filterName=" + filterName + "]";
     }
-
-
 
     public enum Sort {
         ASCENDING,

--- a/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/CalDavConfig.java
+++ b/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/CalDavConfig.java
@@ -123,13 +123,10 @@ public class CalDavConfig {
 
     @Override
     public String toString() {
-        return "CalDavConfig [key=" + key + ", username=" + username
-                + ", password=" + password + ", url=" + url
-                + ", reloadMinutes=" + reloadMinutes + ", preloadMinutes="
-                + preloadMinutes + ", disableCertificateVerification="
-                + disableCertificateVerification
-                + ", lastModifiedFileTimeStampValid="
-                + lastModifiedFileTimeStampValid + "]";
+        return "CalDavConfig [key=" + key + ", username=" + username + ", password=" + password + ", url=" + url
+                + ", reloadMinutes=" + reloadMinutes + ", preloadMinutes=" + preloadMinutes
+                + ", disableCertificateVerification=" + disableCertificateVerification
+                + ", lastModifiedFileTimeStampValid=" + lastModifiedFileTimeStampValid + "]";
     }
 
 }


### PR DESCRIPTION
If config is null, log a warning and return.
Switch to using Objects.toString() for reading config values.
Drop the thrown exceptions for missing username/password, since those values are not required.
Add a warning to the log output if the url is not specified in the configuration.
Use the default TimeZone if the one specified in configuration is invalid.
Misc. fixes in openhab_default.cfg and caldavio.cfg.

Fixes #5116 
