### PR TITLE
[fritzboxtr064] get wan ip from external router (#5283)

### DIFF
--- a/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
@@ -45,7 +45,10 @@ This binding can be configured in the file `services/fritzboxtr064.cfg`.
 
 ```
 String  fboxName            "FBox Model [%s]"           {fritzboxtr064="modelName"}
+# get wan ip if FritzBox establishes the internet connection (e. g. via DSL)
 String  fboxWanIP           "FBox WAN IP [%s]"          {fritzboxtr064="wanip"}
+# get wan ip if FritzBox uses internet connection of external router
+String  fboxWanIPExternal   "FBox external WAN IP [%s]" {fritzboxtr064="externalWanip"}
 Switch  fboxWifi24          "2,4GHz Wifi"               {fritzboxtr064="wifi24Switch"}
 Switch  fboxWifi50          "5,0GHz Wifi"               {fritzboxtr064="wifi50Switch"}
 Switch  fboxGuestWifi       "Guest Wifi"                {fritzboxtr064="wifiGuestSwitch"}

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
@@ -676,6 +676,8 @@ public class Tr064Comm {
         _alItemMap.add(new ItemMap("modelName", "GetInfo", "DeviceInfo-com:serviceId:DeviceInfo1", "", "NewModelName"));
         _alItemMap.add(new ItemMap("wanip", "GetExternalIPAddress",
                 "urn:WANPPPConnection-com:serviceId:WANPPPConnection1", "", "NewExternalIPAddress"));
+        _alItemMap.add(new ItemMap("externalWanip", "GetExternalIPAddress",
+                "urn:WANIPConnection-com:serviceId:WANIPConnection1", "", "NewExternalIPAddress"));
 
         // Wifi 2,4GHz
         ItemMap imWifi24Switch = new ItemMap("wifi24Switch", "GetInfo",


### PR DESCRIPTION
Reading the WAN IP via the FritzBox SOAP service API WANPPPConnection1 only works if the FritzBox establishes the PPP connection itself. If it uses an external router for internet connectivity, WANIPConnection1has to be used instead. The patch adds the option to configure an item for this.

Fixes #5283 