### PR TITLE
[Telegram Action] Add option for Markdown or HTML formatting

### DIFF
--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -66,8 +66,8 @@ public class Telegram {
 
     private static Map<String, TelegramBot> groupTokens = new HashMap<String, TelegramBot>();
 
-    public static void addToken(String group, String chatId, String token) {
-        groupTokens.put(group, new TelegramBot(chatId, token));
+    public static void addToken(String group, String chatId, String token, String parse) {
+        groupTokens.put(group, new TelegramBot(chatId, token, parse));
     }
 
     @ActionDoc(text = "Sends a Telegram via Telegram REST API - direct message")
@@ -89,7 +89,7 @@ public class Telegram {
         postMethod.getParams().setParameter(HttpMethodParams.RETRY_HANDLER,
                 new DefaultHttpMethodRetryHandler(HTTP_RETRIES, false));
         NameValuePair[] data = { new NameValuePair("chat_id", groupTokens.get(group).getChatId()),
-                new NameValuePair("text", message), new NameValuePair("parse_mode", "Markdown") };
+                new NameValuePair("text", message), new NameValuePair("parse_mode", groupTokens.get(group).getParse()) };
         postMethod.setRequestBody(data);
 
         try {

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -89,7 +89,7 @@ public class Telegram {
         postMethod.getParams().setParameter(HttpMethodParams.RETRY_HANDLER,
                 new DefaultHttpMethodRetryHandler(HTTP_RETRIES, false));
         NameValuePair[] data = { new NameValuePair("chat_id", groupTokens.get(group).getChatId()),
-                new NameValuePair("text", message) };
+                new NameValuePair("text", message), new NameValuePair("parse_mode", "Markdown") };
         postMethod.setRequestBody(data);
 
         try {

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -66,10 +66,14 @@ public class Telegram {
 
     private static Map<String, TelegramBot> groupTokens = new HashMap<String, TelegramBot>();
 
-    public static void addToken(String group, String chatId, String token, String parse) {
-        groupTokens.put(group, new TelegramBot(chatId, token, parse));
+    public static void addToken(String group, String chatId, String token) {
+        groupTokens.put(group, new TelegramBot(chatId, token));
     }
 
+    public static void addToken(String group, String parse) {
+        groupTokens.put(group, new TelegramBot(parse));
+    }
+    
     @ActionDoc(text = "Sends a Telegram via Telegram REST API - direct message")
     static public boolean sendTelegram(@ParamDoc(name = "group") String group,
             @ParamDoc(name = "message") String message) {

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
@@ -64,7 +64,8 @@ public class TelegramActionService implements ActionService, ManagedService {
                 String tokenKey = String.format("%s.token", bot);
                 String parseKey = String.format("%s.parseMode", bot);
                 if (config.get(chatIdKey) != null && config.get(tokenKey) != null) {
-                    Telegram.addToken(bot, (String) config.get(chatIdKey), (String) config.get(tokenKey), (String) config.get(parseKey));
+                    Telegram.addToken(bot, (String) config.get(chatIdKey), (String) config.get(tokenKey));
+                    Telegram.addToken(bot, (String) config.get(parseKey));
                     logger.info("Bot {} loaded from config file", bot);
                 } else {
                     logger.warn("Bot {} is misconfigured. Please check the configuration", bot);

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
@@ -62,8 +62,9 @@ public class TelegramActionService implements ActionService, ManagedService {
             for (String bot : bots) {
                 String chatIdKey = String.format("%s.chatId", bot);
                 String tokenKey = String.format("%s.token", bot);
-                if (config.get(chatIdKey) != null && config.get(tokenKey) != null) {
-                    Telegram.addToken(bot, (String) config.get(chatIdKey), (String) config.get(tokenKey));
+                String parseKey = String.format("%s.parseMode", bot);
+                if (config.get(chatIdKey) != null && config.get(tokenKey) != null && config.get(parseKey) != null) {
+                    Telegram.addToken(bot, (String) config.get(chatIdKey), (String) config.get(tokenKey), (String) config.get(parseKey));
                     logger.info("Bot {} loaded from config file", bot);
                 } else {
                     logger.warn("Bot {} is misconfigured. Please check the configuration", bot);

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
@@ -63,7 +63,7 @@ public class TelegramActionService implements ActionService, ManagedService {
                 String chatIdKey = String.format("%s.chatId", bot);
                 String tokenKey = String.format("%s.token", bot);
                 String parseKey = String.format("%s.parseMode", bot);
-                if (config.get(chatIdKey) != null && config.get(tokenKey) != null && config.get(parseKey) != null) {
+                if (config.get(chatIdKey) != null && config.get(tokenKey) != null) {
                     Telegram.addToken(bot, (String) config.get(chatIdKey), (String) config.get(tokenKey), (String) config.get(parseKey));
                     logger.info("Bot {} loaded from config file", bot);
                 } else {

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramBot.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramBot.java
@@ -22,12 +22,15 @@ public class TelegramBot {
     private String token;
     private String parse;
 
-    public TelegramBot(String chatId, String token, String parse) {
+    public TelegramBot(String chatId, String token) {
         this.chatId = chatId;
         this.token = token;
-        this.parse = parse;
     }
 
+    public TelegramBot(String parse) {
+        this.parse = parse;
+    }
+    
     public String getChatId() {
         return chatId;
     }

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramBot.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramBot.java
@@ -20,10 +20,12 @@ public class TelegramBot {
 
     private String chatId;
     private String token;
+    private String parse;
 
-    public TelegramBot(String chatId, String token) {
+    public TelegramBot(String chatId, String token, String parse) {
         this.chatId = chatId;
         this.token = token;
+        this.parse = parse;
     }
 
     public String getChatId() {
@@ -32,5 +34,9 @@ public class TelegramBot {
 
     public String getToken() {
         return token;
+    }
+    
+    public String getParse() {
+        return parse;
     }
 }

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -2509,8 +2509,10 @@ tcp:refreshinterval=250
 # telegram:bots=bot1,bot2
 # telegram:bot1.chatId=22334455
 # telegram:bot1.token=xxxxxx
+# telegram:bot1.parseMode=Markdown
 # telegram:bot2.chatId=654321
 # telegram:bot2.token=yyyyyyyyyyy
+# telegram:bot2.parseMode=HTML
 
 ############################### Pebble Action configuration ###############################
 #


### PR DESCRIPTION
The Telegram Bot API supports basic formatting for messages. My commit add Markdown formatting mode by default to Telegram action.