### PR TITLE
[KNX] Fixed README markdown syntax for docs.openhab.org

### DIFF
--- a/bundles/binding/org.openhab.binding.knx/README.md
+++ b/bundles/binding/org.openhab.binding.knx/README.md
@@ -2,8 +2,7 @@
 
 The openHAB KNX binding allows one to connect to [KNX Home Automation](http://www.knx.org/) installations. Switching lights on and off, activating your roller shutters or changing room temperatures are only some examples.
 
-To access your KNX bus you either need an KNX IP gateway (like e.g. the [Gira KNX IP Router]
-(http://www.gira.com/en/gebaeudetechnik/systeme/knx-eib_system/knx-produkte/systemgeraete/knx-ip-router.html)) or a PC running [EIBD](http://www.auto.tuwien.ac.at/~mkoegler/index.php/eibd) (free open source component that enables communication with the KNX bus).
+To access your KNX bus you either need an KNX IP gateway (like e.g. the [Gira KNX IP Router](http://www.gira.com/en/gebaeudetechnik/systeme/knx-eib_system/knx-produkte/systemgeraete/knx-ip-router.html)) or a PC running [EIBD](http://www.auto.tuwien.ac.at/~mkoegler/index.php/eibd) (free open source component that enables communication with the KNX bus).
 
 > Please note that the KNX Binding is using **224.0.23.12:3671/UDP** by default to connect to your gateway.
 


### PR DESCRIPTION
There was a new line in the markdown link syntax that broke the GIRA link.
minor fix.