### PR TITLE
Add serial-port context to config parameters of bindings

### DIFF
--- a/bundles/binding/org.openhab.binding.dsmr/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.dsmr/ESH-INF/binding/binding.xml
@@ -13,6 +13,7 @@
     <config-description>
         <parameter name="port" type="text" required="true">
             <label>Serial port</label>
+            <context>serial-port</context>            
             <description>The DSMR serial port, e.g. "COM1" for Windows or "/dev/ttyUSB0" for Linux.</description>
             <default>/dev/ttyUSB0</default>
         </parameter>

--- a/bundles/binding/org.openhab.binding.plugwise/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.plugwise/ESH-INF/binding/binding.xml
@@ -12,6 +12,7 @@
     <config-description>
         <parameter name="stick.port" type="text" required="true">
             <label>Stick serial port</label>
+            <context>serial-port</context>            
             <description>The serial port of the Stick, e.g. "COM1" for Windows or "/dev/ttyUSB0" for Linux.</description>
             <default>/dev/ttyUSB0</default>
         </parameter>

--- a/bundles/binding/org.openhab.binding.upb/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.upb/ESH-INF/binding/binding.xml
@@ -18,6 +18,7 @@
         </parameter>
         <parameter name="port" type="text">
             <label>Serial Port</label>
+            <context>serial-port</context>            
             <description>Serial port to which the UPB modem is connected.</description>
             <required>true</required>
         </parameter>


### PR DESCRIPTION
Adds the serial-port context to the other bindings that have a serial port configuration parameter but were not part of #5360.