### PR TITLE
[influxdb] Added possibility to store all measurements in a single measurement

### DIFF
--- a/bundles/persistence/org.openhab.persistence.influxdb/README.md
+++ b/bundles/persistence/org.openhab.persistence.influxdb/README.md
@@ -4,7 +4,7 @@ This service allows you to persist and query states using the [InfluxDB](http://
 
 > There are two Influxdb persistence bundles which support different InfluxDB versions.  This service, named `influxdb`, supports InfluxDB 0.9 and newer, and the `influxdb08` service supports InfluxDB up to version 0.8.x.
 
-## Database Structure
+## Database Structure (classic)
 
 The states of an item are persisted in time series with names equal to the name of the item.  All values are stored in a field called "value" using integers or doubles, `OnOffType` and `OpenClosedType` values are stored using 0 or 1. The times for the entries are calculated by InfluxDB.
 
@@ -13,6 +13,16 @@ An example entry for an item with the name "AmbientLight" would look like this:
 |time |   sequence_number| value|
 |-----|-----------------|-------|
 |1402243200072 |  79370001 |   6|
+
+## Database Structure (single measurement)
+
+To be able to combine different item states in a single query it might be use full to have them stored in a single measurement. If a measurement is defined in the service properties all data will end up in a single measurement. To reflect different value types, they are stored in type specific fields. The field used is referenced in the `type-name`.
+
+An example entry for an item with the name "AmbientLight" would look like this:
+
+|time          |   item-name   | type-name       | value-double | value-integer | value-string | value |
+|--------------|---------------|-----------------|--------------|---------------|--------------|-------|
+|1402243200072 |  AmbientLight |   value-integer |              | 6             |              |       |
 
 ## Prerequisites
 
@@ -31,5 +41,6 @@ This service can be configured in the file `services/influxdb.cfg`.
 | password |         |    Yes   | password of the database user that you chose in [Prerequisites](#prerequisites) above |
 | db       | openhab |    No    | name of the database |
 | retentionPolicy | autogen |  No | name of the retentionPolicy. Please note starting with InfluxDB >= 1.0, the default retention policy name is no longer `default` but `autogen`. |
+| measurement |     |     No    | Should be set if all data should end up in a single measurement. | 
 
 All item- and event-related configuration is defined in either the file `persistence/influxdb.persist`.

--- a/bundles/persistence/org.openhab.persistence.influxdb/README.md
+++ b/bundles/persistence/org.openhab.persistence.influxdb/README.md
@@ -1,6 +1,6 @@
 # InfluxDB (0.9 and newer) Persistence
 
-This service allows you to persist and query states using the [InfluxDB](http://influxdb.org) time series database. The persisted values can be queried from within openHAB. There also are nice tools on the web for visualizing InfluxDB time series, such as [Grafana](http://grafana.org/).
+This service allows you to persist and query states using the [InfluxDB](http://influxdb.org) time series database. The persisted values can be queried from within openHAB. There also are nice tools on the web for visualizing InfluxDB time series, such as [Grafana](http://grafana.org/). 
 
 > There are two Influxdb persistence bundles which support different InfluxDB versions.  This service, named `influxdb`, supports InfluxDB 0.9 and newer, and the `influxdb08` service supports InfluxDB up to version 0.8.x.
 

--- a/bundles/persistence/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBPersistenceService.java
@@ -143,11 +143,11 @@ public class InfluxDBPersistenceService implements QueryablePersistenceService {
             logger.debug("using default retentionPolicy {}", DEFAULT_RETENTION_POLICY);
         }
 
-        measurementName = (String) config.get("measurement");
+        measurementName = (String) config.get("combined_measurements");
         if (isBlank(measurementName)) {
             logger.debug("Using default storage schema");
         } else {
-            logger.debug("Putting all values in central measurement");
+            logger.debug("Putting all values in central combined_measurements");
         }
 
         isProperlyConfigured = true;


### PR DESCRIPTION
In influxdb it is sometimes good to have all data in a single table to do more complicated queries. At least if some external tools are used, e.g. grafana. If the `measurement` property is set, it will switch to the single measurement schema. If not, all will stay like it is. 