### PR TITLE
Z-Wave Binding: Added Fibaro FGS-213

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgs213.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/fibaro/fgs213.xml
@@ -1,0 +1,551 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+    <Model>FGS213</Model>
+    <Label lang="en">Single Switch 2</Label>
+
+    <CommandClasses>
+        <Class>
+            <id>0x00</id>             <!-- NO_OPERATION -->
+        </Class>
+        <Class>
+            <id>0x20</id>             <!-- BASIC -->
+        </Class>
+        <Class>
+            <id>0x22</id>             <!-- APPLICATION_STATUS -->
+        </Class>
+        <Class>
+            <id>0x25</id>             <!-- SWITCH_BINARY -->
+        </Class>
+        <Class>
+            <id>0x31</id>             <!-- SENSOR_MULTILEVEL -->
+        </Class>
+        <Class>
+            <id>0x32</id>             <!-- METER -->
+        </Class>
+        <Class>
+            <id>0x56</id>             <!-- CRC_16_ENCAP -->
+        </Class>
+        <Class>
+            <id>0x59</id>             <!-- ASSOCIATION_GROUP_INFO -->
+        </Class>
+        <Class>
+            <id>0x5A</id>             <!-- DEVICE_RESET_LOCALLY -->
+        </Class>
+        <Class>
+            <id>0x5B</id>             <!-- CENTRAL_SCENE -->
+        </Class>
+        <Class>
+            <id>0x5E</id>             <!-- ZWAVE_PLUS_INFO -->
+        </Class>
+        <Class>
+            <id>0x60</id>             <!-- MULTI_INSTANCE -->
+        </Class>
+        <Class>
+            <id>0x70</id>             <!-- CONFIGURATION -->
+        </Class>
+        <Class>
+            <id>0x71</id>             <!-- ALARM -->
+        </Class>
+        <Class>
+            <id>0x72</id>             <!-- MANUFACTURER_SPECIFIC -->
+        </Class>
+        <Class>
+            <id>0x73</id>             <!-- POWERLEVEL -->
+        </Class>
+        <Class>
+            <id>0x75</id>             <!-- PROTECTION -->
+        </Class>
+        <Class>
+            <id>0x7A</id>             <!-- FIRMWARE_UPDATE_MD -->
+        </Class>
+        <Class>
+            <id>0x85</id>             <!-- ASSOCIATION -->
+        </Class>
+        <Class>
+            <id>0x86</id>             <!-- VERSION -->
+        </Class>
+        <Class>
+            <id>0x8E</id>             <!-- MULTI_INSTANCE_ASSOCIATION -->
+        </Class>
+    </CommandClasses>
+
+    <Configuration>
+
+        <Parameter>
+            <Index>9</Index>
+            <Label lang="en">Restore state after power failure</Label>
+            <Type>list</Type>
+            <Default>1</Default>
+            <Minimum>0</Minimum>
+            <Maximum>1</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">off after power loss</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">restore last state</Label>
+            </Item>
+            <Help><![CDATA[Restore state after power failure
+<p>This parameter determines if the device will return to state prior to the power failure after power is restored.</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>10</Index>
+            <Label lang="en">First channel operating mode</Label>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Minimum>0</Minimum>
+            <Maximum>5</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">standard operation</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">delay ON</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">delay OFF</Label>
+            </Item>
+            <Item>
+                <Value>3</Value>
+                <Label lang="en">auto ON</Label>
+            </Item>
+            <Item>
+                <Value>4</Value>
+                <Label lang="en">auto OFF</Label>
+            </Item>
+            <Item>
+                <Value>5</Value>
+                <Label lang="en">flashing mode</Label>
+            </Item>
+            <Help><![CDATA[First channel - operating mode
+<p>This parameter allows to choose operating for the 1st channel controlled by the S1 switch.</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>11</Index>
+            <Label lang="en">1st ch. reaction to switch</Label>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Minimum>0</Minimum>
+            <Maximum>2</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">cancel mode and set target state</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">no reaction to switch - mode runs until it ends</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">reset timer - start counting from the beginning</Label>
+            </Item>
+            <Help><![CDATA[First channel - reaction to switch for delay/auto ON/OFF modes
+<p>This parameter determines how the device in timed mode reacts to pushing the switch connected to the S1 terminal.</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>12</Index>
+            <Label lang="en">time parameter for delay/auto ON/OFF modes</Label>
+            <Type>short</Type>
+            <Default>50</Default>
+            <Minimum>0</Minimum>
+            <Maximum>32000</Maximum>
+            <Size>2</Size>
+            <Help><![CDATA[First channel - time parameter for delay/auto ON/OFF modes
+<p>This parameter allows to set time parameter used in timed modes.</p> <p>Available settings: 0 (0.1s), 1-32000 (1-32000s, 1s step) - time parameter</p> <p>Default setting: 50 (50s)</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>13</Index>
+            <Label lang="en">1st ch. pulse time for flashing mode</Label>
+            <Type>short</Type>
+            <Default>5</Default>
+            <Minimum>1</Minimum>
+            <Maximum>32000</Maximum>
+            <Size>2</Size>
+            <Help><![CDATA[First channel - pulse time for flashing mode
+<p>This parameter allows to set time of switching to opposite state in flashing mode</p> <p>Available settings: 1-32000 (0.1-3200.0s, 0.1s step) - time parameter</p> <p>Default setting: 5 (0.5s)</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>20</Index>
+            <Label lang="en">Switch type</Label>
+            <Type>list</Type>
+            <Default>2</Default>
+            <Minimum>0</Minimum>
+            <Maximum>2</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">momentary switch</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">toggle switch stable</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">toggle switch</Label>
+            </Item>
+            <Help><![CDATA[Switch type
+<p>This parameter defines as what type the device should treat the switch connected to the S1 and S2 terminals</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>21</Index>
+            <Label lang="en">Flashing mode - reports</Label>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Minimum>0</Minimum>
+            <Maximum>1</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">the device does not send reports</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">the device sends reports</Label>
+            </Item>
+            <Help><![CDATA[Flashing mode - reports
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>27</Index>
+            <Label lang="en">Associations in Z-Wave network security mode</Label>
+            <Type>list</Type>
+            <Default>15</Default>
+            <Minimum>1</Minimum>
+            <Maximum>15</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">no group sent as secure</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">2nd group sent as secure</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">3rd group sent as secure</Label>
+            </Item>
+            <Item>
+                <Value>4</Value>
+                <Label lang="en">4th group sent as secure</Label>
+            </Item>
+            <Item>
+                <Value>8</Value>
+                <Label lang="en">5th group sent as secure</Label>
+            </Item>
+            <Item>
+                <Value>15</Value>
+                <Label lang="en">all groups sent as secure</Label>
+            </Item>
+            <Help><![CDATA[Associations in Z-Wave network security mode
+<p>This parameter defines how commands are sent in specified association groups: as secure or non-secure. Parameter is active only in Z-Wave network security mode. This parameter does not apply to 1st „Lifeline” group.</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>28</Index>
+            <Label lang="en">S1 switch - scenes sent</Label>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Minimum>0</Minimum>
+            <Maximum>15</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">no scenes sent</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">Key pressed 1 time</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">Key pressed 2 times</Label>
+            </Item>
+            <Item>
+                <Value>4</Value>
+                <Label lang="en">Key pressed 3 times</Label>
+            </Item>
+            <Item>
+                <Value>8</Value>
+                <Label lang="en">Key Hold Down and Key Released</Label>
+            </Item>
+            <Help><![CDATA[S1 switch - scenes sent
+<p>This parameter determines which actions result in sending scene IDs assigned to them</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>29</Index>
+            <Label lang="en">S2 switch - scenes sent</Label>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Minimum>0</Minimum>
+            <Maximum>15</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">no scenes sent</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">Key pressed 1 time</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">Key pressed 2 times</Label>
+            </Item>
+            <Item>
+                <Value>4</Value>
+                <Label lang="en">Key pressed 3 times</Label>
+            </Item>
+            <Item>
+                <Value>8</Value>
+                <Label lang="en">Key Hold Down and Key Released</Label>
+            </Item>
+            <Help><![CDATA[S2 switch - scenes sent
+<p>This parameter determines which actions result in sending scene IDs assigned to them</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>30</Index>
+            <Label lang="en">S1 assocs. sent to 2nd and 3rd group</Label>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Minimum>0</Minimum>
+            <Maximum>15</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">All actions are active by default</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">ignore turning ON with 1 click of the switch</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">ignore turning OFF with 1 click of the switch</Label>
+            </Item>
+            <Item>
+                <Value>4</Value>
+                <Label lang="en">ignore holding and releasing the switch</Label>
+            </Item>
+            <Item>
+                <Value>8</Value>
+                <Label lang="en">ignore double click of the switch</Label>
+            </Item>
+            <Help><![CDATA[S1 switch - associations sent to 2nd and 3rd association groups
+<p>This parameter determines which actions are ignored when sending commands to devices associated in 2nd and 3rd association group. All actions are active by default.</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>31</Index>
+            <Label lang="en">S1 ON val sent to 2nd and 3rd groups</Label>
+            <Type>short</Type>
+            <Default>255</Default>
+            <Minimum>0</Minimum>
+            <Maximum>255</Maximum>
+            <Size>2</Size>
+            <Help><![CDATA[S1 switch - Switch ON value sent to 2nd and 3rd association groups
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>32</Index>
+            <Label lang="en">S1 OFF val sent to 2nd and 3rd groups</Label>
+            <Type>short</Type>
+            <Default>0</Default>
+            <Minimum>0</Minimum>
+            <Maximum>255</Maximum>
+            <Size>2</Size>
+            <Help><![CDATA[S1 switch - Switch ON value sent to 2nd and 3rd association groups
+<p>This parameter defines value sent with Switch OFF command to devices associated in 2nd and 3rd association group.</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>33</Index>
+            <Label lang="en">S1 DblClick val sent to 2nd and 3rd groups</Label>
+            <Type>short</Type>
+            <Default>99</Default>
+            <Minimum>0</Minimum>
+            <Maximum>255</Maximum>
+            <Size>2</Size>
+            <Help><![CDATA[S1 switch - Double Click value sent to 2nd and 3rd association groups
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>35</Index>
+            <Label lang="en">S2 assocs. sent to 4th and 5th group</Label>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Minimum>0</Minimum>
+            <Maximum>15</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">All actions are active by default</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">ignore turning on with 1 click of the switch</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">ignore turning off with 1 click of the switch</Label>
+            </Item>
+            <Item>
+                <Value>4</Value>
+                <Label lang="en">ignore holding and releasing the switch</Label>
+            </Item>
+            <Item>
+                <Value>8</Value>
+                <Label lang="en">ignore double click of the switch</Label>
+            </Item>
+            <Help><![CDATA[	S2 switch - associations sent to 4th and 5th association groups
+<p>This parameter determines which actions result in sending commands to devices associated in 4th and 5th association group. All actions are active by default.</p>
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>50</Index>
+            <Label lang="en">Active power reports</Label>
+            <Type>short</Type>
+            <Default>20</Default>
+            <Minimum>0</Minimum>
+            <Maximum>100</Maximum>
+            <Size>1</Size>
+            <Help><![CDATA[The parameter defines the power level change that will result in a new power report being sent. The value is a percentage of the previous report. 0 disables the function.
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>51</Index>
+            <Label lang="en">Minimal time between power report</Label>
+            <Type>short</Type>
+            <Default>10</Default>
+            <Minimum>0</Minimum>
+            <Maximum>120</Maximum>
+            <Size>1</Size>
+            <Help><![CDATA[This  parameter  determines  minimum  time  that  has  to  elapse  before   sending new power report to the main controller. 0 disables the function. 1-120s - report interval in seconds
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>53</Index>
+            <Label lang="en">Energy reports</Label>
+            <Type>short</Type>
+            <Default>100</Default>
+            <Minimum>0</Minimum>
+            <Maximum>32000</Maximum>
+            <Size>2</Size>
+            <Help><![CDATA[Energy level change which will result in sending a new energy report. Available settings: 1-32000 (0.01 - 320 kWh). 0 disables the function.
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>58</Index>
+            <Label lang="en">Periodic power reports</Label>
+            <Type>short</Type>
+            <Default>3600</Default>
+            <Minimum>0</Minimum>
+            <Maximum>32000</Maximum>
+            <Size>2</Size>
+            <Help><![CDATA[This  parameter  determines  in  what  time  interval  the  periodic  power   reports are sent to the main controller. 0  - periodic reports are disabled, 1-32000  (1-32000s) - report interval
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>59</Index>
+            <Label lang="en">Periodic energy reports</Label>
+            <Type>short</Type>
+            <Default>3600</Default>
+            <Minimum>0</Minimum>
+            <Maximum>32000</Maximum>
+            <Size>2</Size>
+            <Help><![CDATA[This parameter determines in what time interval the periodic energy  reports are sent to the main controller. 0  - periodic reports are disabled 1-32000  (1-32000s) - report interval
+            ]]></Help>
+        </Parameter>
+
+        <Parameter>
+            <Index>60</Index>
+            <Label lang="en">Measuring energy consumed by the device itself</Label>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Minimum>0</Minimum>
+            <Maximum>1</Maximum>
+            <Size>1</Size>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">Self-measurement inactive</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">Self-measurement active</Label>
+            </Item>
+            <Help><![CDATA[This parameter determines whether energy metering should include  the amount of energy consumed by the device itself. Results are be - ing added to energy reports for first endpoint. 0: Function deactivated 1: Function activated
+            ]]></Help>
+        </Parameter>
+
+    </Configuration>
+
+    <Associations>
+
+        <Group>
+            <Index>1</Index>
+            <Label lang="en">Lifeline</Label>
+            <Maximum>10</Maximum>
+            <SetToController>true</SetToController>
+        </Group>
+
+        <Group>
+            <Index>2</Index>
+            <Label lang="en">Switch 1</Label>
+            <Maximum>10</Maximum>
+        </Group>
+
+        <Group>
+            <Index>3</Index>
+            <Label lang="en">Dimmer 1</Label>
+            <Maximum>10</Maximum>
+        </Group>
+
+        <Group>
+            <Index>4</Index>
+            <Label lang="en">Switch 2</Label>
+            <Maximum>10</Maximum>
+        </Group>
+
+        <Group>
+            <Index>5</Index>
+            <Label lang="en">Dimmer 2</Label>
+            <Maximum>10</Maximum>
+        </Group>
+
+    </Associations>
+
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1705,15 +1705,15 @@
             <Label lang="en">Roller Shutter</Label>
             <ConfigFile>fibaro/fgrm222.xml</ConfigFile>
         </Product>
-		<Product>
-			<Reference>
-			<Type>0403</Type>
-			<Id>1000</Id>
-			</Reference>
-			<Model>FGS213</Model>
-			<Label lang="en">Single Switch 2</Label>
-			<ConfigFile>fibaro/fgs213.xml</ConfigFile>
-		</Product>
+                <Product>
+                        <Reference>
+                        <Type>0403</Type>
+                        <Id>1000</Id>
+                        </Reference>
+                        <Model>FGS213</Model>
+                        <Label lang="en">Single Switch 2</Label>
+                        <ConfigFile>fibaro/fgs213.xml</ConfigFile>
+                </Product>
         <Product>
             <Reference>
                 <Type>0203</Type>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Manufacturers>
     <Manufacturer>
         <Id>0175</Id>
@@ -1705,6 +1705,15 @@
             <Label lang="en">Roller Shutter</Label>
             <ConfigFile>fibaro/fgrm222.xml</ConfigFile>
         </Product>
+		<Product>
+			<Reference>
+			<Type>0403</Type>
+			<Id>1000</Id>
+			</Reference>
+			<Model>FGS213</Model>
+			<Label lang="en">Single Switch 2</Label>
+			<ConfigFile>fibaro/fgs213.xml</ConfigFile>
+		</Product>
         <Product>
             <Reference>
                 <Type>0203</Type>


### PR DESCRIPTION
Added FGS-213 from OpenHAB 2 repo, as per @cdjackson suggestion, see https://community.openhab.org/t/database-missing-z-wave-fibaro-fgs-213-switch/25298 and https://github.com/openhab/org.openhab.binding.zwave/issues/418. I have added this product next to the similar FGS-223, which was already in products.xml.