### PR TITLE
Weather binding: OpenWeatherMap: remove "daily" from forecast url

### DIFF
--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
@@ -19,7 +19,7 @@ import org.openhab.binding.weather.internal.parser.JsonWeatherParser;
  */
 public class OpenWeatherMapProvider extends AbstractWeatherProvider {
     private static final String URL = "http://api.openweathermap.org/data/2.5/weather?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&mode=json&units=metric&APPID=[API_KEY]";
-    private static final String FORECAST = "http://api.openweathermap.org/data/2.5/forecast/daily?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&cnt=5&mode=json&units=metric&APPID=[API_KEY]";
+    private static final String FORECAST = "http://api.openweathermap.org/data/2.5/forecast?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&cnt=5&mode=json&units=metric&APPID=[API_KEY]";
 
     public OpenWeatherMapProvider() {
         super(new JsonWeatherParser());


### PR DESCRIPTION
There is no "daily" in the forecast url as the documentation (https://openweathermap.org/forecast5) shows.

The binding tries to get wheather forecast information from OpenWeatherMap, but the response is `401 Unauthorized`. Turning debuggin on in karaf shows:
```
13:16:22.182 [TRACE] [nal.provider.AbstractWeatherProvider] - OPENWEATHERMAP[openweather]: request : http://api.openweathermap.org/data/2.5/forecast/daily?lat=48.xxx&lon=7.yyy&lang=de&cnt=5&mode=json&units=metric&APPID=123notthateasy
13:16:22.239 [TRACE] [nal.provider.AbstractWeatherProvider] - OPENWEATHERMAP[openweather]: response: {"cod":401, "message": "Invalid API key. Please see http://openweathermap.org/faq#error401 for more info."}
13:16:22.239 [ERROR] [nal.provider.AbstractWeatherProvider] - OPENWEATHERMAP[openweather]: Can't retreive weather data: HTTP/1.1 401 Unauthorized
```
A quick lookup in the OpenWeatherMap documentation reveals that the url this addon uses is wrong.

Please merge this pull request to fix the url.


Thanks
Dominik