### PR TITLE
Fixes NPE in souliss binding

### DIFF
--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/SoulissBinding.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/SoulissBinding.java
@@ -132,6 +132,10 @@ public class SoulissBinding<E> extends AbstractActiveBinding<SoulissBindingProvi
 
         // Get the typical defined in the hash table
         SoulissGenericTypical T = SoulissGenericBindingProvider.SoulissTypicalsRecipients.getTypicalFromItem(itemName);
+        if (T == null) {
+            logger.debug("SoulissTypical not found for item: " + itemName);
+            return;
+        }
         logger.info("receiveCommand - {} = {} - Typical: 0x{}", itemName, command, Integer.toHexString(T.getType()));
 
         switch (T.getType()) {

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/SoulissBinding.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/SoulissBinding.java
@@ -133,7 +133,7 @@ public class SoulissBinding<E> extends AbstractActiveBinding<SoulissBindingProvi
         // Get the typical defined in the hash table
         SoulissGenericTypical T = SoulissGenericBindingProvider.SoulissTypicalsRecipients.getTypicalFromItem(itemName);
         if (T == null) {
-            logger.debug("SoulissTypical not found for item: " + itemName);
+            logger.debug("receiveCommand - itemName '{}' not a SoulissTypical", itemName);
             return;
         }
         logger.info("receiveCommand - {} = {} - Typical: 0x{}", itemName, command, Integer.toHexString(T.getType()));


### PR DESCRIPTION
The NPE happens for all items that are not of souliss type. The fix is rather ugly, but it works.

There are at least three articles in the community site referencing this problem:

* https://community.openhab.org/t/yamahareceiver-binding-has-issue-with-zone-2/19731/7
* https://community.openhab.org/t/issue-with-souliss-binding-after-update/20246/3
* https://community.openhab.org/t/oh2-crash-after-3-4-days-running/34962

Fixes #5369.