### PR TITLE
[Pushbullet] Added ability to push notes to a channel

### DIFF
--- a/bundles/action/org.openhab.action.pushbullet/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.pushbullet/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Bundle-ManifestVersion: 2
 Bundle-Description: This is the Pushbullet action of the open Home Automation Bus (openHAB)
 Import-Package: com.google.gson,
  com.google.gson.annotations,
+ javax.mail.internet,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.openhab.core.items,

--- a/bundles/action/org.openhab.action.pushbullet/README.md
+++ b/bundles/action/org.openhab.action.pushbullet/README.md
@@ -6,7 +6,10 @@ The Pushbullet action allows you to notify iOS, Android & Windows 10 Phone & Des
 
 The following is a valid action call that can be made when the plugin is loaded.
 For specific information on each item, see the [Pushbullet API](https://docs.pushbullet.com/).
+The recipient can either be an email address or a channel tag.
+If it is not specified or invalid, the note will be broadcast to all of the user account's devices.
 
+- `sendPushbulletNote(String title, String message)`
 - `sendPushbulletNote(String receiver, String title, String message)`
 - `sendPushbulletNote(String botname, String receiver, String title, String message)`
 

--- a/bundles/action/org.openhab.action.pushbullet/src/main/java/org/openhab/action/pushbullet/internal/PushbulletAPIConnector.java
+++ b/bundles/action/org.openhab.action.pushbullet/src/main/java/org/openhab/action/pushbullet/internal/PushbulletAPIConnector.java
@@ -18,6 +18,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
 import org.openhab.action.pushbullet.internal.model.Push;
 import org.openhab.action.pushbullet.internal.model.PushResponse;
 import org.openhab.core.scriptengine.action.ActionDoc;
@@ -95,6 +98,14 @@ public class PushbulletAPIConnector {
         return sendPush(DEFAULT_BOTNAME, recipient, title, message, "note");
     }
 
+    @ActionDoc(text = "Sends a message to PushbulletAPIConnector to all user's devices from default bot")
+    public static boolean sendPushbulletNote(
+            @ParamDoc(name = "title", text = "title of the message") String title,
+            @ParamDoc(name = "message", text = "the message to be sent") String message) {
+        logger.debug("Trying to send a note to all user's devices from the default bot");
+        return sendPush(DEFAULT_BOTNAME, null, title, message, "note");
+    }
+
     /**
      * Inner method handling all the pushes.
      *
@@ -107,7 +118,6 @@ public class PushbulletAPIConnector {
      */
     private static boolean sendPush(String botName, String recipient, String title, String body, String type) {
         boolean result = false;
-
         logger.trace("    Botname is   '{}'", botName);
 
         PushbulletBot bot = bots.get(botName);
@@ -126,7 +136,19 @@ public class PushbulletAPIConnector {
         push.setTitle(title);
         push.setBody(body);
         push.setType(type);
-        push.setEmail(recipient);
+
+        if (recipient != null) {
+            if (isValidEmail(recipient)) {
+                logger.trace("    Recipient is an email address");
+                push.setEmail(recipient);
+            } else if (isValidChannel(recipient)) {
+                logger.trace("    Recipient is a channel tag");
+                push.setChannel(recipient);
+            } else {
+                logger.warn("Invalid recipient: {}", recipient);
+                logger.warn("Message will be broadcast to all user's devices.");
+            }
+        }
 
         logger.trace("     Push: {}", push);
 
@@ -157,5 +179,32 @@ public class PushbulletAPIConnector {
 
         return result;
 
+    }
+
+    /**
+     * Inner method checking if channel tag is valid.
+     *
+     * @param channel
+     * @return
+     */
+    private static boolean isValidChannel(String channel) {
+        String pattern = "^[a-zA-Z0-9_-]+$";
+        return channel.matches(pattern);
+    }
+
+    /**
+     * Inner method checking if email address is valid.
+     *
+     * @param email
+     * @return
+     */
+    private static boolean isValidEmail(String email) {
+        try {
+            InternetAddress emailAddr = new InternetAddress(email);
+            emailAddr.validate();
+            return true;
+        } catch (AddressException e) {
+            return false;
+        }
     }
 }

--- a/bundles/action/org.openhab.action.pushbullet/src/main/java/org/openhab/action/pushbullet/internal/model/Push.java
+++ b/bundles/action/org.openhab.action.pushbullet/src/main/java/org/openhab/action/pushbullet/internal/model/Push.java
@@ -30,6 +30,9 @@ public class Push {
     @SerializedName("email")
     private String email;
 
+    @SerializedName("channel_tag")
+    private String channel_tag;
+
     public String getTitle() {
         return title;
     }
@@ -62,9 +65,17 @@ public class Push {
         this.email = email;
     }
 
+    public String getChannel() {
+        return channel_tag;
+    }
+
+    public void setChannel(String channel_tag) {
+        this.channel_tag = channel_tag;
+    }
+
     @Override
     public String toString() {
         return "Push {" + "title='" + title + '\'' + ", body='" + body + '\'' + ", type='" + type + '\'' + ", email='"
-                + email + '\'' + '}';
+                + email + '\'' + ", channel_tag='" + channel_tag + '\'' + '}';
     }
 }


### PR DESCRIPTION
Added the ability to push notes to all subscribers of a channel based on the recipient format. Also, added the ability to push notes without specifying a recipient as the Pushbullet API will default to broadcast them to all the user account's devices.