### PR TITLE
added serial-port context to config parameters in order to support automatic selection lists

### DIFF
--- a/bundles/binding/org.openhab.binding.iec6205621meter/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/ESH-INF/binding/binding.xml
@@ -28,8 +28,8 @@
         </parameter>        
         <parameter name="serialPort" type="text" required="true">
             <label>Serial port</label>
+            <context>serial-port</context>
             <description>The serial port to use for connecting to the metering device e.g. COM1 for Windows and /dev/ttyS0 or /dev/ttyUSB0 for Linux.</description>
-            <default>/dev/ttyS0</default>
         </parameter>
     </config-description>
 </binding:binding>

--- a/bundles/binding/org.openhab.binding.powermax/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.powermax/ESH-INF/binding/binding.xml
@@ -11,6 +11,7 @@
 	<config-description>
 		<parameter name="serialPort" type="text" required="false">
 			<label>Serial port</label>
+			<context>serial-port</context>
 			<description>The serial port to use for connecting to the serial interface of the PowerMax alarm system e.g. COM1 for Windows and /dev/ttyS0 or /dev/ttyUSB0 for Linux.</description>
 		</parameter>
 		<parameter name="ip" type="text" required="false">


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>