### PR TITLE
[OpenWeatherMap] Change FORECAST path to get free 5 day forecast

### DIFF
--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
@@ -19,7 +19,7 @@ import org.openhab.binding.weather.internal.parser.JsonWeatherParser;
  */
 public class OpenWeatherMapProvider extends AbstractWeatherProvider {
     private static final String URL = "http://api.openweathermap.org/data/2.5/weather?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&mode=json&units=metric&APPID=[API_KEY]";
-    private static final String FORECAST = "http://api.openweathermap.org/data/2.5/forecast/daily?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&cnt=5&mode=json&units=metric&APPID=[API_KEY]";
+    private static final String FORECAST = "http://api.openweathermap.org/data/2.5/forecast?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&cnt=5&mode=json&units=metric&APPID=[API_KEY]";
 
     public OpenWeatherMapProvider() {
         super(new JsonWeatherParser());


### PR DESCRIPTION
I just changed the URL for the forecast information. The original URL is calling up the 16 day forecast information which is not available for Free API users. 