### PR TITLE
Add maven unleash plugin for automated releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,18 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                  <groupId>com.itemis.maven.plugins</groupId>
+                  <artifactId>unleash-maven-plugin</artifactId>
+                  <version>2.7.3</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>com.itemis.maven.plugins</groupId>
+                      <artifactId>unleash-scm-provider-git</artifactId>
+                      <version>2.1.0</version>
+                    </dependency>
+                  </dependencies>
+                </plugin>
+                <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>2.11</version>


### PR DESCRIPTION
Workaround for build issues raised by #5372 (unleash plugin was not present in openHAB 2.1 parent pom).

Signed-off-by: Patrick Fink <mail@pfink.de>