### PR TITLE
proposed solution for "[Tinkerforge] Readme is wrong #5545"

### DIFF
--- a/bundles/binding/org.openhab.binding.tinkerforge/README.md
+++ b/bundles/binding/org.openhab.binding.tinkerforge/README.md
@@ -1526,7 +1526,7 @@ Technical description see [Tinkerforge Website](http://www.tinkerforge.com/en/do
 | property | description | values |
 |----------|--------------|--------|
 | uid | tinkerforge uid | same as bricklet |
-| subid | openHAB subid of the device | in0, in2, in3, in4 |
+| subid | openHAB subid of the device | in0, in1, in2, in3 |
 | type | openHAB type name |  |
 
 ##### tinkerforge.cfg:
@@ -1569,7 +1569,7 @@ Technical description see [Tinkerforge Website](http://www.tinkerforge.com/en/do
 | property | description | values |
 |----------|--------------|--------|
 | uid | tinkerforge uid | same as bricklet |
-| subid | openHAB subid of the device | out0, out2, out3, out4 |
+| subid | openHAB subid of the device | out0, out1, out2, out3 |
 | type | openHAB type name |  |
 
 ##### tinkerforge.cfg:


### PR DESCRIPTION
I changed the subid's for 
* Industrial Digital Out 4 Bricklet:
* Industrial Digital IN 4 Bricklet:
to match the examples.

Fixes #5545