### PR TITLE
Add the Samsung TV Binding to the legacy bindings

### DIFF
--- a/features/openhab-addons-legacy/src/main/feature/feature.xml
+++ b/features/openhab-addons-legacy/src/main/feature/feature.xml
@@ -122,6 +122,12 @@
     <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.rwesmarthome/${project.version}</bundle>
   </feature>
 
+  <feature name="openhab-binding-samungtv1" description="Samsung TV Binding (1.x)" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.samungtv/${project.version}</bundle>
+  </feature>
+
   <feature name="openhab-binding-satel1" description="Satel Binding (1.x)" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>


### PR DESCRIPTION
Because the old binding uses a different protocol the TV's supported by both bindings might vary

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl> (github: martinvw)