### PR TITLE
Remove dependencies to openhab-esh-addons

### DIFF
--- a/features/openhab-addons-verify/pom.xml
+++ b/features/openhab-addons-verify/pom.xml
@@ -86,7 +86,7 @@
                                 <descriptor>mvn:org.eclipse.smarthome/esh-core/${esh.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.eclipse.smarthome/esh-tp/${esh.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.eclipse.smarthome/esh-ext/${esh.version}/xml/features</descriptor>
-                                <descriptor>mvn:org.openhab.core/openhab-core/${ohc.version}/xml/features</descriptor>
+                                <descriptor>mvn:org.openhab.core/openhab-core/${oh2.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.openhab.addons/openhab-addons/${project.version}/xml/features</descriptor>
                             </descriptors>
                             <distribution>org.apache.karaf.features:framework</distribution>

--- a/features/openhab-addons-verify/pom.xml
+++ b/features/openhab-addons-verify/pom.xml
@@ -52,13 +52,6 @@
             <type>xml</type>
         </dependency>
         <dependency>
-            <groupId>org.openhab.core</groupId>
-            <artifactId>openhab-esh-addons</artifactId>
-            <version>${ohc.version}</version>
-            <classifier>features</classifier>
-            <type>xml</type>
-        </dependency>
-        <dependency>
             <groupId>org.openhab.addons</groupId>
             <artifactId>openhab-addons</artifactId>
             <version>${project.version}</version>
@@ -94,7 +87,6 @@
                                 <descriptor>mvn:org.eclipse.smarthome/esh-tp/${esh.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.eclipse.smarthome/esh-ext/${esh.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.openhab.core/openhab-core/${ohc.version}/xml/features</descriptor>
-                                <descriptor>mvn:org.openhab.core/openhab-esh-addons/${ohc.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.openhab.addons/openhab-addons/${project.version}/xml/features</descriptor>
                             </descriptors>
                             <distribution>org.apache.karaf.features:framework</distribution>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -430,8 +430,6 @@
   <feature name="openhab-binding-mios1" description="MiOS Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
-    <feature>openhab-transformation-regex</feature>
-    <feature>openhab-transformation-map</feature>
     <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.mios/${project.version}</bundle>
     <configfile finalname="${openhab.conf}/services/mios.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mios</configfile>
     <configfile finalname="${openhab.conf}/transform/miosArmedCommand.map" override="true">mvn:${project.groupId}/openhab-addons-external/${project.version}/map/mios-armedcommand</configfile>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -15,10 +15,6 @@
 
   <packaging>pom</packaging>
 
-    <properties>
-        <ohc.version>2.0.0-SNAPSHOT</ohc.version>
-    </properties>
-
   <modules>
     <module>openhab-addons</module>
     <module>openhab-addons-legacy</module>

--- a/pom.xml
+++ b/pom.xml
@@ -50,18 +50,17 @@
     <description>This is the open Home Automation Bus (openHAB)</description>
 
     <properties>
-        <oh2.version>${project.parent.version}</oh2.version>
-		<!-- we deactivate the static analysis tool as the openHAB 1 code does not comply to these rules -->
-		<report.fail.on.error>false</report.fail.on.error>
+        <!-- we deactivate the static analysis tool as the openHAB 1 code does not comply to these rules -->
+        <report.fail.on.error>false</report.fail.on.error>
 
-		<!-- JDBC Databasedriver Versions -->
-		<derby.version>10.12.1.1</derby.version>
-		<h2.version>1.4.191</h2.version>
-		<hsqldb.version>2.3.3</hsqldb.version>
-		<mariadb.version>1.3.5</mariadb.version>
-		<mysql.version>5.1.38</mysql.version>
-		<postgresql.version>9.4.1212</postgresql.version>
-		<sqlite.version>3.16.1</sqlite.version>
+        <!-- JDBC Databasedriver Versions -->
+        <derby.version>10.12.1.1</derby.version>
+        <h2.version>1.4.191</h2.version>
+        <hsqldb.version>2.3.3</hsqldb.version>
+        <mariadb.version>1.3.5</mariadb.version>
+        <mysql.version>5.1.38</mysql.version>
+        <postgresql.version>9.4.1212</postgresql.version>
+        <sqlite.version>3.16.1</sqlite.version>
 
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <description>This is the open Home Automation Bus (openHAB)</description>
 
     <properties>
-
+        <oh2.version>${project.parent.version}</oh2.version>
 		<!-- we deactivate the static analysis tool as the openHAB 1 code does not comply to these rules -->
 		<report.fail.on.error>false</report.fail.on.error>
 


### PR DESCRIPTION
@kaikreuzer: This is the PR regarding openhab-esh-addons that we discussed this today. openhab-esh-addons does no longer exist, currently openhab1-addons just works because of a second ugly glitch (openhab-esh-addons is currently taken from 2.0.0-SNAPSHOT - even for release versions).

@mrguessed: The mios binding was the only one that still had dependencies to openhab-esh-addons which I removed from the featues.xml. As you're the main contributor of this binding, could you please review if the transformation features I removed are still in use? Build is fine, but maybe I broke something on runtime. If yes, I hope it's easy to fix...

We need this cleanup for an automated openHAB release process.


Cheers,
Patrick


Signed-off-by: Patrick Fink <mail@pfink.de>