### PR TITLE
Revert "Add the Samsung TV Binding to the legacy bindings"

### DIFF
--- a/features/openhab-addons-legacy/src/main/feature/feature.xml
+++ b/features/openhab-addons-legacy/src/main/feature/feature.xml
@@ -122,12 +122,6 @@
     <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.rwesmarthome/${project.version}</bundle>
   </feature>
 
-  <feature name="openhab-binding-samungtv1" description="Samsung TV Binding (1.x)" version="${project.version}">
-    <feature>openhab-runtime-base</feature>
-    <feature>openhab-runtime-compat1x</feature>
-    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.samungtv/${project.version}</bundle>
-  </feature>
-
   <feature name="openhab-binding-satel1" description="Satel Binding (1.x)" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>


### PR DESCRIPTION
Reverts openhab/openhab1-addons#5564

Sorry. A short test suggests that its not working so I rather not spent time on this but on making the OH2 binding behave properly :-) 

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl>