### PR TITLE
Rename Eclipse projects for bindings that also exist in OH2

### DIFF
--- a/bundles/binding/org.openhab.binding.exec/.project
+++ b/bundles/binding/org.openhab.binding.exec/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.exec</name>
+	<name>org.openhab.binding.exec1</name>
 	<comment>This is the Exec binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.freebox/.project
+++ b/bundles/binding/org.openhab.binding.freebox/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.freebox</name>
+	<name>org.openhab.binding.freebox1</name>
 	<comment>This is the Freebox binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.hdanywhere/.project
+++ b/bundles/binding/org.openhab.binding.hdanywhere/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.hdanywhere</name>
+	<name>org.openhab.binding.hdanywhere1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.mcp23017/.project
+++ b/bundles/binding/org.openhab.binding.mcp23017/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mcp23017</name>
+	<name>org.openhab.binding.mcp23017_1</name>
 	<comment>This is the mcp23017 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.milight/.project
+++ b/bundles/binding/org.openhab.binding.milight/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.milight</name>
+	<name>org.openhab.binding.milight1</name>
 	<comment>This is the Milight binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.netatmo.test/.project
+++ b/bundles/binding/org.openhab.binding.netatmo.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.netatmo.test</name>
+	<name>org.openhab.binding.netatmo.test1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.netatmo.test/.project
+++ b/bundles/binding/org.openhab.binding.netatmo.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.netatmo.test1</name>
+	<name>org.openhab.binding.netatmo1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.oceanic/.project
+++ b/bundles/binding/org.openhab.binding.oceanic/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.oceanic</name>
+	<name>org.openhab.binding.oceanic1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.opensprinkler/.project
+++ b/bundles/binding/org.openhab.binding.opensprinkler/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.opensprinkler</name>
+	<name>org.openhab.binding.opensprinkler1</name>
 	<comment>This is the openpsrinklerpi binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.pioneeravr/.project
+++ b/bundles/binding/org.openhab.binding.pioneeravr/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.pioneeravr</name>
+	<name>org.openhab.binding.pioneeravr1</name>
 	<comment>This is the Pioneer AVR Binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.pulseaudio/.project
+++ b/bundles/binding/org.openhab.binding.pulseaudio/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.pulseaudio</name>
+	<name>org.openhab.binding.pulseaudio1</name>
 	<comment>This is the Pulseaudio binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.rfxcom.test/.project
+++ b/bundles/binding/org.openhab.binding.rfxcom.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.rfxcom.test</name>
+	<name>org.openhab.binding.rfxcom.test1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.rfxcom.test/.project
+++ b/bundles/binding/org.openhab.binding.rfxcom.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.rfxcom.test1</name>
+	<name>org.openhab.binding.rfxcom1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.rfxcom/.project
+++ b/bundles/binding/org.openhab.binding.rfxcom/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.rfxcom</name>
+	<name>org.openhab.binding.rfxcom1</name>
 	<comment>This is the rfxcom binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.rme/.project
+++ b/bundles/binding/org.openhab.binding.rme/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.rme</name>
+	<name>org.openhab.binding.rme1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.samsungtv/.project
+++ b/bundles/binding/org.openhab.binding.samsungtv/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.samsungtv</name>
+	<name>org.openhab.binding.samsungtv1</name>
 	<comment>This is the samsungtv binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.squeezebox/.project
+++ b/bundles/binding/org.openhab.binding.squeezebox/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.squeezebox</name>
+	<name>org.openhab.binding.squeezebox1</name>
 	<comment>This is the squeezebox binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.systeminfo.test/.project
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.systeminfo.test1</name>
+	<name>org.openhab.binding.systeminfo1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.systeminfo.test/.project
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.systeminfo.test</name>
+	<name>org.openhab.binding.systeminfo.test1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.systeminfo/.project
+++ b/bundles/binding/org.openhab.binding.systeminfo/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.systeminfo</name>
+	<name>org.openhab.binding.systeminfo1</name>
 	<comment>This is the Systeminfo Binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.tellstick/.project
+++ b/bundles/binding/org.openhab.binding.tellstick/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.tellstick</name>
+	<name>org.openhab.binding.tellstick1</name>
 	<comment>This is the Tellstick binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.yamahareceiver/.project
+++ b/bundles/binding/org.openhab.binding.yamahareceiver/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.yamahareceiver</name>
+	<name>org.openhab.binding.yamahareceiver1</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
This should fix the issue that only the OH1 or the OH2 version of these projects can be automatically imported in Eclipse.

Maybe we should add the 1 suffix to all binding projects to prevent future issues? The same has been done with the feature names.