### PR TITLE
Correct feature names

### DIFF
--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -295,7 +295,7 @@
     <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.gc100ir/${project.version}</bundle>
   </feature>
   
-  <feature name="openhab-binding-gpio" description="GPIO Binding" version="${project.version}">
+  <feature name="openhab-binding-gpio1" description="GPIO Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
     <feature>openhab-io-gpio1</feature>
@@ -310,7 +310,7 @@
   </feature>
 
 
-  <feature name="openhab-binding-horizon" description="Horizon Binding" version="${project.version}">
+  <feature name="openhab-binding-horizon1" description="Horizon Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
     <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.horizon/${project.version}</bundle>
@@ -324,7 +324,7 @@
     <configfile finalname="${openhab.conf}/services/http.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/http</configfile>
   </feature>
 
-  <feature name="openhab-binding-iec6205621meter" description="IEC 62056-21 Meter" version="${project.version}">
+  <feature name="openhab-binding-iec6205621meter1" description="IEC 62056-21 Meter" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
     <feature>openhab-transport-serial</feature>


### PR DESCRIPTION
Some recently merged bindings don't have a "1" suffix in their feature name. 

This will also resolve the "404 Not Found" errors when you click on the respective bindings in Paper UI to show their documentation.