### PR TITLE
Update GPIOGenericBindingProvider.java

### DIFF
--- a/bundles/binding/org.openhab.binding.gpio/README.md
+++ b/bundles/binding/org.openhab.binding.gpio/README.md
@@ -68,10 +68,10 @@ _NOTE: These options are optional, in most circumstances you don't have to speci
 Allowed item types are `Contact` and `Switch`. Type `Contact` is used for input pins, `Switch` - for output pins. The configuration string is following:
 
 ```
-gpio="pin:PIN_NUMBER [debounce:DEBOUNCE_INTERVAL] [activelow:yes|no] [force:yes|no]"
+gpio="pin:PIN_NUMBER [debounce:DEBOUNCE_INTERVAL] [activelow:yes|no] [force:yes|no] [initialValue:high|low]"
 ```
 
-Key-value pairs are separated by space; their order isn't important. Character's case is also insignificant. Key-value pair `pin` is mandatory, `debounce` and `activelow` are optional. If omitted `activelow` is set to `no`, `debounce` - to global option in configuration file (`debounce`) or 0 (zero) if neither is specified. 
+Key-value pairs are separated by space; their order isn't important. Character's case is also insignificant. Key-value pair `pin` is mandatory, `debounce`, `activelow` and `initialValue` are optional. If omitted `activelow` is set to `no`, `debounce` - to global option in configuration file (`debounce`) or 0 (zero) if neither is specified, initialValue is set to LOW. 
 
 `PIN_NUMBER` is the number of the GPIO pin as seen by the kernel (not necessarily the same as the physical pin number).  
 
@@ -79,13 +79,15 @@ Key-value pairs are separated by space; their order isn't important. Character's
 
 When `activelow` is set to `no` (or omitted) the pins behaves normally: output pins will be set `high` on `ON` command and `low` on `OFF`, input pins will generate `OPEN` event when they are `high` and `CLOSED` when are `low`. However, if `activelow` is set to `yes` the logic is inverted: when `ON` command is sent to output pin it will be set to `low`, on `OFF` command - to `high`. Input pins will generate `OPEN` event when they are `low` and `CLOSED` event on `high`.
 
+`initialValue` is the state of the pin which is set during initialization. It is applicable only for oputput pins (item Switch) and can be HIGH or LOW.
+
 The "force" option can be used to forcefully get hold of the configured pin even if it is currently in use, so it automatically gets unexported and exported again.
 
 Examples:
 
 ```
 Switch LED "LED" { gpio="pin:1" }
-Switch NormallyClosedRelay "Normally Closed Relay" { gpio="pin:2 activelow:yes" }
+Switch NormallyClosedRelay "Normally Closed Relay" { gpio="pin:2 activelow:yes initialValue:high" }
 Contact NormallyOpenPushButton "Normally Open Push Button" { gpio="pin:3 debounce:10" }
 Contact PIR "PIR" { gpio="pin:4 activelow:yes" }
 Contact NormallyClosedPushButton "Normally Closed Push Button" { gpio="pin:5 debounce:10 activelow:yes" }

--- a/bundles/binding/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/GPIOGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.gpio/src/main/java/org/openhab/binding/gpio/internal/GPIOGenericBindingProvider.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Allowed item types in the configuration are "Switch" and "Contact".
  * "Switch" is used for output pins, "Contact" - input pins.
+ * 
  * </p>
  *
  * <p>
@@ -34,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * </p>
  * <p>
  * <code>
- * gpio="pin:PIN_NUMBER [debounce:DEBOUNCE_INTERVAL] [activelow:yes|no] [force:yes|no]"
+ * gpio="pin:PIN_NUMBER [debounce:DEBOUNCE_INTERVAL] [activelow:yes|no] [force:yes|no] [initialValue:high|low]"
  * </code>
  * </p>
  * <p>
@@ -45,11 +46,12 @@ import org.slf4j.LoggerFactory;
  * <br>
  * order of pairs isn't important, the same is valid for character's case
  * <br>
- * key "pin" is mandatory, "debounce", "activelow" and "force" are optional. If omitted
+ * key "pin" is mandatory, "debounce", "activelow", "force" and "initialValue" are optional. If omitted
  * "activelow" is set to "no", "debounce" - to global option in openHAB,
  * configuration file (gpio:debounce) or 0 (zero) if neither is specified
  * "force" - to global option in openHAB,
  * configuration file (gpio:force) or "no" if neither is specified
+ * "initialValue" - to LOW level
  * <br>
  * PIN_NUMBER is the number of the pin as seen by the kernel
  * <br>
@@ -68,7 +70,7 @@ import org.slf4j.LoggerFactory;
  * gpio="pin:49"<br>
  * gpio="pin:49 debounce:10"<br>
  * gpio="pin:49 activelow:yes"<br>
- * gpio="pin:49 force:yes"<br>
+ * gpio="pin:49 force:yes initialValue:high"<br>
  * gpio="pin:49 debounce:10 activelow:yes"</code>
  * </p>
  *
@@ -176,6 +178,17 @@ public class GPIOGenericBindingProvider extends AbstractGenericBindingProvider i
                     throw new BindingConfigParseException("Unsupported value for activelow (" + value
                             + ") in configuration string '" + bindingConfig + "'");
                 }
+            } else if (key.compareToIgnoreCase("initialValue") == 0) {
+                if (value.compareToIgnoreCase("high") == 0) {
+                    config.direction = GPIOPin.DIRECTION_OUT_HIGH;
+                } else if (value.compareToIgnoreCase("low") == 0) {
+                    config.direction = GPIOPin.DIRECTION_OUT_LOW;
+                } else {
+                    logger.error("Unsupported value for initialValue (" + value + ") in configuration string '"
+                            + bindingConfig + "'");
+                    throw new BindingConfigParseException("Unsupported value for initialValue (" + value
+                            + ") in configuration string '" + bindingConfig + "'");
+                }
             } else {
                 logger.error("Unsupported key (" + key + ") in configuration string '" + bindingConfig + "'");
                 throw new BindingConfigParseException(
@@ -192,9 +205,6 @@ public class GPIOGenericBindingProvider extends AbstractGenericBindingProvider i
 
         if (item instanceof ContactItem) {
             config.direction = GPIOPin.DIRECTION_IN;
-        } else {
-            /* Item type 'Switch' */
-            config.direction = GPIOPin.DIRECTION_OUT;
         }
 
         addBindingConfig(item, config);
@@ -293,6 +303,6 @@ public class GPIOGenericBindingProvider extends AbstractGenericBindingProvider i
          * Pin direction. If item type is <code>Switch</code> the pin
          * direction is out, if <code>Contact</code> - in
          */
-        public int direction;
+        public int direction = GPIOPin.DIRECTION_OUT_LOW;
     }
 }


### PR DESCRIPTION
I'm proposing additional property in the GPIO binding item configuration which defines the initial value of the GPIO pin. With the old implementation it was always defined initially to LOW (0). There are cases when it is necessary the initial value to be HIGH (1). There is support for this in org.openhab.io.gpio but wasn't implemented in the configuration part of the GPIO binding.