### PR TITLE
[weather] Fixed parsing of rain value in forecast data

### DIFF
--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/model/Precipitation.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/model/Precipitation.java
@@ -27,8 +27,7 @@ public class Precipitation {
             @Provider(name = ProviderName.WUNDERGROUND, property = "current_observation.precip_1hr_metric"),
             @Provider(name = ProviderName.WUNDERGROUND, property = "qpf_allday.mm"),
             @Provider(name = ProviderName.OPENWEATHERMAP, property = "rain.3h", converter = ConverterType.DOUBLE_3H),
-            @Provider(name = ProviderName.OPENWEATHERMAP, property = "rain", converter = ConverterType.DOUBLE_3H),
-            @Provider(name = ProviderName.OPENWEATHERMAP, property = "rain.1h"),
+            @Provider(name = ProviderName.OPENWEATHERMAP, property = "rain"),
             @Provider(name = ProviderName.WORLDWEATHERONLINE, property = "precipMM"),
             @Provider(name = ProviderName.HAMWEATHER, property = "precipMM"),
             @Provider(name = ProviderName.METEOBLUE, property = "precipitation_amount") })
@@ -37,6 +36,7 @@ public class Precipitation {
     @ProviderMappings({
             @Provider(name = ProviderName.WUNDERGROUND, property = "snow_allday.cm"),
             @Provider(name = ProviderName.OPENWEATHERMAP, property = "snow.3h", converter = ConverterType.DOUBLE_3H),
+            @Provider(name = ProviderName.OPENWEATHERMAP, property = "snow"),
             @Provider(name = ProviderName.HAMWEATHER, property = "snowDepthCM") })
     private Double snow;
 


### PR DESCRIPTION
- The modifier `DOUBLE_3H` is not needed to parse the forecast data.
- Added mapping for parsing snow from forecast data

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>