### PR TITLE
[HTTP Binding] Don't log an error when the "format" configuration setting is found

### DIFF
--- a/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpBinding.java
+++ b/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpBinding.java
@@ -422,7 +422,7 @@ public class HttpBinding extends AbstractActiveBinding<HttpBindingProvider> impl
 
                     // the config-key enumeration contains additional keys that we
                     // don't want to process here ...
-                    if (CONFIG_TIMEOUT.equals(key) || CONFIG_GRANULARITY.equals(key) || "service.pid".equals(key)) {
+                    if (CONFIG_TIMEOUT.equals(key) || CONFIG_GRANULARITY.equals(key) || CONFIG_FORMAT.equals(key) || "service.pid".equals(key)) {
                         continue;
                     }
 


### PR DESCRIPTION
Http Binding logs the following error if the config key "format" is included in http.cfg

> [ERROR] [ab.binding.http.internal.HttpBinding] - given config key 'format' does not follow the expected pattern '<id>.<url|updateInterval>'

This PR adds the format config key to the list of excluded keys from additional processing