### PR TITLE
compile against 2.1.0 target platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.openhab</groupId>
         <artifactId>pom-tycho</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.1.0</version>
         <relativePath></relativePath>
     </parent>
 
@@ -227,7 +227,7 @@
         <!-- openHAB core p2 repository -->
         <repository>
             <id>p2-openhab-core</id>
-            <url>https://dl.bintray.com/openhab/p2/openhab-core/${repo.version}</url>
+            <url>https://dl.bintray.com/openhab/p2/openhab-core/2.0.0</url>
             <layout>p2</layout>
         </repository>
 


### PR DESCRIPTION
This should solve the current build problems.
As openHAB 1 add-ons do not depend on any changes in ESH/openHAB2 target platform, it should be safe to always compile against the older 2.1.0 version of it.

Signed-off-by: Kai Kreuzer <kai@openhab.org>