### PR TITLE
[eBUS] Fix escaping issue if slave CRC is 0xAA

### DIFF
--- a/bundles/binding/org.openhab.binding.ebus/src/main/java/org/openhab/binding/ebus/internal/utils/EBusUtils.java
+++ b/bundles/binding/org.openhab.binding.ebus/src/main/java/org/openhab/binding/ebus/internal/utils/EBusUtils.java
@@ -312,19 +312,25 @@ public class EBusUtils {
             // process answer data and find data end pos.
             // (may moved because expanded bytes)
             if (nn2 > 0) {
-                for (int i = nn2Pos + 1; i < data.length - 3; i++) {
+
+                int u = 1;
+                while (u <= nn2) {
+                    int i = nn2Pos + u++;
                     byte b = data[i];
 
                     uc_crc = crc8_tab(b, uc_crc);
 
                     if (b != (byte) 0xA9) {
                         buffer.put(decodeEBusData(data, i));
+                    } else {
+                        nn2++;
                     }
                 }
             }
 
-            crc = data[data.length - 3];
-            buffer.put(data, data.length - 3, 3);
+            crcPos = nn2Pos + nn2 + 1;
+            crc = data[crcPos];
+            buffer.put(data, crcPos, 3);
 
             if (uc_crc == (byte) 0xAA && crc == (byte) 0xA9 && data[++crcPos] == (byte) 0x01) {
                 // replace with original value


### PR DESCRIPTION
This PR fixes a CRC calculation issue if the CRC byte 0xAA is expanded to 0xA9 0x01

Started from community thread, already got feedback from user.
https://community.openhab.org/t/ebus-binding/3399/163