### PR TITLE
[caldav] Fix race condition causing NPE

### DIFF
--- a/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavBinding.java
+++ b/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavBinding.java
@@ -220,7 +220,7 @@ public class CalDavBinding extends AbstractBinding<CalDavBindingProvider> implem
         for (String item : bindingProvider.getItemNames()) {
             CalDavConfig config = bindingProvider.getConfig(item);
             List<CalDavEvent> events = eventCache.get(config.getUniqueEventListKey());
-            if (events == null) {
+            if (events == null && this.calDavLoader != null) {
                 CalDavQuery query = getQueryForConfig(config);
                 events = this.calDavLoader.getEvents(query);
                 eventCache.put(config.getUniqueEventListKey(), events);


### PR DESCRIPTION
This fixes a problem described in https://community.openhab.org/t/caldav-binding-setup-issue/21651 caused by a race-condition of the binding not having been initialized at the right time.

Should find some time to do a new openhab 2 port, but for now we're fine.