### PR TITLE
[fritzboxtr064] add items for dsl/wan statistics (#5221)

### DIFF
--- a/bundles/binding/org.openhab.binding.fritzboxtr064/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Import-Package: javax.net.ssl,
  org.slf4j
 Export-Package: org.openhab.binding.fritzboxtr064
 Bundle-DocURL: http://www.openhab.org
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/binding.xml, OSGI-INF/genericbindingprovider.xml
 Bundle-ClassPath: lib/httpclient-4.4.1.jar,
  lib/httpcore-4.4.1.jar,

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/OSGI-INF/binding.xml
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/OSGI-INF/binding.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010-2016 by the respective copyright holders.
+    Copyright (c) 2010-2017 by the respective copyright holders.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/OSGI-INF/genericbindingprovider.xml
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/OSGI-INF/genericbindingprovider.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010-2016 by the respective copyright holders.
+    Copyright (c) 2010-2017 by the respective copyright holders.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
@@ -23,6 +23,7 @@ It has been tested on:
 * enabling/disabling telephone answering machines (TAMs) 
 * getting new messages per TAM
 * getting missed calls for the last x days
+* getting DSL statistics for monitoring connection quality
 
 ## Prerequisites
 
@@ -56,6 +57,22 @@ Switch  fboxWifi24          "2,4GHz Wifi"               {fritzboxtr064="wifi24Sw
 Switch  fboxWifi50          "5,0GHz Wifi"               {fritzboxtr064="wifi50Switch"}
 Switch  fboxGuestWifi       "Guest Wifi"                {fritzboxtr064="wifiGuestSwitch"}
 Contact cFboxMacOnline      "Presence (WiFi) [%s]"      {fritzboxtr064="maconline:11-11-11-11-11-11" }
+
+# DSL statistics
+
+Contact fboxDslEnable       "FBox DSL Enable [%s]"      {fritzboxtr064="dslEnable"}
+String  fboxDslStatus       "FBox DSL Status [%s]"      {fritzboxtr064="dslStatus"}
+Number  fboxDslUpstreamCurrRate "DSL Upstream Current [%s mbit/s]" {fritzboxtr064="dslUpstreamCurrRate"}
+Number  fboxDslDownstreamCurrRate "DSL Downstream Current [%s mbit/s]" {fritzboxtr064="dslDownstreamCurrRate"}
+Number  fboxDslUpstreamMaxRate "DSL Upstream Max [%s mbit/s]" {fritzboxtr064="dslUpstreamMaxRate"}
+Number  fboxDslDownstreamMaxRate "DSL Downstream Max [%s mbit/s]" {fritzboxtr064="dslDownstreamMaxRate"}
+Number  fboxDslUpstreamNoiseMargin "DSL Upstream Noise Margin [%s dB*10]" {fritzboxtr064="dslUpstreamNoiseMargin"}
+Number  fboxDslDownstreamNoiseMargin "DSL Downstream Noise Margin [%s dB*10]" {fritzboxtr064="dslDownstreamNoiseMargin"}
+Number  fboxDslUpstreamAttenuation "DSL Upstream Attenuation [%s dB*10]" {fritzboxtr064="dslUpstreamAttenuation"}
+Number  fboxDslDownstreamAttenuation "DSL Downstream Attenuation [%s dB*10]" {fritzboxtr064="dslDownstreamAttenuation"}
+Number  fboxDslFECErrors "DSL FEC Errors [%s]" {fritzboxtr064="dslFECErrors"}
+Number  fboxDslHECErrors "DSL HEC Errors [%s]" {fritzboxtr064="dslHECErrors"}
+Number  fboxDslCRCErrors "DSL CRC Errors [%s]" {fritzboxtr064="dslCRCErrors"}
 
 # only when using call monitor
 Switch  fboxRinging         "Phone ringing [%s]"                {fritzboxtr064="callmonitor_ringing" }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
@@ -5,6 +5,7 @@ This is a binding for communication with AVM Fritz!Box using SOAP requests (TR06
 It has been tested on:
 
 * 7270
+* 7330SL (v6.54)
 * 7360SL (v6.30)
 * 7390
 * 6360 Cable (v6.04)

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
@@ -45,6 +45,9 @@ This binding can be configured in the file `services/fritzboxtr064.cfg`.
 
 ```
 String  fboxName            "FBox Model [%s]"           {fritzboxtr064="modelName"}
+String  fboxManufacturer    "FBox Manufacturer [%s]"    {fritzboxtr064="manufacturerName"}
+String  fboxSerial          "FBox Serial [%s]"          {fritzboxtr064="serialNumber"}
+String  fboxVersion         "FBox Version [%s]"         {fritzboxtr064="softwareVersion"}
 # get wan ip if FritzBox establishes the internet connection (e. g. via DSL)
 String  fboxWanIP           "FBox WAN IP [%s]"          {fritzboxtr064="wanip"}
 # get wan ip if FritzBox uses internet connection of external router

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
@@ -23,7 +23,7 @@ It has been tested on:
 * enabling/disabling telephone answering machines (TAMs) 
 * getting new messages per TAM
 * getting missed calls for the last x days
-* getting DSL statistics for monitoring connection quality
+* getting DSL/WAN statistics for monitoring connection quality
 
 ## Prerequisites
 
@@ -57,6 +57,15 @@ Switch  fboxWifi24          "2,4GHz Wifi"               {fritzboxtr064="wifi24Sw
 Switch  fboxWifi50          "5,0GHz Wifi"               {fritzboxtr064="wifi50Switch"}
 Switch  fboxGuestWifi       "Guest Wifi"                {fritzboxtr064="wifiGuestSwitch"}
 Contact cFboxMacOnline      "Presence (WiFi) [%s]"      {fritzboxtr064="maconline:11-11-11-11-11-11" }
+
+# WAN statistics
+
+String  fboxWanAccessType "FBox WAN access type [%s]" {fritzboxtr064="wanWANAccessType"}
+Number  fboxWanLayer1UpstreamMaxBitRate "FBox WAN us max bit rate [%s]" {fritzboxtr064="wanLayer1UpstreamMaxBitRate"}
+Number  fboxWanLayer1DownstreamMaxBitRate "FBox WAN ds max bit rate [%s]" {fritzboxtr064="wanLayer1DownstreamMaxBitRate"}
+String  fboxWanPhysicalLinkStatus "FBox WAN physical link status [%s]" {fritzboxtr064="wanPhysicalLinkStatus"}
+Number  fboxWanTotalBytesSent "WAN total bytes sent [%s]" {fritzboxtr064="wanTotalBytesSent"}
+Number  fboxWanTotalBytesReceived "WAN total bytes received [%s]" {fritzboxtr064="wanTotalBytesReceived"}
 
 # DSL statistics
 

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/FritzboxTr064BindingProvider.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/FritzboxTr064BindingProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/AbstractItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/AbstractItemMap.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.fritzboxtr064.internal;
+
+/***
+ * Abstract base implementation of an {@link ItemMap}.
+ *
+ * @author Michael Koch <tensberg@gmx.net>
+ * @since 1.11.0
+ */
+public abstract class AbstractItemMap implements ItemMap {
+    // common parameters
+    private String _serviceId; // SOAP service ID
+
+    // read specific
+    private final String _readServiceCommand; // command to execute on fbox if value should be read
+
+    private final SoapValueParser _soapValueParser;
+
+    public AbstractItemMap(String _readServiceCommand, String _serviceId, SoapValueParser _soapValueParser) {
+        this._readServiceCommand = _readServiceCommand;
+        this._serviceId = _serviceId;
+        this._soapValueParser = _soapValueParser;
+    }
+
+    @Override
+    public String getServiceId() {
+        return _serviceId;
+    }
+
+    public void setServiceId(String _serviceId) {
+        this._serviceId = _serviceId;
+    }
+
+    @Override
+    public String getReadServiceCommand() {
+        return _readServiceCommand;
+    }
+
+    @Override
+    public SoapValueParser getSoapValueParser() {
+        return _soapValueParser;
+    }
+}

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/CallEvent.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/CallEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/CallMonitor.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/CallMonitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
@@ -217,9 +217,9 @@ public class FritzboxTr064Binding extends AbstractActiveBinding<FritzboxTr064Bin
                 eventPublisher.postUpdate(itemName, newState);
             } else if (itemType.isAssignableFrom(NumberItem.class)) { // number items e.g. TAM messages
                 // tr064 retrieves only Strings, trying to parse value returned
-                int val = 0;
+                long val = 0;
                 try {
-                    val = Integer.parseInt(tr064result);
+                    val = Long.parseLong(tr064result);
                 } catch (NumberFormatException ex) {
                     val = -1; // indicate error as -1
                 }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
@@ -8,7 +8,11 @@
  */
 package org.openhab.binding.fritzboxtr064.internal;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 
 import org.apache.commons.lang.StringUtils;
@@ -38,6 +42,26 @@ import org.slf4j.LoggerFactory;
  * @since 1.8.0
  */
 public class FritzboxTr064Binding extends AbstractActiveBinding<FritzboxTr064BindingProvider> {
+
+    private static class ItemDescription {
+        private final String _name;
+
+        private final Class<? extends Item> _type;
+
+        public ItemDescription(String _name, Class<? extends Item> _type) {
+            this._name = _name;
+            this._type = _type;
+        }
+
+        public String getName() {
+            return _name;
+        }
+
+        public Class<? extends Item> getType() {
+            return _type;
+        }
+
+    }
 
     private static final Logger logger = LoggerFactory.getLogger(FritzboxTr064Binding.class);
 
@@ -138,6 +162,9 @@ public class FritzboxTr064Binding extends AbstractActiveBinding<FritzboxTr064Bin
     protected void execute() {
         logger.trace("FritzboxTr064 executing...");
 
+        Map<ItemConfiguration, ItemDescription> itemsByConfiguration = new HashMap<>();
+        List<ItemConfiguration> itemConfigurations = new ArrayList<>();
+
         for (FritzboxTr064BindingProvider provider : providers) {
             for (String itemName : provider.getItemNames()) { // check each item relevant for this binding
                 FritzboxTr064BindingConfig conf = provider.getBindingConfigByItemName(itemName); // extract itemconfig
@@ -161,37 +188,47 @@ public class FritzboxTr064Binding extends AbstractActiveBinding<FritzboxTr064Bin
                     continue; // make sure, no callmonitor items are processed by tr064
                 }
 
-                // TR064 protocol usage
-                String tr064result = _fboxComm.getTr064Value(conf.getConfigString()); // try to get value for this item
-                                                                                      // config string from fbox
-                if (tr064result == null) { // if value cannot be read
-                    tr064result = "ERR";
-                }
-                Class<? extends Item> itemType = conf.getItemType();
-                if (itemType.isAssignableFrom(StringItem.class)) {
-                    eventPublisher.postUpdate(itemName, new StringType(tr064result));
-                } else if (itemType.isAssignableFrom(ContactItem.class)) {
-                    State newState = tr064result.equals("1") ? OpenClosedType.OPEN : OpenClosedType.CLOSED;
-                    eventPublisher.postUpdate(itemName, newState);
-                } else if (itemType.isAssignableFrom(SwitchItem.class)) {
-                    State newState = tr064result.equals("1") ? OnOffType.ON : OnOffType.OFF;
-                    eventPublisher.postUpdate(itemName, newState);
-                } else if (itemType.isAssignableFrom(NumberItem.class)) { // number items e.g. TAM messages
-                    // tr064 retrieves only Strings, trying to parse value returned
-                    int val = 0;
-                    try {
-                        val = Integer.parseInt(tr064result);
-                    } catch (NumberFormatException ex) {
-                        val = -1; // indicate error as -1
-                    }
-
-                    State newState = new DecimalType(val);
-                    eventPublisher.postUpdate(itemName, newState);
-                }
-
+                ItemConfiguration request = ItemConfiguration.parse(conf.getConfigString());
+                itemConfigurations.add(request);
+                itemsByConfiguration.put(request, new ItemDescription(itemName, conf.getItemType()));
             }
-
         }
+
+        Map<ItemConfiguration, String> resultsByConfiguration = _fboxComm.getTr064Values(itemConfigurations);
+
+        for (Entry<ItemConfiguration, ItemDescription> entry : itemsByConfiguration.entrySet()) {
+            ItemConfiguration itemConfiguration = entry.getKey();
+            ItemDescription item = entry.getValue();
+            String itemName = item.getName();
+            Class<? extends Item> itemType = item.getType();
+
+            String tr064result = resultsByConfiguration.get(itemConfiguration);
+
+            if (tr064result == null) { // if value cannot be read
+                tr064result = "ERR";
+            }
+            if (itemType.isAssignableFrom(StringItem.class)) {
+                eventPublisher.postUpdate(itemName, new StringType(tr064result));
+            } else if (itemType.isAssignableFrom(ContactItem.class)) {
+                State newState = tr064result.equals("1") ? OpenClosedType.OPEN : OpenClosedType.CLOSED;
+                eventPublisher.postUpdate(itemName, newState);
+            } else if (itemType.isAssignableFrom(SwitchItem.class)) {
+                State newState = tr064result.equals("1") ? OnOffType.ON : OnOffType.OFF;
+                eventPublisher.postUpdate(itemName, newState);
+            } else if (itemType.isAssignableFrom(NumberItem.class)) { // number items e.g. TAM messages
+                // tr064 retrieves only Strings, trying to parse value returned
+                int val = 0;
+                try {
+                    val = Integer.parseInt(tr064result);
+                } catch (NumberFormatException ex) {
+                    val = -1; // indicate error as -1
+                }
+
+                State newState = new DecimalType(val);
+                eventPublisher.postUpdate(itemName, newState);
+            }
+        }
+
     }
 
     /**
@@ -207,8 +244,12 @@ public class FritzboxTr064Binding extends AbstractActiveBinding<FritzboxTr064Bin
         for (FritzboxTr064BindingProvider provider : providers) {
             FritzboxTr064BindingConfig conf = provider.getBindingConfigByItemName(itemName);
             if (conf != null) {
-                _fboxComm.setTr064Value(conf.getConfigString(), command); // pass config String because config string
-                                                                          // needed for finding item map
+                ItemConfiguration request = ItemConfiguration.parse(conf.getConfigString()); // pass config String
+                                                                                             // because config string
+                                                                                             // needed for finding item
+                                                                                             // map
+                _fboxComm.setTr064Value(request, command);
+
             }
         }
     }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064GenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064GenericBindingProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Helper.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Helper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemConfiguration.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemConfiguration.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.openhab.binding.fritzboxtr064.internal;
 
 import static java.util.Collections.emptyList;

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemConfiguration.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemConfiguration.java
@@ -1,0 +1,145 @@
+package org.openhab.binding.fritzboxtr064.internal;
+
+import static java.util.Collections.emptyList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Configuration of an item from the binding config. Each configuration has an {@link #getItemCommand() item command}
+ * which determines the value to read. For parametrisable commands the config may also have
+ * a {@link #getDataInValue() data in value} and {@link #getAdditionalParameters() additional parameters}.
+ *
+ * @author Michael Koch <tensberg@gmx.net>
+ * @since 1.11.0
+ */
+public class ItemConfiguration {
+    private static final String PARAM_SEPARATOR = ":";
+
+    private final String _itemCommand;
+
+    private final Optional<String> _dataInValue;
+
+    private final List<String> _additionalParameters;
+
+    /**
+     * Parses a configuration string from the binding configuration.
+     * The command and parameters must be separated by colons (':').
+     *
+     * @param itemConfig Configuration string from the binding configuration.
+     * @return The parsed configuration.
+     */
+    public static ItemConfiguration parse(String itemConfig) {
+        String[] requestParts = itemConfig.split(PARAM_SEPARATOR);
+
+        String itemCommand = requestParts[0];
+        Optional<String> dataInValue;
+        List<String> _additionalParameters;
+
+        if (requestParts.length >= 2) {
+            dataInValue = Optional.of(requestParts[1]);
+        } else {
+            dataInValue = Optional.empty();
+        }
+
+        if (requestParts.length > 2) {
+            _additionalParameters = new ArrayList<>(requestParts.length - 2);
+            for (int i = 2; i < requestParts.length; i++) {
+                _additionalParameters.add(requestParts[i]);
+            }
+        } else {
+            _additionalParameters = emptyList();
+        }
+
+        return new ItemConfiguration(itemCommand, dataInValue, _additionalParameters);
+    }
+
+    public ItemConfiguration(String _itemCommand) {
+        this(_itemCommand, Optional.empty(), emptyList());
+    }
+
+    public ItemConfiguration(String _itemCommand, String _dataInValue) {
+        this(_itemCommand, Optional.of(_dataInValue), emptyList());
+    }
+
+    public ItemConfiguration(String _itemCommand, Optional<String> _dataInValue, List<String> _additionalParameters) {
+        this._itemCommand = _itemCommand;
+        this._dataInValue = _dataInValue;
+        this._additionalParameters = _additionalParameters;
+    }
+
+    public String getItemCommand() {
+        return _itemCommand;
+    }
+
+    public Optional<String> getDataInValue() {
+        return _dataInValue;
+    }
+
+    public List<String> getAdditionalParameters() {
+        return _additionalParameters;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_itemCommand, _dataInValue, _additionalParameters);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ItemConfiguration other = (ItemConfiguration) obj;
+        if (_additionalParameters == null) {
+            if (other._additionalParameters != null) {
+                return false;
+            }
+        } else if (!_additionalParameters.equals(other._additionalParameters)) {
+            return false;
+        }
+        if (_dataInValue == null) {
+            if (other._dataInValue != null) {
+                return false;
+            }
+        } else if (!_dataInValue.equals(other._dataInValue)) {
+            return false;
+        }
+        if (_itemCommand == null) {
+            if (other._itemCommand != null) {
+                return false;
+            }
+        } else if (!_itemCommand.equals(other._itemCommand)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        String requestString;
+
+        if (_dataInValue.isPresent() || !_additionalParameters.isEmpty()) {
+            StringBuilder requestStringBuilder = new StringBuilder();
+            requestStringBuilder.append(_itemCommand).append(PARAM_SEPARATOR).append(_dataInValue.orElse(""));
+            for (String additionalParameter : _additionalParameters) {
+                requestStringBuilder.append(PARAM_SEPARATOR).append(additionalParameter);
+            }
+
+            requestString = requestStringBuilder.toString();
+        } else {
+            requestString = _itemCommand;
+        }
+
+        return requestString;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemMap.java
@@ -8,117 +8,36 @@
  */
 package org.openhab.binding.fritzboxtr064.internal;
 
+import java.util.Set;
+
 /***
  * Represents a item mapping. An item mapping is a collection of all parameters
- * based on the config string of the item. config string is like the key of an item mapping
+ * based on the config string of the item. config string is like the key of an item mapping.
  * Item Mappings must be created manually to support desired fbox tr064 functions.
+ * Since the FritzBox SOAP services typically return several values in one request,
+ * an item mapping can map a single {@link #getReadServiceCommand() service command} to
+ * multiple {@link #getItemCommands() item commands}. This is used to fetch all configured
+ * items of a service command in a single call.
  *
  * @author gitbock
  *
  */
-public class ItemMap {
-    // common parameters
-    private String _itemCommand; // matches itemconfig
-    private String _serviceId; // SOAP service ID
+public interface ItemMap {
+    /**
+     * @return Names of the item commands which are provided by the response to the
+     *         {@link #getReadDataOutName(String) SOAP service command} of this map.
+     */
+    Set<String> getItemCommands();
 
-    // read specific
-    private String _readServiceCommand; // command to execute on fbox if value should be read
-    private String _readDataInName; // name of parameter to put in soap request to read value
-    private String _readDataOutName; // name of parameter to extract from fbox soap response when reading value (is
-                                     // parsed as value)
-    private SoapValueParser _soapValueParser; // handler to use for parsing soapresponse
+    /**
+     * @param itemCommand
+     * @return Name of the XML element in the service response which contains the value of the given command.
+     */
+    String getReadDataOutName(String itemCommand);
 
-    // write specific
-    private String _writeServiceCommand; // command to execute on fbox if value should be set
-    private String _writeDataInName; // name of parameter which is put in soap request when setting an option on fbox
-    private String _writeDataInNameAdditional; // additional Parameter to add to write request. e.g. id of TAM to set
+    String getServiceId();
 
-    public String getWriteDataInNameAdditional() {
-        return _writeDataInNameAdditional;
-    }
+    String getReadServiceCommand();
 
-    public void setWriteDataInNameAdditional(String _writeDataInNameAdditional) {
-        this._writeDataInNameAdditional = _writeDataInNameAdditional;
-    }
-
-    public String getWriteServiceCommand() {
-        return _writeServiceCommand;
-    }
-
-    public void setWriteServiceCommand(String _writeServiceCommand) {
-        this._writeServiceCommand = _writeServiceCommand;
-    }
-
-    public String getWriteDataInName() {
-        return _writeDataInName;
-    }
-
-    public void setWriteDataInName(String _setDataInName) {
-        this._writeDataInName = _setDataInName;
-    }
-
-    public SoapValueParser getSoapValueParser() {
-        return _soapValueParser;
-    }
-
-    public void setSoapValueParser(SoapValueParser _svp) {
-        this._soapValueParser = _svp;
-    }
-
-    public ItemMap(String _itemCommand, String _getServiceCommand, String _serviceId, String _getDataInName1,
-            String _getDataOutName1) {
-        this._itemCommand = _itemCommand;
-        this._readServiceCommand = _getServiceCommand;
-        this._serviceId = _serviceId;
-        this._readDataInName = _getDataInName1;
-        this._readDataOutName = _getDataOutName1;
-    }
-
-    public String getItemCommand() {
-        return _itemCommand;
-    }
-
-    public void setItemCommand(String _itemCommand) {
-        this._itemCommand = _itemCommand;
-    }
-
-    public String getReadServiceCommand() {
-        return _readServiceCommand;
-    }
-
-    public void setReadServiceCommand(String _serviceCommand) {
-        this._readServiceCommand = _serviceCommand;
-    }
-
-    public String getServiceId() {
-        return _serviceId;
-    }
-
-    public void setServiceId(String _serviceId) {
-        this._serviceId = _serviceId;
-    }
-
-    public String getReadDataInName() {
-        return _readDataInName;
-    }
-
-    public void setReadDataInName1(String _dataInName1) {
-        this._readDataInName = _dataInName1;
-    }
-
-    public String getReadDataOutName() {
-        return _readDataOutName;
-    }
-
-    public void setReadDataOutName(String _dataOutName1) {
-        this._readDataOutName = _dataOutName1;
-    }
-
-    @Override
-    public String toString() {
-        return "ItemMap [_itemCommand=" + _itemCommand + ", _serviceId=" + _serviceId + ", _readServiceCommand="
-                + _readServiceCommand + ", _readDataInName=" + _readDataInName + ", _readDataOutName="
-                + _readDataOutName + ", _svp=" + _soapValueParser + ", _writeDataInName=" + _writeDataInName + "]";
-    }
-
+    SoapValueParser getSoapValueParser();
 }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/MultiItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/MultiItemMap.java
@@ -1,0 +1,42 @@
+package org.openhab.binding.fritzboxtr064.internal;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * {@link ItemMap} for a FritzBox SOAP service which returns the values of multiple items in
+ * a single service response. The value of each {@link #getItemCommands() configured command} is
+ * read from one {@link #getReadDataOutName(String)} XML element in the service response by
+ * a {@link SoapValueParser}.
+ *
+ * @author Michael Koch <tensberg@gmx.net>
+ * @since 1.11.0
+ */
+public class MultiItemMap extends AbstractItemMap {
+
+    private Set<String> _itemCommands;
+    private Function<String, String> _itemCommandToDataOutName;
+
+    public MultiItemMap(Collection<String> _itemCommands, String _readServiceCommand, String _serviceId,
+            Function<String, String> _itemCommandToDataOutName) {
+        super(_readServiceCommand, _serviceId, new SoapValueParser());
+        this._itemCommands = new HashSet<String>(_itemCommands);
+        this._itemCommandToDataOutName = _itemCommandToDataOutName;
+    }
+
+    @Override
+    public Set<String> getItemCommands() {
+        return _itemCommands;
+    }
+
+    @Override
+    public String getReadDataOutName(String itemCommand) {
+        if (!_itemCommands.contains(itemCommand)) {
+            throw new IllegalArgumentException("unsupported itemCommand " + itemCommand);
+        }
+        return _itemCommandToDataOutName.apply(itemCommand);
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/MultiItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/MultiItemMap.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.openhab.binding.fritzboxtr064.internal;
 
 import java.util.Collection;

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ParametrizedItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ParametrizedItemMap.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.fritzboxtr064.internal;
+
+/**
+ * {@link ItemMap} for a SOAP service which takes an input parameter.
+ *
+ * @author Michael Koch <tensberg@gmx.net>
+ * @since 1.11.0
+ */
+public interface ParametrizedItemMap extends ItemMap {
+
+    /**
+     * @return XML element name of the data in parameter of the SOAP service.
+     */
+    String getReadDataInName();
+
+}

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/PhoneBookEntry.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/PhoneBookEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/PhonebookManager.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/PhonebookManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/PhonebookManager.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/PhonebookManager.java
@@ -117,7 +117,7 @@ public class PhonebookManager {
      */
     public Document downloadPhonebook(int id) {
         logger.info("Downloading phonebook ID {}", id);
-        String phoneBookUrl = _tr064comm.getTr064Value("phonebook:" + id);
+        String phoneBookUrl = _tr064comm.getTr064Value(new ItemConfiguration("phonebook", String.valueOf(id)));
         Document phoneBook = _tr064comm.getFboxXmlResponse(phoneBookUrl);
         logger.debug("Downloaded Phonebook:");
         logger.trace(Helper.documentToString(phoneBook));

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SingleItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SingleItemMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SingleItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SingleItemMap.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.fritzboxtr064.internal;
+
+import static java.util.Collections.singleton;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An item map for SOAP services which only return a single item command value per response.
+ * This item map is more flexible than the {@link MultiItemMap} as it supports an optional
+ * {@link #getReadDataInName() input parameter}, a custom {@link #getSoapValueParser() value parser}
+ * and {@link WritableItemMap writable commands}.
+ *
+ * @author Michael Koch <tensberg@gmx.net>
+ * @since 1.11.0
+ */
+public class SingleItemMap extends AbstractItemMap implements ParametrizedItemMap, WritableItemMap {
+    // common parameters
+    private final String _itemCommand; // matches itemconfig
+
+    // read specific
+    private final String _readDataInName; // name of parameter to put in soap request to read value
+    private String _readDataOutName; // name of parameter to extract from fbox soap response when reading value (is
+                                     // parsed as value)
+
+    // write specific
+    private String _writeServiceCommand; // command to execute on fbox if value should be set
+    private String _writeDataInName; // name of parameter which is put in soap request when setting an option on fbox
+    private String _writeDataInNameAdditional; // additional Parameter to add to write request. e.g. id of TAM to set
+
+    public SingleItemMap(String _itemCommand, String _readServiceCommand, String _serviceId, String _getDataInName1,
+            String _getDataOutName1) {
+        this(_itemCommand, _readServiceCommand, _serviceId, _getDataInName1, _getDataOutName1, new SoapValueParser());
+    }
+
+    public SingleItemMap(String _itemCommand, String _readServiceCommand, String _serviceId, String _getDataInName1,
+            String _getDataOutName1, SoapValueParser _soapValueParser) {
+        super(_readServiceCommand, _serviceId, _soapValueParser);
+        this._itemCommand = _itemCommand;
+        _readDataInName = _getDataInName1;
+        _readDataOutName = _getDataOutName1;
+    }
+
+    @Override
+    public String getReadDataInName() {
+        return _readDataInName;
+    }
+
+    @Override
+    public String getWriteDataInNameAdditional() {
+        return _writeDataInNameAdditional;
+    }
+
+    public void setWriteDataInNameAdditional(String _writeDataInNameAdditional) {
+        this._writeDataInNameAdditional = _writeDataInNameAdditional;
+    }
+
+    @Override
+    public String getWriteServiceCommand() {
+        return _writeServiceCommand;
+    }
+
+    public void setWriteServiceCommand(String _writeServiceCommand) {
+        this._writeServiceCommand = _writeServiceCommand;
+    }
+
+    @Override
+    public String getWriteDataInName() {
+        return _writeDataInName;
+    }
+
+    public void setWriteDataInName(String _setDataInName) {
+        this._writeDataInName = _setDataInName;
+    }
+
+    public String getItemCommand() {
+        return _itemCommand;
+    }
+
+    @Override
+    public Set<String> getItemCommands() {
+        return singleton(_itemCommand);
+    }
+
+    public String getReadDataOutName() {
+        return _readDataOutName;
+    }
+
+    @Override
+    public String getReadDataOutName(String itemCommand) {
+        if (!Objects.equals(itemCommand, _itemCommand)) {
+            throw new IllegalArgumentException("unsupported itemCommand " + itemCommand);
+        }
+        return _readDataOutName;
+    }
+}

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SoapValueParser.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SoapValueParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SoapValueParser.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SoapValueParser.java
@@ -8,23 +8,178 @@
  */
 package org.openhab.binding.fritzboxtr064.internal;
 
+import static org.openhab.binding.fritzboxtr064.internal.Tr064Comm.soapToString;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.soap.SOAPBody;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPFault;
 import javax.xml.soap.SOAPMessage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.NodeList;
+
 /***
+ * Parse the responses of FritzBox SOAP services into the values for the
+ * configured items.
+ * <p>
+ * The XML document returned by the FritzBox may contain values for one or more items
+ * configured as {@link ItemMap#getItemCommands() item commands} in the item map of the service.
+ * It generates an {@link ItemConfiguration} for each command with the parameters
+ * given in the {@link ItemConfiguration} used for the service call (since the response
+ * might depend on the parameters of the configuration). It then calls
+ * {@link #parseValueFromSoapBody(ItemConfiguration, SOAPBody, ItemMap) parseValueFromSoapBody}
+ * for every configuration to get the value, or
+ * {@link #parseValueFromSoapFault(ItemConfiguration, SOAPFault, ItemMap) parseValueFromSoapFault}
+ * if the response contained a fault. Subclasses can override these methods to implement
+ * custom behaviour.
+ * </p>
  *
  * @author gitbock
+ * @author Michael Koch <tensberg@gmx.net>
  * @since 1.8.0
  *
  */
+public class SoapValueParser {
+    private static final Logger logger = LoggerFactory.getLogger(SoapValueParser.class);
 
-public interface SoapValueParser {
     /***
-     * 
+     * Parse the FritzBox response to a SOAP service request into values for all defined
+     * {@link ItemMap#getItemCommands() items} of the item map of this service request.
+     *
      * @param sm soap message to parse
-     * @param mapping itemmap with information about all TR064 parameters
-     * @param request the raw original request which was used in itemconfig
-     * @return the value which was parsed from soap message
+     * @param mapping itemmap with information about all TR064 parameters returned by the invoked SOAP service.
+     * @param itemConfiguration the item configuration for which the SOAP service call was initiated.
+     *            All item configuration in the returned map must have the same
+     *            {@link ItemConfiguration#getDataInValue() dataInValue}
+     *            and {@link ItemConfiguration#getAdditionalParameters() parameters} as this configuration.
+     * @return Map of item values for the {@link ItemConfiguration item configurations} corresponding to all
+     *         {@link ItemMap#getItemCommands() items} defined for this service request.
      */
-    String parseValueFromSoapMessage(SOAPMessage sm, ItemMap mapping, String request);
+    public Map<ItemConfiguration, String> parseValuesFromSoapMessage(SOAPMessage sm, ItemMap mapping,
+            ItemConfiguration itemConfiguration) {
+        Set<String> itemCommands = mapping.getItemCommands();
+        Map<ItemConfiguration, String> itemConfigurationToValues = new HashMap<>(itemCommands.size());
+        try {
+            SOAPBody soapBody = sm.getSOAPBody();
+            parseValuesFromSoapBody(sm, soapBody, mapping, itemCommands, itemConfigurationToValues, itemConfiguration);
+        } catch (SOAPException e) {
+            logger.warn("Error parsing SOAP response from FritzBox: {}. ", e.getMessage());
+            setAllItemValuesUnavailable(itemCommands, itemConfigurationToValues, itemConfiguration);
+        }
+        return itemConfigurationToValues;
+    }
+
+    private void parseValuesFromSoapBody(SOAPMessage soapMessage, SOAPBody soapBody, ItemMap mapping,
+            Set<String> itemCommands, Map<ItemConfiguration, String> itemConfigurationToValues,
+            ItemConfiguration originalItemConfiguration) {
+        SOAPFault soapFault = null;
+        if (soapBody.hasFault()) {
+            soapFault = soapBody.getFault();
+        }
+        boolean anyValueMissing = false;
+        boolean soapFaultHandled = false;
+
+        for (String itemCommand : itemCommands) {
+            ItemConfiguration itemConfiguration = deriveConfiguration(itemCommand, originalItemConfiguration);
+            String value;
+            if (soapFault == null) {
+                value = parseValueFromSoapBody(itemConfiguration, soapBody, mapping);
+                anyValueMissing |= (value == null);
+            } else {
+                value = parseValueFromSoapFault(itemConfiguration, soapFault, mapping);
+                soapFaultHandled |= (value != null);
+            }
+            itemConfigurationToValues.put(itemConfiguration, value);
+        }
+
+        // log the SOAP Message once if it contained an unhandled fault or if it did not contain an expected item
+        if (soapFault != null && !soapFaultHandled) {
+            logger.warn("Fault received from FritzBox for item {} in SOAP response {}", originalItemConfiguration,
+                    soapToString(soapMessage));
+        } else if (anyValueMissing) {
+            logger.debug("Some values received from FritzBox for item {} could not be found in SOAP response {}",
+                    originalItemConfiguration, soapToString(soapMessage));
+            // which items exacly were missing was already logged earlier
+        }
+    }
+
+    /**
+     * Get the value for a single {@link ItemConfiguration} from the body of the SOAP service response.
+     * Called for every configured item command of the mapping, unless the response contained a SOAP fault.
+     * <p>
+     * This implementation gets the name of the {@link ItemMap#getReadDataOutName(String) element for the item command}
+     * from the
+     * mapping and returns the text of the XML element with that name. If the element is not found in the response,
+     * <code>null</code> is returned.
+     * </p>
+     * <p>
+     * Subclasses can override this method to implement custom parsing behaviour.
+     * </p>
+     *
+     * @param itemConfiguration Item configuration for which the value should be parsed.
+     * @param soapBody Body of the SOAP service response from which the value should be parsed.
+     * @param mapping Item mapping for which the SOAP service was invoked.
+     * @return Value of this item command. <code>null</code> if the value could not be parsed (will be converted to an
+     *         error value in {@link FritzboxTr064Binding#execute()}).
+     */
+    protected String parseValueFromSoapBody(ItemConfiguration itemConfiguration, SOAPBody soapBody, ItemMap mapping) {
+        String value;
+        String readDataOutName = mapping.getReadDataOutName(itemConfiguration.getItemCommand());
+        NodeList nlDataOutNodes = soapBody.getElementsByTagName(readDataOutName);
+        if (nlDataOutNodes != null && nlDataOutNodes.getLength() > 0) {
+            // extract value from soap response
+            value = nlDataOutNodes.item(0).getTextContent();
+        } else {
+            logger.warn("FritzBox returned unexpected response. Could not find expected data value {} in response.",
+                    readDataOutName);
+            // response XML will be logged once at the end of parseValuesFromSoapBody
+            value = null;
+        }
+        return value;
+    }
+
+    /**
+     * Get the value for a single {@link ItemConfiguration} from the body of the SOAP service response.
+     * Called for every configured item command of the mapping if the response contained a SOAP fault.
+     * <p>
+     * Subclasses may override this method to implement custom error handling. They could for example
+     * return a custom error value for certain known errors. The method should return <code>null</code>
+     * for general errors, which will be converted to an actual error value in {@link FritzboxTr064Binding#execute()}).
+     * </p>
+     * <p>
+     * This class usually logs the content of the SOAP response as warning in case of SOAP faults. If a subclass
+     * returns a non-null value from this method, it is assumed that the SOAP fault occurs during normal operation
+     * and the log message is suppressed.
+     * </p>
+     * <p>
+     * This implementation always returns <code>null</code>.
+     * </p>
+     *
+     * @param itemConfiguration Item configuration for which the value should be parsed.
+     * @param soapFault fault contained in the SOAP service response.
+     * @param mapping Item mapping for which the SOAP service was invoked.
+     * @return Value of this item command for the given fault, or <code>null</code> to use the standard error value.
+     */
+    protected String parseValueFromSoapFault(ItemConfiguration itemConfiguration, SOAPFault soapFault,
+            ItemMap mapping) {
+        return null;
+    }
+
+    private void setAllItemValuesUnavailable(Set<String> itemCommands,
+            Map<ItemConfiguration, String> itemConfigurationToValues, ItemConfiguration originalItemConfiguration) {
+        for (String itemCommand : itemCommands) {
+            itemConfigurationToValues.put(deriveConfiguration(itemCommand, originalItemConfiguration), null);
+        }
+    }
+
+    private ItemConfiguration deriveConfiguration(String itemCommand, ItemConfiguration originalItemConfiguration) {
+        return new ItemConfiguration(itemCommand, originalItemConfiguration.getDataInValue(),
+                originalItemConfiguration.getAdditionalParameters());
+    }
 
 }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
@@ -219,18 +219,18 @@ public class Tr064Comm {
                         beDataNode.addTextNode(dataInValue); // add data which should be requested from fbox for this
                                                              // service
                     } else {
-                        logger.error("item map for command {} does not support dataInValue", itemCommand);
+                        logger.warn("item map for command {} does not support dataInValue", itemCommand);
                     }
                 }
                 logger.trace("Raw SOAP Request to be sent to FritzBox: {}", soapToString(msg));
 
             } catch (Exception e) {
-                logger.error("Error constructing request SOAP msg for getting parameter. {}", e.getMessage());
+                logger.warn("Error constructing request SOAP msg for getting parameter. {}", e.getMessage());
                 logger.debug("Request was: {}", itemConfiguration);
             }
 
             if (bodyData == null) {
-                logger.error("Could not determine data to be sent to FritzBox!");
+                logger.warn("Could not determine data to be sent to FritzBox!");
                 return null;
             }
 
@@ -248,7 +248,7 @@ public class Tr064Comm {
                     _url + tr064service.getControlUrl());
             logger.trace("Raw SOAP Response from FritzBox: {}", soapToString(response));
             if (response == null) {
-                logger.error("Error retrieving SOAP response from FritzBox");
+                logger.warn("Error retrieving SOAP response from FritzBox");
                 continue;
             }
 
@@ -273,7 +273,7 @@ public class Tr064Comm {
         ItemMap itemMapForCommand = determineItemMappingByItemCommand(itemCommand);
 
         if (!(itemMapForCommand instanceof WritableItemMap)) {
-            logger.error("Item command " + itemCommand + " does not support setting values");
+            logger.warn("Item command {} does not support setting values", itemCommand);
             return;
         }
         WritableItemMap itemMap = (WritableItemMap) itemMapForCommand;

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
@@ -661,6 +661,16 @@ public class Tr064Comm {
         addItemMap(new SingleItemMap("externalWanip", "GetExternalIPAddress",
                 "urn:WANIPConnection-com:serviceId:WANIPConnection1", "", "NewExternalIPAddress"));
 
+        // DSL Status
+        addItemMap(new MultiItemMap(
+                Arrays.asList("dslEnable", "dslStatus", "dslUpstreamCurrRate", "dslDownstreamCurrRate",
+                        "dslUpstreamMaxRate", "dslDownstreamMaxRate", "dslUpstreamNoiseMargin",
+                        "dslDownstreamNoiseMargin", "dslUpstreamAttenuation", "dslDownstreamAttenuation"),
+                "GetInfo", "urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1",
+                name -> name.replace("dsl", "New")));
+        addItemMap(new MultiItemMap(Arrays.asList("dslFECErrors", "dslHECErrors", "dslCRCErrors"), "GetStatisticsTotal",
+                "urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1", name -> name.replace("dsl", "New")));
+
         // Wifi 2,4GHz
         SingleItemMap imWifi24Switch = new SingleItemMap("wifi24Switch", "GetInfo",
                 "urn:WLANConfiguration-com:serviceId:WLANConfiguration1", "", "NewEnable");

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
@@ -661,6 +661,17 @@ public class Tr064Comm {
         addItemMap(new SingleItemMap("externalWanip", "GetExternalIPAddress",
                 "urn:WANIPConnection-com:serviceId:WANIPConnection1", "", "NewExternalIPAddress"));
 
+        // WAN Status
+        addItemMap(new MultiItemMap(
+                Arrays.asList("wanWANAccessType", "wanLayer1UpstreamMaxBitRate", "wanLayer1DownstreamMaxBitRate",
+                        "wanPhysicalLinkStatus"),
+                "GetCommonLinkProperties", "urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1",
+                name -> name.replace("wan", "New")));
+        addItemMap(new SingleItemMap("wanTotalBytesSent", "GetTotalBytesSent",
+                "urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1", "", "NewTotalBytesSent"));
+        addItemMap(new SingleItemMap("wanTotalBytesReceived", "GetTotalBytesReceived",
+                "urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1", "", "NewTotalBytesReceived"));
+
         // DSL Status
         addItemMap(new MultiItemMap(
                 Arrays.asList("dslEnable", "dslStatus", "dslUpstreamCurrRate", "dslDownstreamCurrRate",

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Service.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Service.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/WritableItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/WritableItemMap.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.fritzboxtr064.internal;
+
+/**
+ * {@link ItemMap} for a SOAP service which supports writing values to the FritzBox.
+ *
+ * @author Michael Koch <tensberg@gmx.net>
+ * @since 1.11.0
+ */
+public interface WritableItemMap extends ItemMap {
+
+    String getWriteServiceCommand();
+
+    String getWriteDataInName();
+
+    String getWriteDataInNameAdditional();
+
+}


### PR DESCRIPTION
This change adds items for DSL and WAN statistics to the fritzboxtr064 binding.

Supporting the new items required a somewhat large change to the ItemMap-related code because previously the code did not support reading the values of multiple items in a single SOAP service request. I basically splitted the existing ItemMap in a MultiItemMap which can extract multiple item values from a single SOAP response but does not (currently) support input parameters and writing values, and a SingleItemMap, which has all existing functionality but supports only a single item value per SOAP response. I also introduced the ItemConfiguration abstraction for the openhab item config to make the handling of item commands and parameters explicit

I asked gitbock if he agrees with me making changes to the binding. He is fine with it as he is no longer actively working on it.