### PR TITLE
[CUL transport] Throttle commands, which are sent to the CUL

### DIFF
--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
@@ -34,27 +34,39 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
 
     /**
      * Thread which sends all queued commands to the CUL.
+     * The Thread waits on a CUL response before sending a new
+     * command to prevent race conditions. 
      *
      * @author Till Klocke
      * @since 1.4.0
      *
      */
-    private class SendThread extends Thread {
+    private class SendThread extends Thread implements CULListener {
 
         private final Logger logger = LoggerFactory.getLogger(SendThread.class);
+        
+        private Boolean waitOnCULResponse = false;
 
         @Override
         public void run() {
+            int waitTimeout = 0;
+            
             while (!isInterrupted()) {
-                String command = sendQueue.poll();
-                if (command != null) {
-                    if (!command.endsWith("\r\n")) {
-                        command = command + "\r\n";
-                    }
-                    try {
-                        writeMessage(command);
-                    } catch (CULCommunicationException e) {
-                        logger.warn("Error while writing command to CUL", e);
+                if (!waitOnCULResponse) {
+                    String command = sendQueue.poll();
+                    if (command != null) {
+                        if (!command.endsWith("\r\n")) {
+                            command = command + "\r\n";
+                        }
+                        try {
+                            logger.trace("Writing message: {}", command);
+                            
+                            writeMessage(command);
+                            waitOnCULResponse = true;
+                            waitTimeout = 0;
+                        } catch (CULCommunicationException e) {
+                            logger.warn("Error while writing command to CUL", e);
+                        }
                     }
                 }
                 try {
@@ -62,7 +74,25 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
                 } catch (InterruptedException e) {
                     logger.debug("Error while sleeping in SendThread", e);
                 }
+
+                waitTimeout += 1;
+                if (waitOnCULResponse && waitTimeout > 200) {
+                    logger.trace("Reset wait on CUL response due to timeout");;
+                    waitOnCULResponse = false;
+                }
             }
+        }
+
+        @Override
+        public void dataReceived(String data) {
+            logger.trace("CUL response received: {}", data);
+            waitOnCULResponse = false;
+        }
+
+        @Override
+        public void error(Exception e) {
+            logger.trace("CUL error received: {}", e);
+            waitOnCULResponse = false;
         }
     }
 
@@ -131,12 +161,16 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
     @Override
     public void open() throws CULDeviceException {
         openHardware();
+        
+        registerListener(sendThread);
         sendThread.start();
     }
 
     @Override
     public void close() {
         sendThread.interrupt();
+        unregisterListener(sendThread);
+        
         closeHardware();
     }
 
@@ -158,6 +192,7 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
     public void send(String command) {
         if (isMessageAllowed(command)) {
             sendQueue.add(command);
+            requestCreditReport();
         }
     }
 
@@ -217,10 +252,8 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
             return;
         } else if (data.matches("^\\d+\\s+\\d+")) {
             processCreditReport(data);
-            return;
         }
         notifyDataReceived(data);
-        requestCreditReport();
     }
 
     /**
@@ -252,7 +285,11 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
     private void requestCreditReport() {
         /* this requests a report which provides credit10ms */
         log.debug("Requesting credit report");
-        write("X\r\n");
+        try {
+            sendWithoutCheck("X\r\n");
+        } catch (CULCommunicationException e) {
+            log.warn("Error requesting credit report from CUL", e);
+        }
     }
 
     /**
@@ -262,8 +299,8 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
      * @throws CULCommunicationException
      */
     private void writeMessage(String message) throws CULCommunicationException {
+        log.trace("Writing message: {}", message);
         write(message);
-        requestCreditReport();
     }
 
     @Override

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
@@ -242,7 +242,7 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
      *             if
      */
     protected void processNextLine(String data) {
-        log.debug("Received raw message from CUL: " + data);
+        log.debug("Received raw message from CUL: {}", data);
         if ("EOB".equals(data)) {
             log.warn("(EOB) End of Buffer. Last message lost. Try sending less messages per time slot to the CUL");
             return;
@@ -265,7 +265,7 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
         // Credit report received
         String[] report = data.split(" ");
         credit10ms = Integer.parseInt(report[report.length - 1]);
-        log.debug("credit10ms = " + credit10ms);
+        log.debug("credit10ms = {}", credit10ms);
     }
 
     /**

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/CULManager.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/CULManager.java
@@ -49,6 +49,8 @@ public class CULManager {
      * @return config factory for the device type
      */
     public CULConfigFactory getConfigFactory(String deviceType) {
+        logger.trace("Requesting deviceTypeFactory for type '{}'", deviceType);
+        logger.trace("{} factories registered", deviceTypeConfigFactories.size());
         return deviceTypeConfigFactories.get(deviceType);
     }
 
@@ -66,15 +68,14 @@ public class CULManager {
     public <T extends CULConfig> CULHandlerInternal<T> getOpenCULHandler(T config) throws CULDeviceException {
         CULMode mode = config.getMode();
         String deviceName = config.getDeviceName();
-        logger.debug("Trying to open device " + deviceName + " in mode " + mode.toString());
+        logger.debug("Trying to open device {} in mode {}", deviceName, mode.toString());
         synchronized (openDevices) {
 
             if (openDevices.containsKey(deviceName)) {
                 @SuppressWarnings("unchecked")
                 CULHandlerInternal<T> handler = (CULHandlerInternal<T>) openDevices.get(deviceName);
                 if (handler.getConfig().equals(config)) {
-                    logger.debug("Device " + deviceName + " is already open in mode " + mode.toString()
-                            + ", returning already openend handler");
+                    logger.debug("Device {} is already open in mode {}, returning already openend handler", deviceName, mode.toString());
                     return handler;
                 } else {
                     throw new CULDeviceException(
@@ -114,7 +115,7 @@ public class CULManager {
 
     public void registerHandlerClass(String deviceType, Class<? extends CULHandlerInternal<?>> clazz,
             CULConfigFactory configFactory) {
-        logger.debug("Registering class " + clazz.getCanonicalName() + " for device type " + deviceType);
+        logger.debug("Registering class {} for device type {}", clazz.getCanonicalName(), deviceType);
         deviceTypeClasses.put(deviceType, clazz);
         deviceTypeConfigFactories.put(deviceType, configFactory);
     }
@@ -122,7 +123,7 @@ public class CULManager {
     private <T extends CULConfig> CULHandlerInternal<T> createNewHandler(T config) throws CULDeviceException {
         String deviceType = config.getDeviceType();
         CULMode mode = config.getMode();
-        logger.debug("Searching class for device type " + deviceType);
+        logger.debug("Searching class for device type {}", deviceType);
         @SuppressWarnings("unchecked")
         Class<? extends CULHandlerInternal<T>> culHandlerclass = (Class<? extends CULHandlerInternal<T>>) deviceTypeClasses
                 .get(deviceType);
@@ -140,8 +141,8 @@ public class CULManager {
             CULHandlerInternal<T> culHandler = culHanlderConstructor.newInstance(parameters);
             List<String> initCommands = mode.getCommands();
             if (!(culHandler instanceof CULHandlerInternal)) {
-                logger.error(
-                        "Class " + culHandlerclass.getCanonicalName() + " does not implement the internal interface");
+                logger.error("Class {} does not implement the internal interface",
+                        culHandlerclass.getCanonicalName());
                 throw new CULDeviceException("This CULHandler class does not implement the internal interface: "
                         + culHandlerclass.getCanonicalName());
             }

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/serial/CULSerialHandlerImpl.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/serial/CULSerialHandlerImpl.java
@@ -68,6 +68,7 @@ public class CULSerialHandlerImpl extends AbstractCULHandler<CULSerialConfig> im
                         logger.warn("BufferedReader for serial connection is null");
                     } else {
                         String line = br.readLine();
+                        logger.trace("Serial event: received '{}'", line);
                         processNextLine(line);
                     }
                 } catch (IOException e) {
@@ -158,6 +159,7 @@ public class CULSerialHandlerImpl extends AbstractCULHandler<CULSerialConfig> im
                 if (bw == null) {
                     logger.warn("BufferedWriter for serial connection is null");
                 } else {
+                    logger.trace("Write serial: {}", command);
                     bw.write(command);
                     bw.flush();
                 }


### PR DESCRIPTION
I've build a throttle, which waits with sending a new command for the response of the former command to prevent race conditions.

See issue #5328

I've tested this with the Intertechno binding, but no other, which use the CUL transport