### PR TITLE
[JDBC persistence] Decreased logging level

### DIFF
--- a/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
@@ -120,7 +120,7 @@ public class JdbcPersistenceService extends JdbcMapper implements QueryablePersi
     public void store(Item item, String alias) {
         // Don not store undefined/uninitialised data
         if (item.getState() instanceof UnDefType) {
-            logger.warn("JDBC::store: ignore Item '{}' because it is UnDefType", item.getName());
+            logger.debug("JDBC::store: ignore Item '{}' because it is UnDefType", item.getName());
             return;
         }
         if (!checkDBAccessability()) {


### PR DESCRIPTION
Changed logging level from warn to debug for UnDefType items as they
pollute logs.


Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>