### PR TITLE
[KNX1] postCommand only

### DIFF
--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
@@ -122,7 +122,7 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements P
     @Override
     protected void internalReceiveUpdate(String itemName, State newState) {
         logger.trace("Received update (item='{}', state='{}')", itemName, newState.toString());
-        if (!isEcho(itemName, newState)) {
+        if (KNXConnection.getPostUpdateToKNX() && !isEcho(itemName, newState)) {
             writeToKNX(itemName, newState);
         }
     }
@@ -131,7 +131,7 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements P
         String ignoreEventListKey = itemName + type.toString();
         if (ignoreEventList.remove(ignoreEventListKey)) {
             logger.trace(
-                    "We received this event (item='{}', state='{}') from KNX, so we don't send it back again -> ignore!",
+                    "We received this event (item='{}', state='{}') from KNX, so we do not send it back again -> ignore!",
                     itemName, type.toString());
             return true;
         } else {
@@ -265,7 +265,9 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements P
         // we need to make sure that we won't send out this event to
         // the knx bus again, when receiving it on the openHAB bus
         ignoreEventList.add(itemName + type.toString());
-        logger.trace("Added event (item='{}', type='{}') to the ignore event list", itemName, type.toString());
+        logger.trace(
+                "Added event (item='{}', type='{}') to the ignore event list, type is instanceof Command='{}', isCommandGA='{}'",
+                itemName, type.toString(), (type instanceof Command), isCommandGA(destination));
 
         if (type instanceof Command && isCommandGA(destination)) {
             eventPublisher.postCommand(itemName, (Command) type);
@@ -277,6 +279,7 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements P
 
         logger.trace("Processed event (item='{}', type='{}', destination='{}')", itemName, type.toString(),
                 destination.toString());
+
     }
 
     private boolean isStopCommand(byte[] asdu) {
@@ -554,8 +557,9 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements P
         public void run() {
             while (mayRun()) {
                 logger.debug("Post new value {} for items {}", command, item);
+
                 sendTypeToItemButNotToKnx(destination, item, command);
-                eventPublisher.postCommand(item, command);
+
                 try {
                     Thread.sleep(SLEEP_PERIOD_MS);
                 } catch (InterruptedException e) {

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/connection/KNXConnection.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/connection/KNXConnection.java
@@ -119,6 +119,14 @@ public class KNXConnection implements ManagedService {
     private static int sMaxRefreshQueueEntries = 10000;
 
     /**
+     * In openHAB 1.x calling postUpdate AND sendCommand was sent to KNX bus.
+     * While in openHAB2 in some scenarios this generates a lot of Echos and unwanted bus traffic.
+     * In openHAB2 default behavior postUpdate is ignored, calling postUpdate() in rules are no longer sent to the KNX
+     * bus.
+     */
+    private static Boolean sPostUpdateToKNX;
+
+    /**
      * Determines whether Network Address Translation (NAT) will be used for IP connections.
      *
      * Default value is <code>false</code>.
@@ -131,7 +139,7 @@ public class KNXConnection implements ManagedService {
     /**
      * Returns the KNXNetworkLink for talking to the KNX bus.
      * The link can be null, if it has not (yet) been established successfully.
-     * 
+     *
      * @return the KNX network link
      */
     public static synchronized ProcessCommunicator getCommunicator() {
@@ -167,7 +175,7 @@ public class KNXConnection implements ManagedService {
 
     /**
      * Tries to connect either by IP or serial bus, depending on supplied config data.
-     * 
+     *
      * @return true if connection was established, false otherwise
      */
     public static synchronized boolean connect() {
@@ -320,7 +328,7 @@ public class KNXConnection implements ManagedService {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.osgi.service.cm.ManagedService#updated(java.util.Dictionary)
      */
     @Override
@@ -408,6 +416,14 @@ public class KNXConnection implements ManagedService {
                             "Error when trying to read parameter 'maxRefreshQueueEntries' from configuration. '{}' is not a number: using default.",
                             maxRefreshQueueEntriesString);
                 }
+            }
+
+            String postUpdateToKNX = (String) config.get("postUpdateToKNX");
+            if (StringUtils.isNotBlank(postUpdateToKNX)) {
+                sPostUpdateToKNX = postUpdateToKNX.equalsIgnoreCase("true");
+            } else {
+                // if running in openHAB 2 environment postUpdate is ignored by default
+                sPostUpdateToKNX = !getEnvironmentIsFelix();
             }
 
             String numberOfThreadsString = (String) config.get("numberOfThreads");
@@ -504,6 +520,13 @@ public class KNXConnection implements ManagedService {
         return sMaxRefreshQueueEntries;
     }
 
+    /**
+     * @return the sPostUpdateToKNX
+     */
+    public static boolean getPostUpdateToKNX() {
+        return sPostUpdateToKNX;
+    }
+
     private static final class ConnectTimerTask extends TimerTask {
         private final Timer timer;
 
@@ -525,5 +548,12 @@ public class KNXConnection implements ManagedService {
                 }
             }
         }
+    }
+
+    /** if true knx is started in openHAB 2 */
+    private static boolean getEnvironmentIsFelix() {
+        StackTraceElement[] stacktrace = Thread.currentThread().getStackTrace();
+        sLogger.trace("getEnvironmentIsFelix = '{}'", stacktrace[5].getClassName());
+        return stacktrace[5].getClassName().contains("felix");
     }
 }


### PR DESCRIPTION
In openHAB 1.x calling postUpdate AND sendCommand was sent to KNX bus.
While in openHAB2 in some scenarios this generates a lot of Echos and
unwanted bus traffic.
In openHAB2 default behavior postUpdate is ignored, calling postUpdate()
in rules are no longer sent to the KNX bus.