### PR TITLE
[XMPP Action] Fix some linter errors

### DIFF
--- a/bundles/action/org.openhab.action.xmpp/README.md
+++ b/bundles/action/org.openhab.action.xmpp/README.md
@@ -4,9 +4,9 @@ This set of actions allows you to send a message to an XMPP user or multi-user c
 
 ## Actions
 
-*   `sendXMPP(String to, String message)`: Sends a message to an XMPP user
-*   `sendXMPP(String to, String message, String attachmentUrl)`: Sends a message with an attachment to an XMPP user
-*   `chatXMPP(String message)`: Sends a message to a multi user chat
+- `sendXMPP(String to, String message)`: Sends a message to an XMPP user
+- `sendXMPP(String to, String message, String attachmentUrl)`: Sends a message with an attachment to an XMPP user
+- `chatXMPP(String message)`: Sends a message to a multi user chat
 
 ## Configuration
 
@@ -26,13 +26,12 @@ The XMPP Action service can be configured in `services/xmpp.cfg`.
 | chatnickname | `openhab-bot` |       No | The nickname used in the multi-user chat                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | chatpassword |               |          | The password required to join the multi user chat                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
-
 Note: openHAB does not resolve SRV entries like other XMPP clients do, you have to setup the server details manually.
 Generally, if `joe@example.org` is your XMPP user ID and `xmpp.example.net` points to the server running the service, set `servername` to the actual server `xmpp.example.net`, the user name `username` to `joe` and `proxy` to the domain name part of your user ID `example.org`.
 
 ## Example: Google
 
-```
+```java
 servername=talk.google.com
 securitymode=required
 # You need this "tlspin" if openhab cannot verify the certificate from the google server


### PR DESCRIPTION
- Note that linter errors still present around URL literals in table.
Did not know how to correct this.

Signed-off-by: Brad Gilmer <brad@gilmer.tv>