### PR TITLE
[Telegram] Distinguish between "no image retrieved" and "unrecognized image" errors

### DIFF
--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -188,6 +188,7 @@ public class Telegram {
             //flag an appropriate error
             if (getMethod.getResponseContentLength() == 0) {
                 logger.warn("Failed to retrieve an image. Fetched URL returned no data.");
+                return false;
             }
 
             imageFromURL = getMethod.getResponseBody();

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -257,7 +257,7 @@ public class Telegram {
             logger.warn("HTTP protocol violation: {}", e);
             return false;
         } catch (IOException e) {
-            logger.error("Transport error: {}", e);
+            logger.warn("Transport error: {}", e);
             return false;
         } finally {
             postMethod.releaseConnection();

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,6 +11,7 @@ package org.openhab.action.telegram.internal;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -73,7 +74,7 @@ public class Telegram {
             @ParamDoc(name = "message") String message) {
 
         if (groupTokens.get(group) == null) {
-            logger.error("Bot '{}' not defined, action skipped", group);
+            logger.warn("Bot '{}' not defined; action skipped.", group);
             return false;
         }
 
@@ -118,20 +119,19 @@ public class Telegram {
 
             String responseBody = IOUtils.toString(tmpResponseStream);
             if (!responseBody.isEmpty()) {
-                logger.debug(responseBody);
+                logger.debug("Response body: {}", responseBody);
             }
 
+            return true;
         } catch (HttpException e) {
-            logger.error("Fatal protocol violation: {}", e.toString());
+            logger.warn("HTTP protocol violation: {}", e);
             return false;
         } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.toString());
+            logger.warn("Transport error: {}", e);
             return false;
         } finally {
             postMethod.releaseConnection();
         }
-
-        return true;
     }
 
     @ActionDoc(text = "Sends a Telegram via Telegram REST API - build message with format and args")
@@ -154,12 +154,12 @@ public class Telegram {
             @ParamDoc(name = "username") String username, @ParamDoc(name = "password") String password) {
 
         if (groupTokens.get(group) == null) {
-            logger.error("Bot '{}' not defined, action skipped", group);
+            logger.warn("Bot '{}' not defined; action skipped.", group);
             return false;
         }
 
         if (photoURL == null) {
-            logger.error("photoURL not defined, action skipped");
+            logger.warn("Photo URL not defined; unable to retrieve photo for sending.");
             return false;
         }
 
@@ -180,16 +180,22 @@ public class Telegram {
         try {
             int statusCode = getClient.executeMethod(getMethod);
             if (statusCode != HttpStatus.SC_OK) {
-                logger.error("Method failed: {}", getMethod.getStatusLine());
+                logger.warn("Failed to retrieve an image. Received status: {}", getMethod.getStatusLine());
                 return false;
+            }
+
+            //if the content-length is 0 (which shouldn't happen),
+            //flag an appropriate error
+            if (getMethod.getResponseContentLength() == 0) {
+                logger.warn("Failed to retrieve an image. Fetched URL returned no data.");
             }
 
             imageFromURL = getMethod.getResponseBody();
         } catch (HttpException e) {
-            logger.error("Fatal protocol violation: {}", e.toString());
+            logger.warn("HTTP protocol violation: {}", e);
             return false;
         } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.toString());
+            logger.warn("Transport error: {}", e);
             return false;
         } finally {
             getMethod.releaseConnection();
@@ -199,15 +205,19 @@ public class Telegram {
         String imageType;
         try {
             ImageInputStream iis = ImageIO.createImageInputStream(new ByteArrayInputStream(imageFromURL));
+            logger.debug("imageInputStream length: {}", iis.length());
             Iterator<ImageReader> imageReaders = ImageIO.getImageReaders(iis);
             if (!imageReaders.hasNext()) {
-                logger.error("photoURL does not represent a known image type");
+                logger.warn("Fetched photo URL did not contain a known image type.");
+                byte[] bytes = new byte[24];
+                iis.read(bytes);
+                logger.debug("first 24 bytes of data: {}", Arrays.toString(bytes));
                 return false;
             }
             ImageReader reader = imageReaders.next();
             imageType = reader.getFormatName();
         } catch (IOException e) {
-            logger.error("cannot parse photoURL as image: {}", e.getMessage());
+            logger.warn("Cannot parse data fetched from photo URL as an image. Error: {}", e.getMessage());
             return false;
         }
 
@@ -237,19 +247,19 @@ public class Telegram {
             }
 
             if (statusCode != HttpStatus.SC_OK) {
-                logger.error("Method failed: {}", postMethod.getStatusLine());
+                logger.warn("Failed to send photo. Received status: {}", postMethod.getStatusLine());
                 return false;
             }
+
+            return true;
         } catch (HttpException e) {
-            logger.error("Fatal protocol violation: {}", e.toString());
+            logger.warn("HTTP protocol violation: {}", e);
             return false;
         } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.toString());
+            logger.error("Transport error: {}", e);
             return false;
         } finally {
             postMethod.releaseConnection();
         }
-
-        return true;
     }
 }


### PR DESCRIPTION
Related to #5254 from @MrMontesa.

This improves the error handling in the Telegram action by distinguishing between the case where the URL fetch returned "200 OK", but no content, and the case where the URL fetch returned content that could not be recognized as a supported image type.  This provides a better warning message to the user in the logs.

Also cleaned up the log messages to conform better to the logging guidelines.
