### PR TITLE
[tacmi] Add binding to openhab2 distribution

### DIFF
--- a/bundles/binding/org.openhab.binding.tacmi/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.tacmi/ESH-INF/binding/binding.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="tacmi"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0
+        http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+  <name>TA CMI Binding</name>
+  <description>The TA CMI binding integrates the C.M.I module from
+Technische Alternative. It allows to read analog and digital values
+using the TA CoE (CAN over Ethernet) protocol. There is also limited
+write support.
+</description>
+<author>Timo Wendt, Wolfgang Klimt</author>
+
+ <service-id>org.openhab.tacmi</service-id>
+
+<config-description>
+        <parameter name="refresh" type="integer">
+            <label>Refresh interval</label>
+            <description>Data refresh interval in milliseconds.</description>
+            <default>120000</default>
+		</parameter>
+        <parameter name="cmiAddress" type="text" required="true">
+            <label>CMI IP address</label>
+            <description>IP address of the CMI module</description>
+		</parameter>
+</config-description>
+ 
+
+</binding:binding>
+

--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiBinding.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiBinding.java
@@ -52,9 +52,9 @@ public class TACmiBinding extends AbstractActiveBinding<TACmiBindingProvider> {
 
     /**
      * the refresh interval which is used to poll values from the TACmi server
-     * (optional, defaults to 60000ms)
+     * (optional, defaults to 120000ms)
      */
-    private long refreshInterval = 1000;
+    private long refreshInterval = 120000;
 
     /**
      * IP or hostname of the CMI This is set in the activate method
@@ -108,8 +108,8 @@ public class TACmiBinding extends AbstractActiveBinding<TACmiBindingProvider> {
         try {
             clientSocket = new DatagramSocket(cmiPort);
         } catch (SocketException e) {
-            logger.error("Failed to create Socket for receiving UDP packets from CMI");
-            setProperlyConfigured(true);
+            logger.error("Failed to create Socket for receiving UDP packets from CMI. Reason: " + e.getMessage());
+            setProperlyConfigured(false);
             return;
         }
 
@@ -161,6 +161,11 @@ public class TACmiBinding extends AbstractActiveBinding<TACmiBindingProvider> {
     protected void execute() {
         logger.trace("execute() method is called!");
         try {
+            if (clientSocket == null) {
+                logger.error("No client socket present");
+                setProperlyConfigured(false);
+                return;
+            }
             clientSocket.setBroadcast(true);
             clientSocket.setSoTimeout(120000);
             byte[] receiveData = new byte[14];

--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiMeasureType.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiMeasureType.java
@@ -32,7 +32,7 @@ public enum TACmiMeasureType {
     UNKNOWN7(7, 0),
     UNKNOWN8(8, 0),
     UNKNOWN9(9, 0),
-    KILOWATT(10, 1),
+    KILOWATT(10, 2),
     KILOWATTHOURS(11, 1),
     MEGAWATTHOURS(12, 0),
     UNKNOWN13(13, 0),

--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -118,6 +118,7 @@
                                 <artifact><file>src/main/resources/conf/souliss.cfg</file><type>cfg</type><classifier>souliss</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/swegonventilation.cfg</file><type>cfg</type><classifier>swegonventilation</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/systeminfo.cfg</file><type>cfg</type><classifier>systeminfo</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/tacmi.cfg</file><type>cfg</type><classifier>tacmi</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/tcp.cfg</file><type>cfg</type><classifier>tcp</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/telegram.cfg</file><type>cfg</type><classifier>telegram</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/tinkerforge.cfg</file><type>cfg</type><classifier>tinkerforge</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/tacmi.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/tacmi.cfg
@@ -1,0 +1,8 @@
+# Configuration file for the TA CMI binding
+
+# IP address of the CMI module
+#cmiAddress="192.168.2.10"
+
+# refresh interval. Specifies the timeout the binding waits for new
+# data from the CMI module. If not set, a default of 120sec is used.
+# refresh="120000"


### PR DESCRIPTION
As I now have the TA CMI binding running with openhab 2 for several months, I think it is safe to add it to the distribution.

Included is a small change of one scale factor which turned out to be necessary after a firmware change of the C.M.I, and a slightly better error handling when the listening socket can't be created.