### PR TITLE
Move MiLight1 Binding to legacy bindings since openHAB2 binding is in…

### DIFF
--- a/features/openhab-addons-legacy/src/main/feature/feature.xml
+++ b/features/openhab-addons-legacy/src/main/feature/feature.xml
@@ -36,6 +36,13 @@
     <configfile finalname="${openhab.conf}/services/homematic.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/homematic</configfile>
   </feature>
 
+  <feature name="openhab-binding-milight1" description="Milight Binding" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.milight/${project.version}</bundle>
+    <configfile finalname="${openhab.conf}/services/milight.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/milight</configfile>
+  </feature>
+
   <feature name="openhab-binding-netatmo1" description="Netatmo Binding (1.x)" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -413,13 +413,6 @@
     <configfile finalname="${openhab.conf}/services/mochadx10.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mochadx10</configfile>
   </feature>
 
-  <feature name="openhab-binding-milight1" description="Milight Binding" version="${project.version}">
-    <feature>openhab-runtime-base</feature>
-    <feature>openhab-runtime-compat1x</feature>
-    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.milight/${project.version}</bundle>
-    <configfile finalname="${openhab.conf}/services/milight.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/milight</configfile>
-  </feature>
-
   <feature name="openhab-binding-mios1" description="MiOS Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>


### PR DESCRIPTION
… place.

Signed-off-by: Hans-Jörg Merk <hans-joerg.merk@t-online.de>