### PR TITLE
[Serial] Fix configuration parsing error in the serial binding

### DIFF
--- a/bundles/binding/org.openhab.binding.serial/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.serial/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: gnu.io,
  org.apache.commons.codec.binary,
  org.apache.commons.io,
+ org.apache.commons.lang,
  org.openhab.core.events,
  org.openhab.core.items,
  org.openhab.core.library.items,
@@ -20,5 +21,6 @@ Import-Package: gnu.io,
  org.osgi.service.event,
  org.slf4j
 Service-Component: OSGI-INF/serialbinding.xml
+Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-Activator: org.openhab.binding.serial.internal.SerialActivator

--- a/bundles/binding/org.openhab.binding.serial/README.md
+++ b/bundles/binding/org.openhab.binding.serial/README.md
@@ -10,27 +10,27 @@ The Serial binding allows openHAB to communicate in ASCII over serial ports atta
 
 ## Port Configuration Notes
 
-In most cases you will not need to perform special steps to access your serial ports, but these notes might be helpful.
+In most cases it will not be needed to perform special steps to access serial ports, but these notes might be helpful.
 
 ### Linux Users
 
-* If you are using **non standard serial ports** you have to adapt start.sh to have the serial port included. The `java` command line should then include the following parameters:
+* When using **non standard serial ports**, adapt start.sh to have the serial port included. The `java` command line should then include the following parameters:
 
 ```
 -Dgnu.io.rxtx.SerialPorts=/dev/ttyAMA0
 ```
 
-where `/dev/ttyAMA0` is the path to your serial port. Please be aware to change all scripts you might use for startup (debug, automatic start in Linux, etc.).
+where `/dev/ttyAMA0` is the path to the serial port. Remember to change all scripts used for startup (debug, automatic start in Linux, etc.).
 
-* Your Linux distro might require that you add the `openhab` user to the `dialout` group to grant permission to read/write to the serial port.
+* A Linux distro might require adding the `openhab` user to the `dialout` group to grant permission to read/write to the serial port.
 
 ```
 sudo usermod -a -G dialout openhab
 ```
 
-The user will need to logout from all login instances and log back in to see their new group added.  If you add your user to this group and still cannot get permission, rebooting the box to ensure the new group permission is attached to your user is suggested.
+The user will need to logout from all login instances and log back in to see their new group added.  If the user added to this group still cannot get permission, rebooting the box to ensure the new group permission is attached to the user is suggested.
 
-* If you use more than one USB serial converter like FTDI or CP2102, it may happen that your /dev/ttyUSB0 device is named /dev/ttyUSB1 after a reboot. To prevent this problem you can assign alias names for your serial devices by adding them to `/etc/udev/rules.d/99-com.rules`.
+* When using more than one USB serial converter like FTDI or CP2102, it may happen that the /dev/ttyUSB0 device is named /dev/ttyUSB1 after a reboot. To prevent this problem, alias names can be assigned to serial devices by adding them to `/etc/udev/rules.d/99-com.rules`.
 
 example:
 
@@ -41,7 +41,7 @@ SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", ATTRS{seria
 
 ### Mac Users
 
-If you are working with a Mac, you might need to install a driver for your USB-RS232 converter (e.g. [osx-pl2303](http://osx-pl2303.sourceforge.net/) or [pl2303](http://mac.softpedia.com/get/Drivers/PL2303-OS-X-driver.shtml)) and create the /var/lock folder, see the [rxtx troubleshooting guide](http://rxtx.qbang.org/wiki/index.php/Trouble_shooting#Mac_OS_X_users).
+When working with a Mac, it may be necessary to install a driver for the USB-RS232 converter (e.g. [osx-pl2303](http://osx-pl2303.sourceforge.net/) or [pl2303](http://mac.softpedia.com/get/Drivers/PL2303-OS-X-driver.shtml)) and create the /var/lock folder; see the [rxtx troubleshooting guide](http://rxtx.qbang.org/wiki/index.php/Trouble_shooting#Mac_OS_X_users).
 
 ## Binding Configuration
 
@@ -62,11 +62,11 @@ serial="<port>@<baudrate>,REGEX(<regular expression>), UP(<Up string>),DOWN(<Dow
 where:
 
 * `<port>` is the identification of the serial port on the host system, e.g. `COM1` on Windows, `/dev/ttyS0` on Linux or `/dev/tty.PL2303-0000103D` on Mac.  The same `<port>` can be bound to multiple items.
-* `<baudrate>` is the baud rate of the port. Backward compatibility is given; if no baud rate is specified  the serial binding defaults to 9600 baud.
-* `REGEX(<regular expression>)` allows parsing for special strings or numbers in the serial stream. You can use a capture group (e.g. REGEX(Position:([0-9.]*)) to capture 12 in "Position:12" or substitution (e.g. REGEX(s/Position:100/ON/) or REGEX(s/Position:100/ON/g)) to replace (FIRST or ALL) "Position:100" strings in response with "ON". This is based on the [RegEx Service](https://github.com/openhab/openhab1-addons/wiki/Transformations#regex-transformation-service) and [ESH RegExTransformationService](https://github.com/eclipse/smarthome/tree/master/extensions/transform/org.eclipse.smarthome.transform.regex). This is optional. 
-* `BASE64` enables the Base64 mode. With this mode all data received on the serial port is saved in Base64 format. In this mode also all data that is sent to the serial port has to be Base64 encoded. (This was implemented because some serial devices are using bytes that are not supported by the REST interface). 
-* `ON(<On string>),OFF(<Off string>)` if used in conjunction with a Switch this mapping will send specific commands to serial port and also match a serial command to specific ON/OFF state. This way you don't have to use a rule to send a command to serial
-* `UP(<Up string>),DOWN(<Down string>),STOP(<Stop string>)` if used in conjunction with a Rollershutter this mapping will send specific commands to serial port. Use REGEX to parse Rollershutter postion (0-100%) comming as feedback over serial link
+* `<baudrate>` is the baud rate of the port. If no baud rate is specified, the binding defaults to 9600 baud.
+* `REGEX(<regular expression>)` allows parsing for special strings or numbers in the serial stream. A capture group (e.g. REGEX(Position:([0-9.]*)) can be used to capture "12" in `Position:12` or substitution (e.g. REGEX(s/Position:100/ON/) or REGEX(s/Position:100/ON/g)) to replace (FIRST or ALL) "Position:100" strings in response with "ON". This is based on the [RegEx Service](https://github.com/openhab/openhab1-addons/wiki/Transformations#regex-transformation-service) and [ESH RegExTransformationService](https://github.com/eclipse/smarthome/tree/master/extensions/transform/org.eclipse.smarthome.transform.regex). This is optional.
+* `BASE64` enables the Base64 mode. With this mode all data received on the serial port is saved in Base64 format. All data that is sent to the serial port also has to be Base64 encoded. (This was implemented because some serial devices are using bytes that are not supported by the REST interface).
+* `ON(<On string>),OFF(<Off string>)` used in conjunction with a Switch, this mapping will send specific commands to serial port and also match a serial command to specific ON/OFF state. This makes it unnecessary to use a rule to send a command to serial.
+* `UP(<Up string>),DOWN(<Down string>),STOP(<Stop string>)` used in conjunction with a Rollershutter, this mapping will send specific commands to serial port. Use REGEX to parse Rollershutter postion (0-100%) coming as feedback over serial link.
 
 Base64 can be decoded in the rules by importing `javax.xml.bind.DatatypeConverter` and then decoding the value like this:
 
@@ -74,9 +74,9 @@ Base64 can be decoded in the rules by importing `javax.xml.bind.DatatypeConverte
 DatatypeConverter::parseBase64Binary(ITEM.state.toString)
 ```
 
-For encoding use the `printBase64Binary` method of the `DatatypeConverter`. This is optional. 
+For encoding, use the `printBase64Binary` method of the `DatatypeConverter`. This is optional. 
 
-As a result, your lines in the items file might look like these:
+As a result, lines in the items file might look like these:
 
 ```
 Switch         HardwareButton     "Bell"              (Entrance)      { serial="/dev/ttyS0" }

--- a/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialBinding.java
+++ b/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialBinding.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
 
 import org.openhab.core.events.AbstractEventSubscriber;
 import org.openhab.core.events.EventPublisher;
@@ -32,40 +34,50 @@ import org.openhab.core.types.State;
 import org.openhab.model.item.binding.BindingConfigParseException;
 import org.openhab.model.item.binding.BindingConfigReader;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * <p>
  * This class implements a binding of serial devices to openHAB.
- * The binding configurations are provided by the {@link GenericItemProvider}.
- * </p>
+ * The binding configurations are provided by the {@link
+ * GenericItemProvider}.
  *
- * <p>
  * The format of the binding configuration is simple and looks like this:
- * </p>
- * serial="&lt;port&gt;" where &lt;port&gt; is the identification of the serial port on the host system, e.g.
- * "COM1" on Windows, "/dev/ttyS0" on Linux or "/dev/tty.PL2303-0000103D" on Mac
- * <p>
- * Switch items with this binding will receive an ON-OFF update on the bus, whenever data becomes available on the
- * serial interface<br/>
- * String items will receive the submitted data in form of a string value as a status update, while openHAB commands to
- * a Switch item is
- * sent out as data through the serial interface.
- * </p>
+ *     serial="<port>@<baudrate>"
+ *
+ * `port` is the identification of the serial port on the host system, e.g.
+ * "COM1" on Windows, "/dev/ttyS0" on Linux or "/dev/tty.PL2303-0000103D" on
+ * Mac.
+ *
+ * `baudrate` is the baud rate of the port. if not specified, the default is
+ * 9600.
+ *
+ * Switch items with this binding will receive an ON-OFF update on the bus,
+ * whenever data becomes available on the serial interface.
+ *
+ * String items will receive the submitted data in form of a string value as a
+ * status update.
+ *
+ * openHAB commands to a Switch item are sent out as data through the serial
+ * interface.
  *
  * @author Kai Kreuzer
- *
+ * @since 0.6.0
  */
 public class SerialBinding extends AbstractEventSubscriber implements BindingConfigReader {
 
+    private Logger logger = LoggerFactory.getLogger(SerialBinding.class);
     private Map<String, SerialDevice> serialDevices = new HashMap<>();
 
     /**
-     * stores information about the which items are associated to which port. The map has this content structure:
-     * itemname -> port
+     * Stores information about the which items are associated to which port.
+     * The map has this content structure: itemname -> port
      */
     private Map<String, String> itemMap = new HashMap<String, String>();
 
     /**
-     * stores information about the context of items. The map has this content structure: context -> Set of itemNames
+     * Stores information about the context of items. The map has this content
+     * structure: context -> Set of itemNames
      */
     private Map<String, Set<String>> contextMap = new HashMap<>();
 
@@ -139,6 +151,14 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
      */
     @Override
     public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
+        if (item == null) {
+            throw new BindingConfigParseException("Item received was null");
+        }
+
+        if (StringUtils.isBlank(bindingConfig)) {
+            throw new BindingConfigParseException("No binding configuration provided");
+        }
+
         if (!(item instanceof SwitchItem || item instanceof StringItem || item instanceof NumberItem
                 || item instanceof RollershutterItem || item instanceof ContactItem || item instanceof DimmerItem)) {
             throw new BindingConfigParseException("Item '" + item.getName() + "' is of type '"
@@ -153,6 +173,13 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
     @Override
     public void processBindingConfiguration(String context, Item item, String bindingConfig)
             throws BindingConfigParseException {
+        if (StringUtils.isBlank(context)) {
+            throw new BindingConfigParseException("No context provided");
+        }
+
+        if (StringUtils.isBlank(bindingConfig)) {
+            throw new BindingConfigParseException("No binding configuration provided");
+        }
 
         String pattern = null;
         boolean base64 = false;
@@ -166,26 +193,36 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
         int parameterSplitterAt = bindingConfig.indexOf(",");
 
         if (parameterSplitterAt > 0) {
-            String[] split = bindingConfig.substring(parameterSplitterAt + 1, bindingConfig.length() - 1).split("\\),");
+            String[] split = bindingConfig.substring(parameterSplitterAt + 1, bindingConfig.length()).split("\\),");
             for (int i = 0; i < split.length; i++) {
                 String substring = split[i];
 
                 if (substring.startsWith("REGEX(")) {
-                    pattern = substring.substring(6, substring.length());
+                    pattern = substring.substring(6, substring.length()-1);
+                    logger.debug("REGEX: '{}'", pattern);
                 } else if (substring.startsWith("FORMAT(")) {
-                    format = substring.substring(7, substring.length());
+                    format = substring.substring(7, substring.length()-1);
+                    logger.debug("FORMAT: '{}'", format);
                 } else if (substring.equals("BASE64")) {
                     base64 = true;
+                    logger.debug("Base64-Mode enabled");
                 } else if (substring.startsWith("ON(")) {
-                    onCommand = substring.substring(3, substring.length());
+                    onCommand = substring.substring(3, substring.length()-1);
+                    logger.debug("ON: '{}'", onCommand);
                 } else if (substring.startsWith("OFF(")) {
-                    offCommand = substring.substring(4, substring.length());
+                    offCommand = substring.substring(4, substring.length()-1);
+                    logger.debug("OFF: '{}'", offCommand);
                 } else if (substring.startsWith("UP(")) {
-                    upCommand = substring.substring(3, substring.length());
+                    upCommand = substring.substring(3, substring.length()-1);
+                    logger.debug("UP: '{}'", upCommand);
                 } else if (substring.startsWith("DOWN(")) {
-                    downCommand = substring.substring(5, substring.length());
+                    downCommand = substring.substring(5, substring.length()-1);
+                    logger.debug("DOWN: '{}'", downCommand);
                 } else if (substring.startsWith("STOP(")) {
-                    stopCommand = substring.substring(5, substring.length());
+                    stopCommand = substring.substring(5, substring.length()-1);
+                    logger.debug("STOP: '{}'", stopCommand);
+                } else {
+                    logger.warn("Unrecognized transform: {}", substring);
                 }
             }
         }
@@ -198,10 +235,14 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
         }
 
         String port = portConfig[0];
+        logger.debug("Port: {}", port);
         int baudRate = 0;
 
         if (portConfig.length > 1) {
             baudRate = Integer.parseInt(portConfig[1]);
+            logger.debug("Baud rate: {}", baudRate);
+        } else {
+            logger.debug("Baud rate: 9600");
         }
 
         SerialDevice serialDevice = serialDevices.get(port);
@@ -263,5 +304,4 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
             contextMap.remove(context);
         }
     }
-
 }

--- a/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialDevice.java
+++ b/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialDevice.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2018 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -289,7 +289,7 @@ public class SerialDevice implements SerialPortEventListener {
                     String result = sb.toString();
 
                     // send data to the bus
-                    logger.debug("Received message '{}' on serial port {}", new String[] { result, port });
+                    logger.debug("Received message '{}' on serial port {}", result, port);
 
                     if (eventPublisher != null) {
                         if (configMap != null && !configMap.isEmpty()) {
@@ -317,7 +317,7 @@ public class SerialDevice implements SerialPortEventListener {
                                                 eventPublisher.postUpdate(entry.getKey(), state);
                                             } catch (NumberFormatException e) {
                                                 logger.warn("Unable to convert regex result '{}' for item {} to number",
-                                                        new String[] { result, entry.getKey() });
+                                                        result, entry.getKey());
                                             }
                                         }
                                     } catch (TransformationException e) {
@@ -365,7 +365,7 @@ public class SerialDevice implements SerialPortEventListener {
                     }
 
                 } catch (IOException e) {
-                    logger.debug("Error receiving data on serial port {}: {}", new String[] { port, e.getMessage() });
+                    logger.debug("Error receiving data on serial port {}: {}", port, e.getMessage());
                 }
                 break;
         }
@@ -377,7 +377,7 @@ public class SerialDevice implements SerialPortEventListener {
      * @param msg the string to send
      */
     public void writeString(String msg) {
-        logger.debug("Writing '{}' to serial port {}", new String[] { msg, port });
+        logger.debug("Writing '{}' to serial port {}", msg, port);
         try {
             // write string to serial port
             if (msg.startsWith("BASE64:")) {
@@ -388,7 +388,7 @@ public class SerialDevice implements SerialPortEventListener {
 
             outputStream.flush();
         } catch (IOException e) {
-            logger.error("Error writing '{}' to serial port {}: {}", new String[] { msg, port, e.getMessage() });
+            logger.warn("Error writing '{}' to serial port {}: {}", msg, port, e.getMessage());
         }
     }
 


### PR DESCRIPTION
Fix the configuration parsing error.
Clean up compiler warnings.
Make minor fixes in README.md.

Fixes #5542