### PR TITLE
[Pushover] Added Receipts and Callback API for handling of emergency-priority notifications

### DIFF
--- a/bundles/action/org.openhab.action.pushover/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.pushover/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-Version: 1.12.0.qualifier
 Bundle-Activator: org.openhab.action.pushover.internal.PushoverActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Pushover action of the open Home Automation Bus (openHAB)
-Import-Package: org.apache.commons.io;version="2.0.1",
+Import-Package: com.google.gson,
+ org.apache.commons.io,
  org.apache.commons.lang,
  org.openhab.core.items,
  org.openhab.core.library.items,

--- a/bundles/action/org.openhab.action.pushover/README.md
+++ b/bundles/action/org.openhab.action.pushover/README.md
@@ -35,25 +35,26 @@ For specific information on each item, see the [Pushover API](https://pushover.n
 - `pushover(String message, String device, int priority, String url, String urlTitle)`
 - `pushover(String message, String device, int priority, String url, String urlTitle, String soundFile)`
 - `pushover(String apiToken, String userKey, String message)`
-- `pushover(String apiToken, String userKey, String message, String device)`
 - `pushover(String apiToken, String userKey, String message, int priority)`
+- `pushover(String apiToken, String userKey, String message, String device)`
 - `pushover(String apiToken, String userKey, String message, String device, int priority)`
 - `pushover(String apiToken, String userKey, String message, String device, String title, String url, String urlTitle, int priority, String soundFile)`
+
+The action calls have to be configured in the above sequence, if you need to omit one of the call parameters you may use a null value or two double quotes.
+In this case any default values from `services/pushover.cfg` will be used.
+Note that you cannot use a null value for int priority.
 
 - `sendPushoverEmergency(String message)`
 - `sendPushoverEmergency(String message, String title)`
 - `sendPushoverEmergency(String message, String title, String device)`
 - `sendPushoverEmergency(String message, String title, String device, String soundFile)`
 
-- `sendPushover(String apiToken, String userKey, String message, String device, String title, String url, String urlTitle, int priority, String soundFile)`
-
 - `cancelPushoverEmergency(String receipt)`
 - `cancelPushoverEmergency(String apiToken, String userKey, String receipt)`
 
-The action calls have to be configured in the above sequence, if you need to omit one of the call parameters you may use a null value or two double quotes.
-In this case any default values from `services/pushover.cfg` will be used.
-Note that you cannot use a null value for int priority.
-The `sendPushoverEmergency` actions will return a `receipt` parameter that can be used with the `cancelPushoverEmergency` actions to cancel an emergency-priority notification before the `defaultExpire` value will be reached.
+The `sendPushoverEmergency` actions will send a message with [Emergency Priority](https://pushover.net/api#priority).
+The actions return a receipt identifier (String).
+The identifier has to be passed on to the `cancelPushoverEmergency` actions to cancel the notification prior to reaching the `defaultExpire` value of one hour.
 
 ### Basic example
 
@@ -65,9 +66,7 @@ Send a message without a sound, omit String url and String urlTitle.
 ### Emergency example
 
 ```php
-var String receipt = null
-
-receipt = sendPushoverEmergency("Panic !")
+var String receipt = sendPushoverEmergency("Attention, front door opened!")
 
 // wait for your cancel condition
 

--- a/bundles/action/org.openhab.action.pushover/README.md
+++ b/bundles/action/org.openhab.action.pushover/README.md
@@ -25,11 +25,11 @@ The following are valid action calls that can be made when the plugin is loaded.
 For specific information on each item, see the [Pushover API](https://pushover.net/api).
 
 - `pushover(String message)`
-- `pushover(String message, String device)`
 - `pushover(String message, int priority)`
 - `pushover(String message, int priority, String url)`
 - `pushover(String message, int priority, String url, String urlTitle)`
 - `pushover(String message, int priority, String url, String urlTitle, String soundFile)`
+- `pushover(String message, String device)`
 - `pushover(String message, String device, int priority)`
 - `pushover(String message, String device, int priority, String url)`
 - `pushover(String message, String device, int priority, String url, String urlTitle)`
@@ -40,13 +40,39 @@ For specific information on each item, see the [Pushover API](https://pushover.n
 - `pushover(String apiToken, String userKey, String message, String device, int priority)`
 - `pushover(String apiToken, String userKey, String message, String device, String title, String url, String urlTitle, int priority, String soundFile)`
 
+- `sendPushoverEmergency(String message)`
+- `sendPushoverEmergency(String message, String title)`
+- `sendPushoverEmergency(String message, String title, String device)`
+- `sendPushoverEmergency(String message, String title, String device, String soundFile)`
+
+- `sendPushover(String apiToken, String userKey, String message, String device, String title, String url, String urlTitle, int priority, String soundFile)`
+
+- `cancelPushoverEmergency(String receipt)`
+- `cancelPushoverEmergency(String apiToken, String userKey, String receipt)`
+
 The action calls have to be configured in the above sequence, if you need to omit one of the call parameters you may use a null value or two double quotes.
 In this case any default values from `services/pushover.cfg` will be used.
 Note that you cannot use a null value for int priority.
+The `sendPushoverEmergency` actions will return a `receipt` parameter that can be used with the `cancelPushoverEmergency` actions to cancel an emergency-priority notification before the `defaultExpire` value will be reached.
 
-### Example
+### Basic example
 
 Send a message without a sound, omit String url and String urlTitle.
 
 - `pushover("test message", 1, null, null, "none")` or
 - `pushover("test message", 1, "", "", "none")`
+
+### Emergency example
+
+```php
+var String receipt = null
+
+receipt = sendPushoverEmergency("Panic !")
+
+// wait for your cancel condition
+
+if( receipt !== null ) {
+    cancelPushoverEmergency(receipt)
+    receipt = null
+}
+```

--- a/bundles/action/org.openhab.action.pushover/src/main/java/org/openhab/action/pushover/internal/Pushover.java
+++ b/bundles/action/org.openhab.action.pushover/src/main/java/org/openhab/action/pushover/internal/Pushover.java
@@ -243,7 +243,7 @@ public class Pushover {
             } else if (!StringUtils.isEmpty(defaultApiKey)) {
                 addEncodedParameter(data, MESSAGE_KEY_API_KEY, defaultApiKey);
             } else {
-                logger.error("Application API token not specified.");
+                logger.warn("Application API token not specified.");
                 return false;
             }
 
@@ -252,7 +252,7 @@ public class Pushover {
             } else if (!StringUtils.isEmpty(defaultUser)) {
                 addEncodedParameter(data, MESSAGE_KEY_USER, defaultUser);
             } else {
-                logger.error("The user/group key was not specified.");
+                logger.warn("The user/group key was not specified.");
                 return false;
             }
 
@@ -260,12 +260,12 @@ public class Pushover {
                 if ((message.length() + title.length()) <= API_MAX_MESSAGE_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_MESSAGE, message);
                 } else {
-                    logger.error("Together, the event message and title total more than " + API_MAX_MESSAGE_LENGTH
-                            + " characters.");
+                    logger.warn("Together, the event message and title total more than {} characters.",
+                            API_MAX_MESSAGE_LENGTH);
                     return false;
                 }
             } else {
-                logger.error("The event message is missing.");
+                logger.warn("The event message is missing.");
                 return false;
             }
 
@@ -285,14 +285,14 @@ public class Pushover {
                 if (url.length() <= API_MAX_URL_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_URL, url);
                 } else {
-                    logger.error("The url is greater than {} characters.", API_MAX_URL_LENGTH);
+                    logger.warn("The url is greater than {} characters.", API_MAX_URL_LENGTH);
                     return false;
                 }
             } else if (!StringUtils.isEmpty(defaultUrl)) {
                 if (defaultUrl.length() <= API_MAX_URL_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_URL, defaultUrl);
                 } else {
-                    logger.error("The url is greater than {} characters.", API_MAX_URL_LENGTH);
+                    logger.warn("The url is greater than {} characters.", API_MAX_URL_LENGTH);
                     return false;
                 }
             }
@@ -301,14 +301,14 @@ public class Pushover {
                 if (urlTitle.length() <= API_MAX_URL_TITLE_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_URL_TITLE, urlTitle);
                 } else {
-                    logger.error("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
+                    logger.warn("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
                     return false;
                 }
             } else if (!StringUtils.isEmpty(defaultUrlTitle)) {
                 if (defaultUrlTitle.length() <= API_MAX_URL_TITLE_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_URL_TITLE, defaultUrlTitle);
                 } else {
-                    logger.error("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
+                    logger.warn("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
                     return false;
                 }
             }
@@ -349,14 +349,14 @@ public class Pushover {
             }
 
             String content = data.toString();
-            logger.debug("Executing post to " + XML_API_URL + " with the following content: " + content);
+            logger.debug("Executing post to {} with the following content: {}", XML_API_URL, content);
             String response = HttpUtil.executeUrl("POST", XML_API_URL, IOUtils.toInputStream(content), CONTENT_TYPE,
                     timeout);
             logger.debug("Raw response: {}", response);
 
             try {
                 if (StringUtils.isEmpty(response)) {
-                    logger.error(
+                    logger.warn(
                             "Received an empty response from our Pushover API call. This can mean either we are having trouble connecting to the Pushover API or the Pushover API is actively enforcing rate limits with a connection time-out.");
                     return false;
                 }
@@ -364,16 +364,16 @@ public class Pushover {
                 if (StringUtils.isEmpty(responseMessage)) {
                     return true;
                 } else {
-                    logger.error("Received error message from Pushover: {}", responseMessage);
+                    logger.warn("Received error message from Pushover: {}", responseMessage);
                     return false;
                 }
             } catch (Exception e) {
-                logger.warn("Can't parse response from Pushover.", e);
+                logger.warn("Can't parse response from Pushover: {}", e.getMessage());
                 logger.debug("Raw response: {}", response);
                 return false;
             }
         } catch (Exception e) {
-            logger.error("An error occurred while notifying your mobile device.", e);
+            logger.warn("An error occurred while notifying your mobile device: {}", e.getMessage());
             return false;
         }
     }
@@ -462,7 +462,7 @@ public class Pushover {
             } else if (!StringUtils.isEmpty(defaultApiKey)) {
                 addEncodedParameter(data, MESSAGE_KEY_API_KEY, defaultApiKey);
             } else {
-                logger.error("Application API token not specified.");
+                logger.warn("Application API token not specified.");
                 return null;
             }
 
@@ -471,7 +471,7 @@ public class Pushover {
             } else if (!StringUtils.isEmpty(defaultUser)) {
                 addEncodedParameter(data, MESSAGE_KEY_USER, defaultUser);
             } else {
-                logger.error("The user/group key was not specified.");
+                logger.warn("The user/group key was not specified.");
                 return null;
             }
 
@@ -479,12 +479,12 @@ public class Pushover {
                 if ((message.length() + title.length()) <= API_MAX_MESSAGE_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_MESSAGE, message);
                 } else {
-                    logger.error("Together, the event message and title total more than " + API_MAX_MESSAGE_LENGTH
-                            + " characters.");
+                    logger.warn("Together, the event message and title total more than {} characters.",
+                            API_MAX_MESSAGE_LENGTH);
                     return null;
                 }
             } else {
-                logger.error("The event message is missing.");
+                logger.warn("The event message is missing.");
                 return null;
             }
 
@@ -504,14 +504,14 @@ public class Pushover {
                 if (url.length() <= API_MAX_URL_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_URL, url);
                 } else {
-                    logger.error("The url is greater than {} characters.", API_MAX_URL_LENGTH);
+                    logger.warn("The url is greater than {} characters.", API_MAX_URL_LENGTH);
                     return null;
                 }
             } else if (!StringUtils.isEmpty(defaultUrl)) {
                 if (defaultUrl.length() <= API_MAX_URL_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_URL, defaultUrl);
                 } else {
-                    logger.error("The url is greater than {} characters.", API_MAX_URL_LENGTH);
+                    logger.warn("The url is greater than {} characters.", API_MAX_URL_LENGTH);
                     return null;
                 }
             }
@@ -520,14 +520,14 @@ public class Pushover {
                 if (urlTitle.length() <= API_MAX_URL_TITLE_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_URL_TITLE, urlTitle);
                 } else {
-                    logger.error("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
+                    logger.warn("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
                     return null;
                 }
             } else if (!StringUtils.isEmpty(defaultUrlTitle)) {
                 if (defaultUrlTitle.length() <= API_MAX_URL_TITLE_LENGTH) {
                     addEncodedParameter(data, MESSAGE_KEY_URL_TITLE, defaultUrlTitle);
                 } else {
-                    logger.error("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
+                    logger.warn("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
                     return null;
                 }
             }
@@ -568,13 +568,13 @@ public class Pushover {
             }
 
             String content = data.toString();
-            logger.debug("Executing post to " + JSON_API_URL + " with the following content: " + content);
+            logger.debug("Executing post to {} with the following content: {}", JSON_API_URL, content);
             String response = HttpUtil.executeUrl("POST", JSON_API_URL, IOUtils.toInputStream(content), CONTENT_TYPE,
                     timeout);
             logger.debug("Raw response: {}", response);
 
             if (StringUtils.isEmpty(response)) {
-                logger.error(
+                logger.warn(
                         "Received an empty response from our Pushover API call. This can mean either we are having trouble connecting to the Pushover API or the Pushover API is actively enforcing rate limits with a connection time-out.");
                 return null;
             }
@@ -586,12 +586,12 @@ public class Pushover {
             if (json.has(API_RETURN_STATUS_TAG) && json.get(API_RETURN_STATUS_TAG).getAsInt() == 1) {
                 return json.has(API_RETURN_RECEIPT_TAG) ? json.get(API_RETURN_RECEIPT_TAG).getAsString() : null;
             } else {
-                logger.error("Received error message from Pushover: {}",
+                logger.warn("Received error message from Pushover: {}",
                         json.get(API_RETURN_ERRORS_TAG).getAsJsonArray().getAsString());
                 return null;
             }
         } catch (Exception e) {
-            logger.error("An error occurred while notifying your mobile device.", e);
+            logger.warn("An error occurred while notifying your mobile device: {}", e.getMessage());
             return null;
         }
     }
@@ -617,7 +617,7 @@ public class Pushover {
             } else if (!StringUtils.isEmpty(defaultApiKey)) {
                 addEncodedParameter(data, MESSAGE_KEY_API_KEY, defaultApiKey);
             } else {
-                logger.error("Application API token not specified.");
+                logger.warn("Application API token not specified.");
                 return false;
             }
 
@@ -626,23 +626,23 @@ public class Pushover {
             } else if (!StringUtils.isEmpty(defaultUser)) {
                 addEncodedParameter(data, MESSAGE_KEY_USER, defaultUser);
             } else {
-                logger.error("The user/group key was not specified.");
+                logger.warn("The user/group key was not specified.");
                 return false;
             }
 
             if (StringUtils.isEmpty(receipt)) {
-                logger.error("The message's receipt is missing.");
+                logger.warn("The message's receipt is missing.");
                 return false;
             }
 
             String url = JSON_CANCEL_API_URL.replace("{receipt}", receipt);
             String content = data.toString();
-            logger.debug("Executing post to " + url + " with the following content: " + content);
+            logger.debug("Executing post to {} with the following content: {}", url, content);
             String response = HttpUtil.executeUrl("POST", url, IOUtils.toInputStream(content), CONTENT_TYPE, timeout);
             logger.debug("Raw response: {}", response);
 
             if (StringUtils.isEmpty(response)) {
-                logger.error(
+                logger.warn(
                         "Received an empty response from our Pushover API call. This can mean either we are having trouble connecting to the Pushover API or the Pushover API is actively enforcing rate limits with a connection time-out.");
                 return false;
             }
@@ -650,12 +650,12 @@ public class Pushover {
             if (json.has(API_RETURN_STATUS_TAG) && json.get(API_RETURN_STATUS_TAG).getAsInt() == 1) {
                 return true;
             } else {
-                logger.error("Received error message from Pushover: {}",
+                logger.warn("Received error message from Pushover: {}",
                         json.get(API_RETURN_ERRORS_TAG).getAsJsonArray().getAsString());
                 return false;
             }
         } catch (Exception e) {
-            logger.error("An error occurred while canceling your notification.", e);
+            logger.warn("An error occurred while canceling your notification: {}", e.getMessage());
             return false;
         }
     }

--- a/bundles/action/org.openhab.action.pushover/src/main/java/org/openhab/action/pushover/internal/Pushover.java
+++ b/bundles/action/org.openhab.action.pushover/src/main/java/org/openhab/action/pushover/internal/Pushover.java
@@ -31,34 +31,46 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 /**
  * This class contains the methods that are made available in scripts and rules
  * for sending messages via the Pushover mobile device push service..
  *
- * @author Chris Graham
+ * @author Chris Graham - Initial contribution
+ * @author Christoph Weitkamp - Added Receipts and Callback API for handling of emergency-priority notifications
  * @since 1.5.0
  */
 public class Pushover {
 
     private static final Logger logger = LoggerFactory.getLogger(Pushover.class);
 
-    private final static String API_URL = "https://api.pushover.net/1/messages.xml";
-    private final static String CONTENT_TYPE = "application/x-www-form-urlencoded";
-    private final static String UTF_8_ENCODING = "UTF-8";
+    private static final String JSON_API_URL = "https://api.pushover.net/1/messages.json";
+    private static final String JSON_CANCEL_API_URL = "https://api.pushover.net/1/receipts/{receipt}/cancel.json";
+    private static final String XML_API_URL = "https://api.pushover.net/1/messages.xml";
+    private static final String CONTENT_TYPE = "application/x-www-form-urlencoded";
+    private static final String UTF_8_ENCODING = "UTF-8";
 
-    private final static String API_RETURN_ROOT_TAG = "response";
-    private final static String API_RETURN_STATUS_TAG = "status";
-    private final static String API_RETURN_INFO_TAG = "info";
-    private final static String API_RETURN_ERROR_TAG = "error";
-    private final static String API_RETURN_STATUS_SUCCESS = "1";
+    private static final JsonParser parser = new JsonParser();
 
-    private final static int API_MAX_MESSAGE_LENGTH = 512;
-    private final static int API_MAX_URL_LENGTH = 512;
-    private final static int API_MAX_URL_TITLE_LENGTH = 100;
-    private final static int[] API_VALID_PRIORITY_LIST = { -2, -1, 0, 1, 2 };
-    private final static int[] API_HIGH_PRIORITY_LIST = { 2 };
-    private final static int API_MIN_RETRY_SECONDS = 30;
-    private final static int API_MAX_EXPIRE_SECONDS = 86400;
+    private static final String API_RETURN_ROOT_TAG = "response";
+    private static final String API_RETURN_STATUS_TAG = "status";
+    private static final String API_RETURN_INFO_TAG = "info";
+    private static final String API_RETURN_ERROR_TAG = "error";
+    private static final String API_RETURN_ERRORS_TAG = "errors";
+    private static final String API_RETURN_STATUS_SUCCESS = "1";
+    private static final String API_RETURN_RECEIPT_TAG = "receipt";
+
+    private static final int API_MAX_MESSAGE_LENGTH = 512;
+    private static final int API_MAX_URL_LENGTH = 512;
+    private static final int API_MAX_URL_TITLE_LENGTH = 100;
+    private static final int[] API_VALID_PRIORITY_LIST = { -2, -1, 0, 1, 2 };
+    private static final int[] API_HIGH_PRIORITY_LIST = { 2 };
+    private static final int API_MIN_RETRY_SECONDS = 30;
+    private static final int API_MAX_EXPIRE_SECONDS = 86400;
 
     public static final String MESSAGE_KEY_API_KEY = "token";
     public static final String MESSAGE_KEY_USER = "user";
@@ -83,6 +95,7 @@ public class Pushover {
     static String defaultUrl;
     static String defaultUrlTitle;
     static int defaultPriority = 0;
+    static int emergencyPriority = 2;
     static String defaultSound;
 
     static int retry = 300;
@@ -303,6 +316,24 @@ public class Pushover {
             try {
                 if (isValueInList(API_VALID_PRIORITY_LIST, priority)) {
                     addEncodedParameter(data, MESSAGE_KEY_PRIORITY, String.valueOf(priority));
+
+                    if (isValueInList(API_HIGH_PRIORITY_LIST, priority)) {
+                        if (retry >= API_MIN_RETRY_SECONDS) {
+                            addEncodedParameter(data, MESSAGE_KEY_RETRY, String.valueOf(retry));
+                        } else {
+                            logger.warn("Retry value of {} is too small. Using default value of {}.", retry,
+                                    API_MIN_RETRY_SECONDS);
+                            addEncodedParameter(data, MESSAGE_KEY_RETRY, String.valueOf(API_MIN_RETRY_SECONDS));
+                        }
+
+                        if (expire <= API_MAX_EXPIRE_SECONDS) {
+                            addEncodedParameter(data, MESSAGE_KEY_EXPIRE, String.valueOf(expire));
+                        } else {
+                            logger.warn("Expire value of {} is too large. Using default value of {}.", expire,
+                                    API_MAX_EXPIRE_SECONDS);
+                            addEncodedParameter(data, MESSAGE_KEY_EXPIRE, String.valueOf(API_MAX_EXPIRE_SECONDS));
+                        }
+                    }
                 } else {
                     logger.warn("Invalid priority, skipping. Expected: {}. Got: {}.",
                             Arrays.toString(API_VALID_PRIORITY_LIST), priority);
@@ -317,27 +348,9 @@ public class Pushover {
                 addEncodedParameter(data, MESSAGE_KEY_SOUND, defaultSound);
             }
 
-            if (isValueInList(API_HIGH_PRIORITY_LIST, priority)) {
-                if (retry >= API_MIN_RETRY_SECONDS) {
-                    addEncodedParameter(data, MESSAGE_KEY_RETRY, String.valueOf(retry));
-                } else {
-                    logger.warn("Retry value of {} is too small. Using default value of {}.", retry,
-                            API_MIN_RETRY_SECONDS);
-                    addEncodedParameter(data, MESSAGE_KEY_RETRY, String.valueOf(API_MIN_RETRY_SECONDS));
-                }
-
-                if (expire <= API_MAX_EXPIRE_SECONDS) {
-                    addEncodedParameter(data, MESSAGE_KEY_EXPIRE, String.valueOf(expire));
-                } else {
-                    logger.warn("Expire value of {} is too large. Using default value of {}.", expire,
-                            API_MAX_EXPIRE_SECONDS);
-                    addEncodedParameter(data, MESSAGE_KEY_EXPIRE, String.valueOf(API_MAX_EXPIRE_SECONDS));
-                }
-            }
-
             String content = data.toString();
-            logger.debug("Executing post to " + API_URL + " with the following content: " + content);
-            String response = HttpUtil.executeUrl("POST", API_URL, IOUtils.toInputStream(content), CONTENT_TYPE,
+            logger.debug("Executing post to " + XML_API_URL + " with the following content: " + content);
+            String response = HttpUtil.executeUrl("POST", XML_API_URL, IOUtils.toInputStream(content), CONTENT_TYPE,
                     timeout);
             logger.debug("Raw response: {}", response);
 
@@ -347,7 +360,7 @@ public class Pushover {
                             "Received an empty response from our Pushover API call. This can mean either we are having trouble connecting to the Pushover API or the Pushover API is actively enforcing rate limits with a connection time-out.");
                     return false;
                 }
-                String responseMessage = parseResponse(response);
+                String responseMessage = parseXMLResponse(response);
                 if (StringUtils.isEmpty(responseMessage)) {
                     return true;
                 } else {
@@ -365,7 +378,7 @@ public class Pushover {
         }
     }
 
-    private static String parseResponse(String response)
+    private static String parseXMLResponse(String response)
             throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder db = factory.newDocumentBuilder();
@@ -397,6 +410,254 @@ public class Pushover {
         }
 
         return response;
+    }
+
+    @ActionDoc(text = "Send an emergency-priority notification to your mobile device using the default api key.", returns = "a <code>receipt</code> (30 character string containing the character set [A-Za-z0-9]), if successful and <code>null</code> otherwise.")
+    public static String sendPushoverEmergency(@ParamDoc(name = "message", text = "Your message.") String message) {
+        return sendPushover(defaultApiKey, defaultUser, message, defaultDevice, defaultTitle, defaultUrl,
+                defaultUrlTitle, emergencyPriority, defaultSound);
+    }
+
+    @ActionDoc(text = "Send an emergency-priority notification to your mobile device using the default api key.", returns = "a <code>receipt</code> (30 character string containing the character set [A-Za-z0-9]), if successful and <code>null</code> otherwise.")
+    public static String sendPushoverEmergency(@ParamDoc(name = "message", text = "Your message.") String message,
+            @ParamDoc(name = "title", text = "Your message's title, otherwise your app's name is used.") String title) {
+        return sendPushover(defaultApiKey, defaultUser, message, defaultDevice, title, defaultUrl, defaultUrlTitle,
+                emergencyPriority, defaultSound);
+    }
+
+    @ActionDoc(text = "Send an emergency-priority notification to your mobile device using the default api key.", returns = "a <code>receipt</code> (30 character string containing the character set [A-Za-z0-9]), if successful and <code>null</code> otherwise.")
+    public static String sendPushoverEmergency(@ParamDoc(name = "message", text = "Your message.") String message,
+            @ParamDoc(name = "title", text = "Your message's title, otherwise your app's name is used.") String title,
+            @ParamDoc(name = "device", text = " Your user's device name to send the message directly to that device, rather than all of the user's devices.") String device) {
+        return sendPushover(defaultApiKey, defaultUser, message, device, title, defaultUrl, defaultUrlTitle,
+                emergencyPriority, defaultSound);
+    }
+
+    @ActionDoc(text = "Send an emergency-priority notification to your mobile device using the default api key.", returns = "a <code>receipt</code> (30 character string containing the character set [A-Za-z0-9]), if successful and <code>null</code> otherwise.")
+    public static String sendPushoverEmergency(@ParamDoc(name = "message", text = "Your message.") String message,
+            @ParamDoc(name = "title", text = "Your message's title, otherwise your app's name is used.") String title,
+            @ParamDoc(name = "device", text = " Your user's device name to send the message directly to that device, rather than all of the user's devices.") String device,
+            @ParamDoc(name = "sound", text = "The name of one of the sounds supported by device clients to override the user's default sound choice.") String sound) {
+        return sendPushover(defaultApiKey, defaultUser, message, device, title, defaultUrl, defaultUrlTitle,
+                emergencyPriority, sound);
+    }
+
+    // Primary method for sending a message to the Pushover API
+    @ActionDoc(text = "Send a notification to your Android device. apiKey, user and message are required. All else can effectively be null.", returns = "a <code>receipt</code> (30 character string containing the character set [A-Za-z0-9]), if successful and <code>null</code> otherwise.")
+    public static String sendPushover(@ParamDoc(name = "apiKey", text = "Your application's API token.") String apiKey,
+            @ParamDoc(name = "user", text = "The user/group key (not e-mail address) of your user (or you), viewable when logged into Pushover dashboard.") String user,
+            @ParamDoc(name = "message", text = "Your message.") String message,
+            @ParamDoc(name = "device", text = " Your user's device name to send the message directly to that device, rather than all of the user's devices.") String device,
+            @ParamDoc(name = "title", text = "Your message's title, otherwise your app's name is used.") String title,
+            @ParamDoc(name = "url", text = "A supplementary URL to show with your message.") String url,
+            @ParamDoc(name = "urlTitle", text = "A title for your supplementary URL, otherwise just the URL is shown.") String urlTitle,
+            @ParamDoc(name = "priority", text = "Send as -1 to always send as a quiet notification, 1 to display as high-priority and bypass the user's quiet hours, or 2 to also require confirmation from the user.") int priority,
+            @ParamDoc(name = "sound", text = "The name of one of the sounds supported by device clients to override the user's default sound choice.") String sound) {
+
+        StringBuilder data = new StringBuilder();
+
+        try {
+            if (!StringUtils.isEmpty(apiKey)) {
+                addEncodedParameter(data, MESSAGE_KEY_API_KEY, apiKey);
+            } else if (!StringUtils.isEmpty(defaultApiKey)) {
+                addEncodedParameter(data, MESSAGE_KEY_API_KEY, defaultApiKey);
+            } else {
+                logger.error("Application API token not specified.");
+                return null;
+            }
+
+            if (!StringUtils.isEmpty(user)) {
+                addEncodedParameter(data, MESSAGE_KEY_USER, user);
+            } else if (!StringUtils.isEmpty(defaultUser)) {
+                addEncodedParameter(data, MESSAGE_KEY_USER, defaultUser);
+            } else {
+                logger.error("The user/group key was not specified.");
+                return null;
+            }
+
+            if (!StringUtils.isEmpty(message)) {
+                if ((message.length() + title.length()) <= API_MAX_MESSAGE_LENGTH) {
+                    addEncodedParameter(data, MESSAGE_KEY_MESSAGE, message);
+                } else {
+                    logger.error("Together, the event message and title total more than " + API_MAX_MESSAGE_LENGTH
+                            + " characters.");
+                    return null;
+                }
+            } else {
+                logger.error("The event message is missing.");
+                return null;
+            }
+
+            if (!StringUtils.isEmpty(device)) {
+                addEncodedParameter(data, MESSAGE_KEY_DEVICE, device);
+            } else if (!StringUtils.isEmpty(defaultDevice)) {
+                addEncodedParameter(data, MESSAGE_KEY_DEVICE, defaultDevice);
+            }
+
+            if (!StringUtils.isEmpty(title)) {
+                addEncodedParameter(data, MESSAGE_KEY_TITLE, title);
+            } else if (!StringUtils.isEmpty(defaultTitle)) {
+                addEncodedParameter(data, MESSAGE_KEY_TITLE, defaultTitle);
+            }
+
+            if (!StringUtils.isEmpty(url)) {
+                if (url.length() <= API_MAX_URL_LENGTH) {
+                    addEncodedParameter(data, MESSAGE_KEY_URL, url);
+                } else {
+                    logger.error("The url is greater than {} characters.", API_MAX_URL_LENGTH);
+                    return null;
+                }
+            } else if (!StringUtils.isEmpty(defaultUrl)) {
+                if (defaultUrl.length() <= API_MAX_URL_LENGTH) {
+                    addEncodedParameter(data, MESSAGE_KEY_URL, defaultUrl);
+                } else {
+                    logger.error("The url is greater than {} characters.", API_MAX_URL_LENGTH);
+                    return null;
+                }
+            }
+
+            if (!StringUtils.isEmpty(urlTitle)) {
+                if (urlTitle.length() <= API_MAX_URL_TITLE_LENGTH) {
+                    addEncodedParameter(data, MESSAGE_KEY_URL_TITLE, urlTitle);
+                } else {
+                    logger.error("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
+                    return null;
+                }
+            } else if (!StringUtils.isEmpty(defaultUrlTitle)) {
+                if (defaultUrlTitle.length() <= API_MAX_URL_TITLE_LENGTH) {
+                    addEncodedParameter(data, MESSAGE_KEY_URL_TITLE, defaultUrlTitle);
+                } else {
+                    logger.error("The url title is greater than {} characters.", API_MAX_URL_TITLE_LENGTH);
+                    return null;
+                }
+            }
+
+            try {
+                if (isValueInList(API_VALID_PRIORITY_LIST, priority)) {
+                    addEncodedParameter(data, MESSAGE_KEY_PRIORITY, String.valueOf(priority));
+
+                    if (isValueInList(API_HIGH_PRIORITY_LIST, priority)) {
+                        if (retry >= API_MIN_RETRY_SECONDS) {
+                            addEncodedParameter(data, MESSAGE_KEY_RETRY, String.valueOf(retry));
+                        } else {
+                            logger.warn("Retry value of {} is too small. Using default value of {}.", retry,
+                                    API_MIN_RETRY_SECONDS);
+                            addEncodedParameter(data, MESSAGE_KEY_RETRY, String.valueOf(API_MIN_RETRY_SECONDS));
+                        }
+
+                        if (expire <= API_MAX_EXPIRE_SECONDS) {
+                            addEncodedParameter(data, MESSAGE_KEY_EXPIRE, String.valueOf(expire));
+                        } else {
+                            logger.warn("Expire value of {} is too large. Using default value of {}.", expire,
+                                    API_MAX_EXPIRE_SECONDS);
+                            addEncodedParameter(data, MESSAGE_KEY_EXPIRE, String.valueOf(API_MAX_EXPIRE_SECONDS));
+                        }
+                    }
+                } else {
+                    logger.warn("Invalid priority, skipping. Expected: {}. Got: {}.",
+                            Arrays.toString(API_VALID_PRIORITY_LIST), priority);
+                }
+            } catch (Exception exp) {
+                logger.warn("Can't parse the priority value, skipping.");
+            }
+
+            if (!StringUtils.isEmpty(sound)) {
+                addEncodedParameter(data, MESSAGE_KEY_SOUND, sound);
+            } else if (!StringUtils.isEmpty(defaultSound)) {
+                addEncodedParameter(data, MESSAGE_KEY_SOUND, defaultSound);
+            }
+
+            String content = data.toString();
+            logger.debug("Executing post to " + JSON_API_URL + " with the following content: " + content);
+            String response = HttpUtil.executeUrl("POST", JSON_API_URL, IOUtils.toInputStream(content), CONTENT_TYPE,
+                    timeout);
+            logger.debug("Raw response: {}", response);
+
+            if (StringUtils.isEmpty(response)) {
+                logger.error(
+                        "Received an empty response from our Pushover API call. This can mean either we are having trouble connecting to the Pushover API or the Pushover API is actively enforcing rate limits with a connection time-out.");
+                return null;
+            }
+            JsonObject json = parser.parse(response).getAsJsonObject();
+            if (json.has(API_RETURN_INFO_TAG)) {
+                logger.warn("Received info message from Pushover: {}",
+                        json.get(API_RETURN_INFO_TAG).getAsJsonArray().getAsString());
+            }
+            if (json.has(API_RETURN_STATUS_TAG) && json.get(API_RETURN_STATUS_TAG).getAsInt() == 1) {
+                return json.has(API_RETURN_RECEIPT_TAG) ? json.get(API_RETURN_RECEIPT_TAG).getAsString() : null;
+            } else {
+                logger.error("Received error message from Pushover: {}",
+                        json.get(API_RETURN_ERRORS_TAG).getAsJsonArray().getAsString());
+                return null;
+            }
+        } catch (Exception e) {
+            logger.error("An error occurred while notifying your mobile device.", e);
+            return null;
+        }
+    }
+
+    @ActionDoc(text = "Cancel an emergency-priority notification using the default api key.", returns = "<code>true</code>, if successful and <code>false</code> otherwise.")
+    public static boolean cancelPushoverEmergency(
+            @ParamDoc(name = "receipt", text = "Your message's receipt.") String receipt) {
+        return cancelPushoverEmergency(defaultApiKey, defaultUser, receipt);
+    }
+
+    // Primary method for canceling an emergency-priority message
+    @ActionDoc(text = "Cancel an emergency-priority notification. apiKey, user and receipt are required.", returns = "<code>true</code>, if successful and <code>false</code> otherwise.")
+    public static boolean cancelPushoverEmergency(
+            @ParamDoc(name = "apiKey", text = "Your application's API token.") String apiKey,
+            @ParamDoc(name = "user", text = "The user/group key (not e-mail address) of your user (or you), viewable when logged into Pushover dashboard.") String user,
+            @ParamDoc(name = "receipt", text = "Your message's receipt.") String receipt) {
+
+        StringBuilder data = new StringBuilder();
+
+        try {
+            if (!StringUtils.isEmpty(apiKey)) {
+                addEncodedParameter(data, MESSAGE_KEY_API_KEY, apiKey);
+            } else if (!StringUtils.isEmpty(defaultApiKey)) {
+                addEncodedParameter(data, MESSAGE_KEY_API_KEY, defaultApiKey);
+            } else {
+                logger.error("Application API token not specified.");
+                return false;
+            }
+
+            if (!StringUtils.isEmpty(user)) {
+                addEncodedParameter(data, MESSAGE_KEY_USER, user);
+            } else if (!StringUtils.isEmpty(defaultUser)) {
+                addEncodedParameter(data, MESSAGE_KEY_USER, defaultUser);
+            } else {
+                logger.error("The user/group key was not specified.");
+                return false;
+            }
+
+            if (StringUtils.isEmpty(receipt)) {
+                logger.error("The message's receipt is missing.");
+                return false;
+            }
+
+            String url = JSON_CANCEL_API_URL.replace("{receipt}", receipt);
+            String content = data.toString();
+            logger.debug("Executing post to " + url + " with the following content: " + content);
+            String response = HttpUtil.executeUrl("POST", url, IOUtils.toInputStream(content), CONTENT_TYPE, timeout);
+            logger.debug("Raw response: {}", response);
+
+            if (StringUtils.isEmpty(response)) {
+                logger.error(
+                        "Received an empty response from our Pushover API call. This can mean either we are having trouble connecting to the Pushover API or the Pushover API is actively enforcing rate limits with a connection time-out.");
+                return false;
+            }
+            JsonObject json = parser.parse(response).getAsJsonObject();
+            if (json.has(API_RETURN_STATUS_TAG) && json.get(API_RETURN_STATUS_TAG).getAsInt() == 1) {
+                return true;
+            } else {
+                logger.error("Received error message from Pushover: {}",
+                        json.get(API_RETURN_ERRORS_TAG).getAsJsonArray().getAsString());
+                return false;
+            }
+        } catch (Exception e) {
+            logger.error("An error occurred while canceling your notification.", e);
+            return false;
+        }
     }
 
     private static void addEncodedParameter(StringBuilder sb, String name, String value)


### PR DESCRIPTION
- Added new actions `sendPushoverEmergency` for sending emergency-priority notifications
- Added new actions `cancelPushoverEmergency` to cancel emergency-priority notifications
- Switched API partially to JSON
- Code cleanup

Closes #5458 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>