### PR TITLE
[iec6205621meter Binding] Fix ArrayIndexOutOfBoundsException

### DIFF
--- a/bundles/binding/org.openhab.binding.iec6205621meter/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Bundle-Activator: org.openhab.binding.iec6205621meter.internal.Iec6205621MeterAc
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the IEC 62056-21 Meter binding of the open Home Aut
  omation Bus (openHAB)
-Import-Package: org.apache.commons.lang,
+Import-Package: org.apache.commons.codec.binary,
+ org.apache.commons.lang,
  org.openhab.core.binding,
  org.openhab.core.events,
  org.openhab.core.items,

--- a/bundles/binding/org.openhab.binding.iec6205621meter/src/main/java/org/openmuc/j62056/Connection.java
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/src/main/java/org/openmuc/j62056/Connection.java
@@ -36,6 +36,8 @@ import gnu.io.RXTXPort;
 import gnu.io.SerialPort;
 import gnu.io.UnsupportedCommOperationException;
 
+import org.apache.commons.codec.binary.Hex;
+
 public class Connection {
 
     private final String serialPortName;
@@ -316,7 +318,8 @@ public class Connection {
         if(protocolMode == 'B'|| protocolMode=='C'){
             if (baudRate == -1) {
                     throw new IOException(
-                                    "Syntax error in identification message received: unknown baud rate received." + bytesToHex(bytes));
+                        "Syntax error in identification message received: unknown baud rate received: (hex: "
+                        + Hex.encodeHexString(bytes) + ")");
             }
         }
                 
@@ -438,8 +441,8 @@ public class Connection {
 							startPosition++;
 						} else {
 							throw new IOException(
-                                    "STX (0x02) character is expected but not received as first byte of data message."
-                                            + bytesToHex(buffer));
+                                    "STX (0x02) character is expected but not received as first byte of data message. (hex: "
+                                            + Hex.encodeHexString(buffer) + ")");
 						}
 					}
 				}
@@ -453,13 +456,13 @@ public class Connection {
 		}
 
         if (buffer[endIndex + 1] != 0x0D) {
-            throw new IOException("CR (0x0D) character is expected but not received after data block of data message."
-                    + bytesToHex(buffer));
+            throw new IOException("CR (0x0D) character is expected but not received after data block of data message. (hex: "
+                    + Hex.encodeHexString(buffer) + ")");
         }
 
         if (buffer[endIndex + 2] != 0x0A) {
-            throw new IOException("LF (0x0A) character is expected but not received after data block of data message."
-                    + bytesToHex(buffer));
+            throw new IOException("LF (0x0A) character is expected but not received after data block of data message. (hex: "
+                    + Hex.encodeHexString(buffer) + ")");
         }
 
         List<DataSet> dataSets = new ArrayList<DataSet>();
@@ -478,8 +481,8 @@ public class Connection {
             }
             if (id == null) {
                 throw new IOException(
-                        "'(' (0x28) character is expected but not received inside data block of data message."
-                                + bytesToHex(buffer));
+                        "'(' (0x28) character is expected but not received inside data block of data message. (hex: "
+                                + Hex.encodeHexString(buffer) + ")");
             }
 
             String value = "";
@@ -513,8 +516,8 @@ public class Connection {
             }
             if (buffer[index - 1] != 0x29) {
                 throw new IOException(
-                        "')' (0x29) character is expected but not received inside data block of data message."
-                                + bytesToHex(buffer));
+                        "')' (0x29) character is expected but not received inside data block of data message. (hex: "
+                                + Hex.encodeHexString(buffer) + ")");
             }
 
             dataSets.add(new DataSet(id, value, unit));
@@ -570,50 +573,5 @@ public class Connection {
             }
         }
         return -1;
-    }
-
-    /**
-     * Converts a byte array to good readable string.
-     * 
-     * @param bytes
-     *            to be converted
-     * @return string representing the bytes
-     */
-    private String bytesToHex(byte[] bytes) {
-        try {
-            int dwords = bytes.length / 4 + 1;
-            char[] hexChars = new char[bytes.length * 3 + dwords * 4];
-            int position = 0;
-            for (int j = 0; j < bytes.length; j++) {
-                int v = bytes[j] & 0xFF;
-                if (j % 4 == 0) {
-                    String str = "(" + String.format("%02d", j) + ")";
-                    char[] charArray = str.toCharArray();
-                    for (char character : charArray) {
-                        hexChars[position] = character;
-                        position++;
-                    }
-                }
-                hexChars[position] = hexArray[v >>> 4];
-                position++;
-                hexChars[position] = hexArray[v & 0x0F];
-                position++;
-                hexChars[position] = ' ';
-                position++;
-            }
-            return new String(hexChars);
-        }
-        catch(ArrayIndexOutOfBoundsException e) {
-            StringBuffer buf = new StringBuffer();
-            for( int i=0; i<bytes.length; i++ ) {
-                buf.append("[");
-                if( bytes[i] < 16 ) {
-                    buf.append("0");
-                }
-                buf.append(Integer.toHexString(bytes[i]) + "]");
-            }
-
-            return buf.toString();
-        }
     }
 }

--- a/bundles/binding/org.openhab.binding.iec6205621meter/src/main/java/org/openmuc/j62056/Connection.java
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/src/main/java/org/openmuc/j62056/Connection.java
@@ -571,6 +571,7 @@ public class Connection {
         }
         return -1;
     }
+
     /**
      * Converts a byte array to good readable string.
      * 
@@ -579,26 +580,40 @@ public class Connection {
      * @return string representing the bytes
      */
     private String bytesToHex(byte[] bytes) {
-        int dwords = bytes.length / 4 + 1;
-        char[] hexChars = new char[bytes.length * 3 + dwords * 4];
-        int position = 0;
-        for (int j = 0; j < bytes.length; j++) {
-            int v = bytes[j] & 0xFF;
-            if (j % 4 == 0) {
-                String str = "(" + String.format("%02d", j) + ")";
-                char[] charArray = str.toCharArray();
-                for (char character : charArray) {
-                    hexChars[position] = character;
-                    position++;
+        try {
+            int dwords = bytes.length / 4 + 1;
+            char[] hexChars = new char[bytes.length * 3 + dwords * 4];
+            int position = 0;
+            for (int j = 0; j < bytes.length; j++) {
+                int v = bytes[j] & 0xFF;
+                if (j % 4 == 0) {
+                    String str = "(" + String.format("%02d", j) + ")";
+                    char[] charArray = str.toCharArray();
+                    for (char character : charArray) {
+                        hexChars[position] = character;
+                        position++;
+                    }
                 }
+                hexChars[position] = hexArray[v >>> 4];
+                position++;
+                hexChars[position] = hexArray[v & 0x0F];
+                position++;
+                hexChars[position] = ' ';
+                position++;
             }
-            hexChars[position] = hexArray[v >>> 4];
-            position++;
-            hexChars[position] = hexArray[v & 0x0F];
-            position++;
-            hexChars[position] = ' ';
-            position++;
+            return new String(hexChars);
         }
-        return new String(hexChars);
+        catch(ArrayIndexOutOfBoundsException e) {
+            StringBuffer buf = new StringBuffer();
+            for( int i=0; i<bytes.length; i++ ) {
+                buf.append("[");
+                if( bytes[i] < 16 ) {
+                    buf.append("0");
+                }
+                buf.append(Integer.toHexString(bytes[i]) + "]");
+            }
+
+            return buf.toString();
+        }
     }
 }


### PR DESCRIPTION
Trap ArrayIndexOutOfBoundsException in the bytesToHexString() method.
When encountered, fall back to a simpler method of conversion.

Fixes #4651.