### PR TITLE
Add '1' suffix to Eclipse project names of bindings

### DIFF
--- a/bundles/binding/org.openhab.binding.akm868/.project
+++ b/bundles/binding/org.openhab.binding.akm868/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.akm868</name>
+	<name>org.openhab.binding.akm868_1</name>
 	<comment>This is the AKM868 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.alarmdecoder/.project
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.alarmdecoder</name>
+	<name>org.openhab.binding.alarmdecoder1</name>
 	<comment>This is the AlarmDecoder binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.anel/.project
+++ b/bundles/binding/org.openhab.binding.anel/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.anel</name>
+	<name>org.openhab.binding.anel1</name>
 	<comment>This is the Anel binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.asterisk/.project
+++ b/bundles/binding/org.openhab.binding.asterisk/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.asterisk</name>
+	<name>org.openhab.binding.asterisk1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.benqprojector/.project
+++ b/bundles/binding/org.openhab.binding.benqprojector/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.benqprojector</name>
+	<name>org.openhab.binding.benqprojector1</name>
 	<comment>This is the BenqProjector binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.bluetooth/.project
+++ b/bundles/binding/org.openhab.binding.bluetooth/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.bluetooth</name>
+	<name>org.openhab.binding.bluetooth1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.bticino/.project
+++ b/bundles/binding/org.openhab.binding.bticino/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.bticino</name>
+	<name>org.openhab.binding.bticino1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.caldav-command/.project
+++ b/bundles/binding/org.openhab.binding.caldav-command/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.caldav-command</name>
+	<name>org.openhab.binding.caldav-command1</name>
 	<comment>This is the CalDav Command binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.caldav-personal/.project
+++ b/bundles/binding/org.openhab.binding.caldav-personal/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.caldav-personal</name>
+	<name>org.openhab.binding.caldav-personal1</name>
 	<comment>This is the CalDav Personal binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.comfoair/.project
+++ b/bundles/binding/org.openhab.binding.comfoair/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.comfoair</name>
+	<name>org.openhab.binding.comfoair1</name>
 	<comment>This is the HTTP binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.configadmin/.project
+++ b/bundles/binding/org.openhab.binding.configadmin/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.configadmin</name>
+	<name>org.openhab.binding.configadmin1</name>
 	<comment>This is the ConfigAdmin binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.cups/.project
+++ b/bundles/binding/org.openhab.binding.cups/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.cups</name>
+	<name>org.openhab.binding.cups1</name>
 	<comment>This is the CUPS binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.daikin/.project
+++ b/bundles/binding/org.openhab.binding.daikin/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.daikin</name>
+	<name>org.openhab.binding.daikin1</name>
 	<comment>This is the Daikin binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.davis/.project
+++ b/bundles/binding/org.openhab.binding.davis/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.davis</name>
+	<name>org.openhab.binding.davis1</name>
 	<comment>This is the Davis binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ddwrt/.project
+++ b/bundles/binding/org.openhab.binding.ddwrt/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ddwrt</name>
+	<name>org.openhab.binding.ddwrt1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.denon/.project
+++ b/bundles/binding/org.openhab.binding.denon/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.denon</name>
+	<name>org.openhab.binding.denon1</name>
 	<comment>This is the Denon binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.digitalstrom/.project
+++ b/bundles/binding/org.openhab.binding.digitalstrom/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.digitalstrom</name>
+	<name>org.openhab.binding.digitalstrom1</name>
 	<comment>This is the DigitalSTROM binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.diyonxbee/.project
+++ b/bundles/binding/org.openhab.binding.diyonxbee/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.diyonxbee</name>
+	<name>org.openhab.binding.diyonxbee1</name>
 	<comment>This is the DiyOnXBee binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.dmx.artnet/.project
+++ b/bundles/binding/org.openhab.binding.dmx.artnet/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.dmx.artnet</name>
+	<name>org.openhab.binding.dmx1.artnet</name>
 	<comment>This is the dmx binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.dmx.lib485/.project
+++ b/bundles/binding/org.openhab.binding.dmx.lib485/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.dmx.lib485</name>
+	<name>org.openhab.binding.dmx1.lib485</name>
 	<comment>This is the dmx binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.dmx.ola/.project
+++ b/bundles/binding/org.openhab.binding.dmx.ola/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.dmx.ola</name>
+	<name>org.openhab.binding.dmx1.ola</name>
 	<comment>This is the dmx binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.dmx.test/.project
+++ b/bundles/binding/org.openhab.binding.dmx.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.dmx.test</name>
+	<name>org.openhab.binding.dmx1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.dmx/.project
+++ b/bundles/binding/org.openhab.binding.dmx/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.dmx</name>
+	<name>org.openhab.binding.dmx1</name>
 	<comment>This is the dmx binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.dsmr/.project
+++ b/bundles/binding/org.openhab.binding.dsmr/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.dsmr</name>
+	<name>org.openhab.binding.dsmr1</name>
 	<comment>This is the DSMR binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ebus/.project
+++ b/bundles/binding/org.openhab.binding.ebus/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ebus</name>
+	<name>org.openhab.binding.ebus1</name>
 	<comment>This is the eBus binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ecobee/.project
+++ b/bundles/binding/org.openhab.binding.ecobee/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ecobee</name>
+	<name>org.openhab.binding.ecobee1</name>
 	<comment>This is the Ecobee binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ecotouch/.project
+++ b/bundles/binding/org.openhab.binding.ecotouch/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ecotouch</name>
+	<name>org.openhab.binding.ecotouch1</name>
 	<comment>This is the EcoTouch binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ehealth/.project
+++ b/bundles/binding/org.openhab.binding.ehealth/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ehealth</name>
+	<name>org.openhab.binding.ehealth1</name>
 	<comment>This is the Libelium eHealth binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ekey/.project
+++ b/bundles/binding/org.openhab.binding.ekey/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ekey</name>
+	<name>org.openhab.binding.ekey1</name>
 	<comment>This is the eKey binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.em.test/.project
+++ b/bundles/binding/org.openhab.binding.em.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.em.test</name>
+	<name>org.openhab.binding.em1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.em/.project
+++ b/bundles/binding/org.openhab.binding.em/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.em</name>
+	<name>org.openhab.binding.em1</name>
 	<comment>This is the EM binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.energenie/.project
+++ b/bundles/binding/org.openhab.binding.energenie/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.energenie</name>
+	<name>org.openhab.binding.energenie1</name>
 	<comment>This is the Energenie binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.enigma2.test/.project
+++ b/bundles/binding/org.openhab.binding.enigma2.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.enigma2.test</name>
+	<name>org.openhab.binding.enigma2_1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.enigma2/.project
+++ b/bundles/binding/org.openhab.binding.enigma2/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.enigma2</name>
+	<name>org.openhab.binding.enigma2_1</name>
 	<comment>This is the Enigma2 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.enocean.test/.project
+++ b/bundles/binding/org.openhab.binding.enocean.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.enocean.test</name>
+	<name>org.openhab.binding.enocean1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.enocean/.project
+++ b/bundles/binding/org.openhab.binding.enocean/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.enocean</name>
+	<name>org.openhab.binding.enocean1</name>
 	<comment>This is the open Home Automation Bus (openHAB). NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.enphaseenergy/.project
+++ b/bundles/binding/org.openhab.binding.enphaseenergy/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.enphaseenergy</name>
+	<name>org.openhab.binding.enphaseenergy1</name>
 	<comment>This is the Enphase Energy binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.epsonprojector/.project
+++ b/bundles/binding/org.openhab.binding.epsonprojector/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.epsonprojector</name>
+	<name>org.openhab.binding.epsonprojector1</name>
 	<comment>This is the Epson projector binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.exec.test/.project
+++ b/bundles/binding/org.openhab.binding.exec.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.exec.test</name>
+	<name>org.openhab.binding.exec1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.expire/.project
+++ b/bundles/binding/org.openhab.binding.expire/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.expire</name>
+	<name>org.openhab.binding.expire1</name>
 	<comment>This is the Expire binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.fatekplc/.project
+++ b/bundles/binding/org.openhab.binding.fatekplc/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.fatekplc</name>
+	<name>org.openhab.binding.fatekplc1</name>
 	<comment>This is the fatekplc binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.fht/.project
+++ b/bundles/binding/org.openhab.binding.fht/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.fht</name>
+	<name>org.openhab.binding.fht1</name>
 	<comment>This is the FHT binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.freeswitch/.project
+++ b/bundles/binding/org.openhab.binding.freeswitch/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.freeswitch</name>
+	<name>org.openhab.binding.freeswitch1</name>
 	<comment>This is the Freeswitch binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.fritzaha/.project
+++ b/bundles/binding/org.openhab.binding.fritzaha/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.fritzaha</name>
+	<name>org.openhab.binding.fritzaha1</name>
 	<comment>This is the fritzaha binding of the open Home Automation Bus
 		(openHAB)</comment>
 	<projects>

--- a/bundles/binding/org.openhab.binding.fritzbox/.project
+++ b/bundles/binding/org.openhab.binding.fritzbox/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.fritzbox</name>
+	<name>org.openhab.binding.fritzbox1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/.project
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.fritzboxtr064</name>
+	<name>org.openhab.binding.fritzboxtr064_1</name>
 	<comment>This is the FritzboxTr064 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/.project
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.frontiersiliconradio</name>
+	<name>org.openhab.binding.frontiersiliconradio1</name>
 	<comment>This is the FrontierSiliconRadio binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.fs20/.project
+++ b/bundles/binding/org.openhab.binding.fs20/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.fs20</name>
+	<name>org.openhab.binding.fs20_1</name>
 	<comment>This is the FS20 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.garadget/.project
+++ b/bundles/binding/org.openhab.binding.garadget/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.garadget</name>
+	<name>org.openhab.binding.garadget1</name>
 	<comment>This is the Garadget binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.gc100ir/.project
+++ b/bundles/binding/org.openhab.binding.gc100ir/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.gc100ir</name>
+	<name>org.openhab.binding.gc100ir1</name>
 	<comment>This is the GC100 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.gpio/.project
+++ b/bundles/binding/org.openhab.binding.gpio/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.gpio</name>
+	<name>org.openhab.binding.gpio1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.heatmiser/.project
+++ b/bundles/binding/org.openhab.binding.heatmiser/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.heatmiser</name>
+	<name>org.openhab.binding.heatmiser1</name>
 	<comment>This is the Heatmiser binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.hms/.project
+++ b/bundles/binding/org.openhab.binding.hms/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.hms</name>
+	<name>org.openhab.binding.hms1</name>
 	<comment>This is the HMS binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.homematic.test/.project
+++ b/bundles/binding/org.openhab.binding.homematic.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.homematic.test</name>
+	<name>org.openhab.binding.homematic1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.horizon/.project
+++ b/bundles/binding/org.openhab.binding.horizon/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.horizon</name>
+	<name>org.openhab.binding.horizon1</name>
 	<comment>This is the horizon binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.http.test/.project
+++ b/bundles/binding/org.openhab.binding.http.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.http.test</name>
+	<name>org.openhab.binding.http1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.http/.project
+++ b/bundles/binding/org.openhab.binding.http/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.http</name>
+	<name>org.openhab.binding.http1</name>
 	<comment>This is the HTTP binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.hue/.project
+++ b/bundles/binding/org.openhab.binding.hue/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.hue</name>
+	<name>org.openhab.binding.hue1</name>
 	<comment>This is the HTTP binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.iec6205621meter/.project
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.iec6205621meter</name>
+	<name>org.openhab.binding.iec6205621meter1</name>
 	<comment>This is the dmlsMeter binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ihc/.project
+++ b/bundles/binding/org.openhab.binding.ihc/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ihc</name>
+	<name>org.openhab.binding.ihc1</name>
 	<comment>This is the IHC / ELKO LS binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.insteonhub/.project
+++ b/bundles/binding/org.openhab.binding.insteonhub/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.insteonhub</name>
+	<name>org.openhab.binding.insteonhub1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.insteonplm/.project
+++ b/bundles/binding/org.openhab.binding.insteonplm/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.insteonplm</name>
+	<name>org.openhab.binding.insteonplm1</name>
 	<comment>This is the Insteon PLM binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.intertechno/.project
+++ b/bundles/binding/org.openhab.binding.intertechno/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.intertechno</name>
+	<name>org.openhab.binding.intertechno1</name>
 	<comment>This is the CULIntertechno binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ipx800/.project
+++ b/bundles/binding/org.openhab.binding.ipx800/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ipx800</name>
+	<name>org.openhab.binding.ipx800_1</name>
 	<comment>This is the Ipx800 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.irtrans/.project
+++ b/bundles/binding/org.openhab.binding.irtrans/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.irtrans</name>
+	<name>org.openhab.binding.irtrans1</name>
 	<comment>This is the IRTrans binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.isy/.project
+++ b/bundles/binding/org.openhab.binding.isy/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.isy</name>
+	<name>org.openhab.binding.isy1</name>
 	<comment>This is the isy binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.jointspace/.project
+++ b/bundles/binding/org.openhab.binding.jointspace/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.jointspace</name>
+	<name>org.openhab.binding.jointspace1</name>
 	<comment>This is the JointSpace binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.k8055/.project
+++ b/bundles/binding/org.openhab.binding.k8055/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.k8055</name>
+	<name>org.openhab.binding.k8055_1</name>
 	<comment>This is the k8055 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.koubachi/.project
+++ b/bundles/binding/org.openhab.binding.koubachi/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.koubachi</name>
+	<name>org.openhab.binding.koubachi_1</name>
 	<comment>This is the Koubachi binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.lcn/.project
+++ b/bundles/binding/org.openhab.binding.lcn/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.lcn</name>
+	<name>org.openhab.binding.lcn1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.lgtv/.project
+++ b/bundles/binding/org.openhab.binding.lgtv/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.lgtv</name>
+	<name>org.openhab.binding.lgtv1</name>
 	<comment>This is the LGTV binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.lightwaverf.test/.project
+++ b/bundles/binding/org.openhab.binding.lightwaverf.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.lightwaverf.test</name>
+	<name>org.openhab.binding.lightwaverf1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.lightwaverf/.project
+++ b/bundles/binding/org.openhab.binding.lightwaverf/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.lightwaverf</name>
+	<name>org.openhab.binding.lightwaverf1</name>
 	<comment>This is the LightwaveRf binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.mailcontrol/.project
+++ b/bundles/binding/org.openhab.binding.mailcontrol/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mailcontrol</name>
+	<name>org.openhab.binding.mailcontrol1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.maxcube.test/.project
+++ b/bundles/binding/org.openhab.binding.maxcube.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.maxcube.test</name>
+	<name>org.openhab.binding.maxcube1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.maxcube/.project
+++ b/bundles/binding/org.openhab.binding.maxcube/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.maxcube</name>
+	<name>org.openhab.binding.maxcube1</name>
 	<comment>This is the NetworkHealth binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.maxcul/.project
+++ b/bundles/binding/org.openhab.binding.maxcul/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.maxcul</name>
+	<name>org.openhab.binding.maxcul1</name>
 	<comment>This is the MaxCul binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 		<project>org.openhab.io.transport.cul</project>

--- a/bundles/binding/org.openhab.binding.mcp3424/.project
+++ b/bundles/binding/org.openhab.binding.mcp3424/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mcp3424</name>
+	<name>org.openhab.binding.mcp3424_1</name>
 	<comment>This is the mcp3424 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.mios/.project
+++ b/bundles/binding/org.openhab.binding.mios/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mios</name>
+	<name>org.openhab.binding.mios1</name>
 	<comment>This is the MiOS binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.mochadx10/.project
+++ b/bundles/binding/org.openhab.binding.mochadx10/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mochadx10</name>
+	<name>org.openhab.binding.mochadx10_1</name>
 	<comment>This is the HTTP binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.modbus.test/.project
+++ b/bundles/binding/org.openhab.binding.modbus.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.modbus.test</name>
+	<name>org.openhab.binding.modbus1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.modbus/.project
+++ b/bundles/binding/org.openhab.binding.modbus/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.modbus</name>
+	<name>org.openhab.binding.modbus1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.mpd/.project
+++ b/bundles/binding/org.openhab.binding.mpd/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mpd</name>
+	<name>org.openhab.binding.mpd1</name>
 	<comment>This is the MPD binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.mqtt.test/.project
+++ b/bundles/binding/org.openhab.binding.mqtt.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mqtt.test</name>
+	<name>org.openhab.binding.mqtt1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.mqtt/.project
+++ b/bundles/binding/org.openhab.binding.mqtt/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mqtt</name>
+	<name>org.openhab.binding.mqtt1</name>
 	<comment>This is the MQTT binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.mqttitude/.project
+++ b/bundles/binding/org.openhab.binding.mqttitude/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mqttitude</name>
+	<name>org.openhab.binding.mqttitude1</name>
 	<comment>This is the Mqttitude binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.myq/.project
+++ b/bundles/binding/org.openhab.binding.myq/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.myq</name>
+	<name>org.openhab.binding.myq1</name>
 	<comment>This is the myq binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.mystromecopower/.project
+++ b/bundles/binding/org.openhab.binding.mystromecopower/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.mystromecopower</name>
+	<name>org.openhab.binding.mystromecopower1</name>
 	<comment>This is the MyStromEcoPower binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.neohub/.project
+++ b/bundles/binding/org.openhab.binding.neohub/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.neohub</name>
+	<name>org.openhab.binding.neohub1</name>
 	<comment>This is the neohub binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.networkhealth/.project
+++ b/bundles/binding/org.openhab.binding.networkhealth/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.networkhealth</name>
+	<name>org.openhab.binding.networkhealth1</name>
 	<comment>This is the NetworkHealth binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.networkupstools/.project
+++ b/bundles/binding/org.openhab.binding.networkupstools/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.networkupstools</name>
+	<name>org.openhab.binding.networkupstools1</name>
 	<comment>This is the NetworkUpsTools binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.nibeheatpump/.project
+++ b/bundles/binding/org.openhab.binding.nibeheatpump/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.nibeheatpump</name>
+	<name>org.openhab.binding.nibeheatpump1</name>
 	<comment>This is the nibeheatpump binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.nikobus.test/.project
+++ b/bundles/binding/org.openhab.binding.nikobus.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.nikobus.test</name>
+	<name>org.openhab.binding.nikobus1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.nikobus/.project
+++ b/bundles/binding/org.openhab.binding.nikobus/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.nikobus</name>
+	<name>org.openhab.binding.nikobus1</name>
 	<comment>This is the nikobus binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.novelanheatpump/.project
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.novelanheatpump</name>
+	<name>org.openhab.binding.novelanheatpump1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ntp/.project
+++ b/bundles/binding/org.openhab.binding.ntp/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ntp</name>
+	<name>org.openhab.binding.ntp1</name>
 	<comment>This is the NTP binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ntp/bin/.project
+++ b/bundles/binding/org.openhab.binding.ntp/bin/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.networkhealth</name>
+	<name>org.openhab.binding.networkhealth1</name>
 	<comment>This is the NetworkHealth binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.octoller/.project
+++ b/bundles/binding/org.openhab.binding.octoller/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.octoller</name>
+	<name>org.openhab.binding.octoller1</name>
 	<comment>This is the octoller binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.omnilink/.project
+++ b/bundles/binding/org.openhab.binding.omnilink/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.omnilink</name>
+	<name>org.openhab.binding.omnilink1</name>
 	<comment>This is the Omnilink binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.onewire/.project
+++ b/bundles/binding/org.openhab.binding.onewire/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.onewire</name>
+	<name>org.openhab.binding.onewire1</name>
 	<comment>This is the OneWire binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.openenergymonitor/.project
+++ b/bundles/binding/org.openhab.binding.openenergymonitor/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.openenergymonitor</name>
+	<name>org.openhab.binding.openenergymonitor1</name>
 	<comment>This is the Open Energy Monitor binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.openpaths/.project
+++ b/bundles/binding/org.openhab.binding.openpaths/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.openpaths</name>
+	<name>org.openhab.binding.openpaths1</name>
 	<comment>This is the OpenPaths binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.owserver/.project
+++ b/bundles/binding/org.openhab.binding.owserver/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.owserver</name>
+	<name>org.openhab.binding.owserver1</name>
 	<comment>This is the OWServer binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.panasonictv/.project
+++ b/bundles/binding/org.openhab.binding.panasonictv/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.panasonictv</name>
+	<name>org.openhab.binding.panasonictv1</name>
 	<comment>This is the PanansonicTV binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.panstamp/.project
+++ b/bundles/binding/org.openhab.binding.panstamp/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.panstamp</name>
+	<name>org.openhab.binding.panstamp1</name>
 	<comment>This is the PanStamp binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.piface/.project
+++ b/bundles/binding/org.openhab.binding.piface/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.piface</name>
+	<name>org.openhab.binding.piface1</name>
 	<comment>This is the PiFace binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.pilight.test/.project
+++ b/bundles/binding/org.openhab.binding.pilight.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.pilight.test</name>
+	<name>org.openhab.binding.pilight1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.pilight/.project
+++ b/bundles/binding/org.openhab.binding.pilight/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.pilight</name>
+	<name>org.openhab.binding.pilight1</name>
 	<comment>This is the pilight binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.plcbus/.project
+++ b/bundles/binding/org.openhab.binding.plcbus/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.plcbus</name>
+	<name>org.openhab.binding.plcbus1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.plclogo/.project
+++ b/bundles/binding/org.openhab.binding.plclogo/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.plclogo</name>
+	<name>org.openhab.binding.plclogo1</name>
 	<comment>This is the PlcLogo binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.plex/.project
+++ b/bundles/binding/org.openhab.binding.plex/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.plex</name>
+	<name>org.openhab.binding.plex1</name>
 	<comment>This is the Plex binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.powerdoglocalapi/.project
+++ b/bundles/binding/org.openhab.binding.powerdoglocalapi/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.powerdoglocalapi</name>
+	<name>org.openhab.binding.powerdoglocalapi1</name>
 	<comment>This is the PowerDogLocalApi binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.powermax/.project
+++ b/bundles/binding/org.openhab.binding.powermax/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.powermax</name>
+	<name>org.openhab.binding.powermax1</name>
 	<comment>This is the PowerMax binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.primare/.project
+++ b/bundles/binding/org.openhab.binding.primare/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.primare</name>
+	<name>org.openhab.binding.primare1</name>
 	<comment>This is the primare binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.rpircswitch/.project
+++ b/bundles/binding/org.openhab.binding.rpircswitch/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.rpircswitch</name>
+	<name>org.openhab.binding.rpircswitch1</name>
 	<comment>This is the rcswitch binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.rwesmarthome/.project
+++ b/bundles/binding/org.openhab.binding.rwesmarthome/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.rwesmarthome</name>
+	<name>org.openhab.binding.rwesmarthome1</name>
 	<comment>This is the RWE Smarthome binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.s300th.test/.project
+++ b/bundles/binding/org.openhab.binding.s300th.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.s300th.test</name>
+	<name>org.openhab.binding.s300th1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.s300th/.project
+++ b/bundles/binding/org.openhab.binding.s300th/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.s300th</name>
+	<name>org.openhab.binding.s300th1</name>
 	<comment>This is the S300TH binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.sagercaster/.project
+++ b/bundles/binding/org.openhab.binding.sagercaster/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.sagercaster</name>
+	<name>org.openhab.binding.sagercaster1</name>
 	<comment>This is the SagerCaster binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.sallegra/.project
+++ b/bundles/binding/org.openhab.binding.sallegra/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.sallegra</name>
+	<name>org.openhab.binding.sallegra1</name>
 	<comment>This is the Sallegra binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.samsungac.test/.project
+++ b/bundles/binding/org.openhab.binding.samsungac.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.samsungac.test</name>
+	<name>org.openhab.binding.samsungac1.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.samsungac/.project
+++ b/bundles/binding/org.openhab.binding.samsungac/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.samsungac</name>
+	<name>org.openhab.binding.samsungac1</name>
 	<comment>This is the Samsung AC Binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.sapp/.project
+++ b/bundles/binding/org.openhab.binding.sapp/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.sapp</name>
+	<name>org.openhab.binding.sapp1</name>
 	<comment>This is the Sapp binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.satel/.project
+++ b/bundles/binding/org.openhab.binding.satel/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.satel</name>
+	<name>org.openhab.binding.satel1</name>
 	<comment>This is the Satel binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.serial/.project
+++ b/bundles/binding/org.openhab.binding.serial/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.serial</name>
+	<name>org.openhab.binding.serial1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.smarthomatic/.project
+++ b/bundles/binding/org.openhab.binding.smarthomatic/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.smarthomatic</name>
+	<name>org.openhab.binding.smarthomatic1</name>
 	<comment>This is the Smarthomatic binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.snmp/.project
+++ b/bundles/binding/org.openhab.binding.snmp/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.snmp</name>
+	<name>org.openhab.binding.snmp1</name>
 	<comment>This is the SNMP binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.sonance/.project
+++ b/bundles/binding/org.openhab.binding.sonance/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.sonance</name>
+	<name>org.openhab.binding.sonance1</name>
 	<comment>This is the Sonance binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.sonos/.project
+++ b/bundles/binding/org.openhab.binding.sonos/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.sonos</name>
+	<name>org.openhab.binding.sonos1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.souliss/.project
+++ b/bundles/binding/org.openhab.binding.souliss/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.souliss</name>
+	<name>org.openhab.binding.souliss1</name>
 	<comment>This is the souliss binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.stiebelheatpump.test/.project
+++ b/bundles/binding/org.openhab.binding.stiebelheatpump.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-  <name>org.openhab.binding.stiebelheatpump.test</name>
+  <name>org.openhab.binding.stiebelheatpump1.test</name>
   <comment>This is the open Home Automation Bus (openHAB). NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
   <projects/>
   <buildSpec>

--- a/bundles/binding/org.openhab.binding.stiebelheatpump/.project
+++ b/bundles/binding/org.openhab.binding.stiebelheatpump/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.stiebelheatpump</name>
+	<name>org.openhab.binding.stiebelheatpump1</name>
 	<comment>This is the dmlsMeter binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.swegonventilation/.project
+++ b/bundles/binding/org.openhab.binding.swegonventilation/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.swegonventilation</name>
+	<name>org.openhab.binding.swegonventilation1</name>
 	<comment>This is the Swegon ventilation binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.tacmi/.project
+++ b/bundles/binding/org.openhab.binding.tacmi/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.tacmi</name>
+	<name>org.openhab.binding.tacmi1</name>
 	<comment>This is the TACmi binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.tcp/.project
+++ b/bundles/binding/org.openhab.binding.tcp/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.tcp</name>
+	<name>org.openhab.binding.tcp1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.tinkerforge/.project
+++ b/bundles/binding/org.openhab.binding.tinkerforge/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.tinkerforge</name>
+	<name>org.openhab.binding.tinkerforge1</name>
 	<comment>This is the Tinkerforge binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.tivo/.project
+++ b/bundles/binding/org.openhab.binding.tivo/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.tivo</name>
+	<name>org.openhab.binding.tivo1</name>
 	<comment>This is the tivo binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.ucprelayboard/.project
+++ b/bundles/binding/org.openhab.binding.ucprelayboard/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.ucprelayboard</name>
+	<name>org.openhab.binding.ucprelayboard1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.upb/.project
+++ b/bundles/binding/org.openhab.binding.upb/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.upb</name>
+	<name>org.openhab.binding.upb1</name>
 	<comment>This is the UPB binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.urtsi/.project
+++ b/bundles/binding/org.openhab.binding.urtsi/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.urtsi</name>
+	<name>org.openhab.binding.urtsi1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.vdr/.project
+++ b/bundles/binding/org.openhab.binding.vdr/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.vdr</name>
+	<name>org.openhab.binding.vdr1</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.wago/.project
+++ b/bundles/binding/org.openhab.binding.wago/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.wago</name>
+	<name>org.openhab.binding.wago1</name>
 	<comment>This is the Wago binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.weather/.project
+++ b/bundles/binding/org.openhab.binding.weather/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.weather</name>
+	<name>org.openhab.binding.weather1</name>
 	<comment>This is the Weather binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.wemo/.project
+++ b/bundles/binding/org.openhab.binding.wemo/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.wemo</name>
+	<name>org.openhab.binding.wemo1</name>
 	<comment>This is the Wemo binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.withings/.project
+++ b/bundles/binding/org.openhab.binding.withings/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.withings</name>
+	<name>org.openhab.binding.withings1</name>
 	<comment>This is the Withings binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.wol/.project
+++ b/bundles/binding/org.openhab.binding.wol/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.wol</name>
+	<name>org.openhab.binding.wol1</name>
 	<comment>This is the Wake-on-LAN binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.wr3223/.project
+++ b/bundles/binding/org.openhab.binding.wr3223/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.wr3223</name>
+	<name>org.openhab.binding.wr3223_1</name>
 	<comment>This is the WR3223 binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.xbmc/.project
+++ b/bundles/binding/org.openhab.binding.xbmc/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.xbmc</name>
+	<name>org.openhab.binding.xbmc1</name>
 	<comment>This is the XBMC binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.xpl/.project
+++ b/bundles/binding/org.openhab.binding.xpl/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.xpl</name>
+	<name>org.openhab.binding.xpl1</name>
 	<comment>This is the xPL Network binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>

--- a/bundles/binding/org.openhab.binding.zibase/.project
+++ b/bundles/binding/org.openhab.binding.zibase/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.zibase</name>
+	<name>org.openhab.binding.zibase1</name>
 	<comment>This is the zibase binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
Adds the '1' suffix to the remaining openhab1-addons Eclipse project names so there will be no future project import issues when new bindings get merged in openhab2-addons.

Follow up to: https://github.com/openhab/openhab1-addons/pull/5515