### PR TITLE
[KNX.Test][KNX] Add a NotNull assertion to the 19.001 DPT_DATE_TIME test.

### DIFF
--- a/bundles/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/bundles/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -1652,6 +1652,7 @@ public class KNXCoreTypeMapperTest {
          * Standard Summer Time: Time = UT+X, Quality of Clock: clock without ext. sync signal
          */
         Type type = testToType(dpt, new byte[] { 0x00, 0x01, 0x01, 0x21, 0x02, 0x03, 0x00, 0x00 }, DateTimeType.class);
+        assertNotNull("Failed to get a type for the datapoint '" + dpt + "'", type);
         testToDPTValue(dpt, type, "1900-01-01 01:02:03");
 
         /*
@@ -1665,27 +1666,32 @@ public class KNXCoreTypeMapperTest {
          */
         assertNull("KNXCoreTypeMapper.toType() should return null (date but no year)",
                 testToType(dpt, new byte[] { 0x00, 0x01, 0x01, 0x20, 0x00, 0x00, 0x10, 0x00 }, DateTimeType.class));
+
         /*
          * Reference testcase + Months and Day fields invalid => not supported
          */
         assertNull("KNXCoreTypeMapper.toType() should return null (date but no day and month)",
                 testToType(dpt, new byte[] { 0x00, 0x01, 0x01, 0x20, 0x00, 0x00, 0x08, 0x00 }, DateTimeType.class));
+
         /*
          * Reference testcase + Year, Months and Day fields invalid
          */
         type = testToType(dpt, new byte[] { 0x00, 0x01, 0x01, 0x21, 0x02, 0x03, 0x18, 0x00 }, DateTimeType.class);
         testToDPTValue(dpt, type, "1970-01-01 01:02:03");
+
         /*
          * Reference testcase + Year , Months and Day fields invalid + Day of week field invalid
          */
         type = testToType(dpt, new byte[] { 0x00, 0x01, 0x01, 0x21, 0x02, 0x03, 0x1C, 0x00 }, DateTimeType.class);
         testToDPTValue(dpt, type, "1970-01-01 01:02:03");
+
         /*
          * Reference testcase + Year, Months and Day fields invalid + Day of week field invalid
          * Working day field invalid
          */
         type = testToType(dpt, new byte[] { 0x00, 0x01, 0x01, 0x21, 0x02, 0x03, 0x3C, 0x00 }, DateTimeType.class);
         testToDPTValue(dpt, type, "1970-01-01 01:02:03");
+
         /*
          * Reference testcase + Year Field invalid + Months and Day fields invalid + Day of week field invalid
          * Working day field invalid + Hour of day, Minutes and Seconds fields invalid
@@ -1701,16 +1707,19 @@ public class KNXCoreTypeMapperTest {
         assertNull("KNXCoreTypeMapper.toType() should return null (neither date nor time, but summertime flag)",
                 type = testToType(dpt, new byte[] { 0x00, 0x01, 0x01, 0x20, 0x00, 0x00, 0x3F, 0x00 },
                         DateTimeType.class));
+
         /*
          * Reference testcase + day of week=Any day, Day of week field invalid
          */
         type = testToType(dpt, new byte[] { 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00 }, DateTimeType.class);
         testToDPTValue(dpt, type, "1900-01-01 00:00:00");
+
         /*
          * Reference testcase + Day of week field invalid
          */
         type = testToType(dpt, new byte[] { 0x00, 0x01, 0x01, 0x20, 0x00, 0x00, 0x04, 0x00 }, DateTimeType.class);
         testToDPTValue(dpt, type, "1900-01-01 00:00:00");
+
         /*
          * Reference testcase + day of week=Any day, Day of week field invalid, working day, working day field invalid
          */
@@ -1724,6 +1733,7 @@ public class KNXCoreTypeMapperTest {
         type = testToType(dpt, new byte[] { (byte) 0xFF, 0x0C, 0x1F, 0x17, 0x3B, 0x3B, (byte) 0x04, (byte) 0x00 },
                 DateTimeType.class);
         testToDPTValue(dpt, type, "2155-12-31 23:59:59");
+
         /*
          * December 31st, 2155, 24:00:00, day of week=Any day, Day of week field invalid
          *
@@ -1737,6 +1747,7 @@ public class KNXCoreTypeMapperTest {
         type = testToType(dpt, new byte[] { (byte) 0xFF, 0x0C, 0x1F, 0x18, 0x00, 0x00, (byte) 0x04, (byte) 0x00 },
                 DateTimeType.class);
         testToDPTValue(dpt, type, "2155-12-31 23:59:59");
+
         /*
          * December 31st, 2014 24:00:00, day of week=Any day, Day of week field invalid
          *

--- a/bundles/binding/org.openhab.binding.knx/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.knx/META-INF/MANIFEST.MF
@@ -32,6 +32,7 @@ Bundle-SymbolicName: org.openhab.binding.knx
 Bundle-DocURL: http://www.openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/knxconnection.xml, OSGI-INF/knxbinding.xml, OSGI-INF/knxcoretypemapper.xml, OSGI-INF/knxgenericbindingprovider.xml
+Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/calimero-rxtx-2.0a3.jar,
  lib/calimero-core-2.3-beta.jar,
  .

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -277,10 +277,6 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements P
 
         logger.trace("Processed event (item='{}', type='{}', destination='{}')", itemName, type.toString(),
                 destination.toString());
-    }
-
-    private boolean isStopCommand(byte[] asdu) {
-        return asdu.length > 0 && (asdu[0] == 0x00 || asdu[0] == 0x08);
     }
 
     private boolean isStartStopEnabled(String itemName, GroupAddress destination, Datapoint datapoint) {

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBindingDatapointReaderTask.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBindingDatapointReaderTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -49,7 +49,7 @@ public class KNXBindingDatapointReaderTask extends Thread implements KNXConnecti
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see java.lang.Runnable#run()
      */
     @Override
@@ -61,27 +61,24 @@ public class KNXBindingDatapointReaderTask extends Thread implements KNXConnecti
                 dp = readQueue.take();
                 sLogger.debug("Autorefresh: got new item {} in reader queue", dp.getName());
 
-                if (dp != null) {
-                    if (mKNXConnected) {
-                        sLogger.debug("Autorefresh: Trying to read from KNX bus: {}", dp);
-                        readFromKNXBus(dp);
+                if (mKNXConnected) {
+                    sLogger.debug("Autorefresh: Trying to read from KNX bus: {}", dp);
+                    readFromKNXBus(dp);
 
-                        long readingPause = KNXConnection.getReadingPause();
-                        if (readingPause > 0) {
-                            try {
-                                sLogger.debug(
-                                        "Autorefresh: DatapointReaderTask Waiting {} msecs to prevent KNX bus overload",
-                                        readingPause);
-                                Thread.sleep(readingPause);
-                            } catch (InterruptedException e) {
-                                sLogger.debug(
-                                        "Autorefresh: DatapointReaderTask KNX reading pause has been interrupted: {}",
-                                        e.getMessage());
-                            }
+                    long readingPause = KNXConnection.getReadingPause();
+                    if (readingPause > 0) {
+                        try {
+                            sLogger.debug(
+                                    "Autorefresh: DatapointReaderTask Waiting {} msecs to prevent KNX bus overload",
+                                    readingPause);
+                            Thread.sleep(readingPause);
+                        } catch (InterruptedException e) {
+                            sLogger.debug("Autorefresh: DatapointReaderTask KNX reading pause has been interrupted: {}",
+                                    e.getMessage());
                         }
-                    } else {
-                        sLogger.debug("Autorefresh: Not connected. Skipping bus read.");
                     }
+                } else {
+                    sLogger.debug("Autorefresh: Not connected. Skipping bus read.");
                 }
             }
         } catch (InterruptedException ex) {
@@ -129,7 +126,7 @@ public class KNXBindingDatapointReaderTask extends Thread implements KNXConnecti
      * Adds or re-adds a datapoint to readQueue,
      * if datapoint is known in dpReadRetries, retries will be reduced.
      * Otherwise it will be registered in dpReadRetries with retriesLimit.
-     * 
+     *
      * @param datapoint
      */
     private void addToReadQueue(Datapoint datapoint) throws InterruptedException {
@@ -148,7 +145,7 @@ public class KNXBindingDatapointReaderTask extends Thread implements KNXConnecti
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.openhab.binding.knx.internal.connection.KNXConnectionListener#connectionEstablished()
      */
     @Override
@@ -158,7 +155,7 @@ public class KNXBindingDatapointReaderTask extends Thread implements KNXConnecti
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.openhab.binding.knx.internal.connection.KNXConnectionListener#connectionLost()
      */
     @Override

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/config/KNXGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/config/KNXGenericBindingProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -448,7 +448,7 @@ public class KNXGenericBindingProvider extends AbstractGenericBindingProvider
                         // DatapointID specified in binding config, so use it
                         dptID = segments[0];
                     }
-                    if (dptID == null || dptID.trim().isEmpty()) {
+                    if ((dptID == null || dptID.trim().isEmpty()) && typeClass != null) {
                         throw new BindingConfigParseException(
                                 "No DPT could be determined for the type '" + typeClass.getSimpleName() + "'.");
                     }

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -544,6 +544,7 @@ public class KNXCoreTypeMapper implements KNXTypeMapper {
      */
     private String formatDateTime(String value, String dpt) {
         Date date = null;
+        String valueToUse = value;
 
         try {
             if (DPTXlatorDate.DPT_DATE.getID().equals(dpt)) {
@@ -560,9 +561,9 @@ public class KNXCoreTypeMapper implements KNXTypeMapper {
                     int start = stb.indexOf("no-day");
                     int end = start + "no-day".length();
                     stb.replace(start, end, String.format(Locale.US, "%1$ta", Calendar.getInstance()));
-                    value = stb.toString();
+                    valueToUse = stb.toString();
                 }
-                date = new SimpleDateFormat(TIME_DAY_FORMAT, Locale.US).parse(value);
+                date = new SimpleDateFormat(TIME_DAY_FORMAT, Locale.US).parse(valueToUse);
             }
         } catch (ParseException pe) {
             // do nothing but logging


### PR DESCRIPTION
Added an assertion that the type not be null in the test for 19.001 DPT_DATE_TIME. This is for #5422.
(However, not that this is not a fix for #5422, just an enhancement)

Also cleaned up some compiler warnings.
