### PR TITLE
Added information about group chats chatId

### DIFF
--- a/bundles/action/org.openhab.action.telegram/README.md
+++ b/bundles/action/org.openhab.action.telegram/README.md
@@ -15,7 +15,7 @@ As described in the Telegram Bot API, this is the manual procedure needed in ord
 
 - Open a new chat with your new Bot and post a message on the chat
 - Open a browser and invoke `https://api.telegram.org/bot<token>/getUpdates` (where `<token>` is the authentication token previously obtained)
-- Look at the JSON result and write down the value of `result[0].message.chat.id`. That is the chatId.
+- Look at the JSON result and write down the value of `result[0].message.chat.id`. That is the chatId. (Note that Telegram group chats chatIds are prefixed with a "-". Include the "-" in the chatId in the config file eg: bot1.chatId: -22334455)
 
 ## Configuration
 


### PR DESCRIPTION
Group chat chatId are prefixed with a "-" that must be included in the config file