### PR TITLE
[FritzboxTr064] Add switch to change call deflection on/off (#5290)

### DIFF
--- a/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
@@ -108,7 +108,7 @@ Number  fboxMissedCalls  "Missed Calls [%s]"            {fritzboxtr064="missedCa
 // Number after callDeflectionSwitch is ID of configured call deflection
 // The ID count includes the entries from the "Call Blocks" page.
 // If you have no "Call Blocks", the first entry on the "Call Diversions" page has ID 0.
-// If you have e. g. 3 "Call Blocks", the first entry on the "Call Diversions" page has ID 3.
+// If you have 3 "Call Blocks", the first entry on the "Call Diversions" page has ID 3.
 Switch  fboxCD0Switch    "Call Deflection ID 0"         {fritzboxtr064="callDeflectionSwitch:0"}
 ```
 

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/README.md
@@ -22,7 +22,8 @@ It has been tested on:
  * Switch Item: Receives "ON" state when call is incoming
  * Call Items: Shows external an internal number for incoming/outgoing calls
  * Resolve external call number to phonebook name
-* enabling/disabling telephone answering machines (TAMs) 
+* enabling/disabling telephone answering machines (TAMs)
+* enabling/disabling of call deflection
 * getting new messages per TAM
 * getting missed calls for the last x days
 * getting DSL/WAN statistics for monitoring connection quality
@@ -101,8 +102,14 @@ Switch  fboxTAM0Switch   "Answering machine ID 0"       {fritzboxtr064="tamSwitc
 Number  fboxTAM0NewMsg   "New Messages TAM 0 [%s]"      {fritzboxtr064="tamNewMessages:0"}
 
 // Missed calls: specify the number of last days which should be searched for missed calls
-Number  fboxMissedCalls     "Missed Calls [%s]"         {fritzboxtr064="missedCallsInDays:5"}
+Number  fboxMissedCalls  "Missed Calls [%s]"            {fritzboxtr064="missedCallsInDays:5"}
 
+// Call deflection items
+// Number after callDeflectionSwitch is ID of configured call deflection
+// The ID count includes the entries from the "Call Blocks" page.
+// If you have no "Call Blocks", the first entry on the "Call Diversions" page has ID 0.
+// If you have e. g. 3 "Call Blocks", the first entry on the "Call Diversions" page has ID 3.
+Switch  fboxCD0Switch    "Call Deflection ID 0"         {fritzboxtr064="callDeflectionSwitch:0"}
 ```
 
 ## Examples and Hints

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/InputArgument.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/InputArgument.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.fritzboxtr064.internal;
+
+/**
+ * Input argument for a TR064 SOAP call. Input arguments are added to the SOAP request of both reading
+ * and writing values.
+ *
+ * @author Michael Koch <tensberg@gmx.net>
+ * @since 1.12.0
+ */
+public class InputArgument {
+    private final String name;
+    private final String value;
+
+    InputArgument(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemConfiguration.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemConfiguration.java
@@ -10,89 +10,67 @@ package org.openhab.binding.fritzboxtr064.internal;
 
 import static java.util.Collections.emptyList;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Configuration of an item from the binding config. Each configuration has an {@link #getItemCommand() item command}
  * which determines the value to read. For parametrisable commands the config may also have
- * a {@link #getDataInValue() data in value} and {@link #getAdditionalParameters() additional parameters}.
+ * {@link #getArgumentValues() values for the input arguments}.
  *
  * @author Michael Koch <tensberg@gmx.net>
  * @since 1.11.0
  */
 public class ItemConfiguration {
-    private static final String PARAM_SEPARATOR = ":";
+    private static final String VALUE_SEPARATOR = ":";
 
     private final String _itemCommand;
 
-    private final Optional<String> _dataInValue;
-
-    private final List<String> _additionalParameters;
+    private final List<String> _argumentValues;
 
     /**
      * Parses a configuration string from the binding configuration.
-     * The command and parameters must be separated by colons (':').
+     * The command and argument values must be separated by colons (':').
      *
      * @param itemConfig Configuration string from the binding configuration.
      * @return The parsed configuration.
      */
     public static ItemConfiguration parse(String itemConfig) {
-        String[] requestParts = itemConfig.split(PARAM_SEPARATOR);
+        String[] requestParts = itemConfig.split(VALUE_SEPARATOR);
 
         String itemCommand = requestParts[0];
-        Optional<String> dataInValue;
-        List<String> _additionalParameters;
+        List<String> _argumentValues;
 
-        if (requestParts.length >= 2) {
-            dataInValue = Optional.of(requestParts[1]);
+        if (requestParts.length > 1) {
+            _argumentValues = Arrays.asList(requestParts).subList(1, requestParts.length);
         } else {
-            dataInValue = Optional.empty();
+            _argumentValues = emptyList();
         }
 
-        if (requestParts.length > 2) {
-            _additionalParameters = new ArrayList<>(requestParts.length - 2);
-            for (int i = 2; i < requestParts.length; i++) {
-                _additionalParameters.add(requestParts[i]);
-            }
-        } else {
-            _additionalParameters = emptyList();
-        }
-
-        return new ItemConfiguration(itemCommand, dataInValue, _additionalParameters);
+        return new ItemConfiguration(itemCommand, _argumentValues);
     }
 
-    public ItemConfiguration(String _itemCommand) {
-        this(_itemCommand, Optional.empty(), emptyList());
+    public ItemConfiguration(String _itemCommand, String... _argumentValues) {
+        this(_itemCommand, Arrays.asList(_argumentValues));
     }
 
-    public ItemConfiguration(String _itemCommand, String _dataInValue) {
-        this(_itemCommand, Optional.of(_dataInValue), emptyList());
-    }
-
-    public ItemConfiguration(String _itemCommand, Optional<String> _dataInValue, List<String> _additionalParameters) {
+    public ItemConfiguration(String _itemCommand, List<String> _argumentValues) {
         this._itemCommand = _itemCommand;
-        this._dataInValue = _dataInValue;
-        this._additionalParameters = _additionalParameters;
+        this._argumentValues = _argumentValues;
     }
 
     public String getItemCommand() {
         return _itemCommand;
     }
 
-    public Optional<String> getDataInValue() {
-        return _dataInValue;
-    }
-
-    public List<String> getAdditionalParameters() {
-        return _additionalParameters;
+    public List<String> getArgumentValues() {
+        return _argumentValues;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_itemCommand, _dataInValue, _additionalParameters);
+        return Objects.hash(_itemCommand, _argumentValues);
     }
 
     @Override
@@ -107,18 +85,11 @@ public class ItemConfiguration {
             return false;
         }
         ItemConfiguration other = (ItemConfiguration) obj;
-        if (_additionalParameters == null) {
-            if (other._additionalParameters != null) {
+        if (_argumentValues == null) {
+            if (other._argumentValues != null) {
                 return false;
             }
-        } else if (!_additionalParameters.equals(other._additionalParameters)) {
-            return false;
-        }
-        if (_dataInValue == null) {
-            if (other._dataInValue != null) {
-                return false;
-            }
-        } else if (!_dataInValue.equals(other._dataInValue)) {
+        } else if (!_argumentValues.equals(other._argumentValues)) {
             return false;
         }
         if (_itemCommand == null) {
@@ -135,11 +106,10 @@ public class ItemConfiguration {
     public String toString() {
         String requestString;
 
-        if (_dataInValue.isPresent() || !_additionalParameters.isEmpty()) {
+        if (!_argumentValues.isEmpty()) {
             StringBuilder requestStringBuilder = new StringBuilder();
-            requestStringBuilder.append(_itemCommand).append(PARAM_SEPARATOR).append(_dataInValue.orElse(""));
-            for (String additionalParameter : _additionalParameters) {
-                requestStringBuilder.append(PARAM_SEPARATOR).append(additionalParameter);
+            for (String argumentValue : _argumentValues) {
+                requestStringBuilder.append(VALUE_SEPARATOR).append(argumentValue);
             }
 
             requestString = requestStringBuilder.toString();

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ItemMap.java
@@ -25,15 +25,17 @@ import java.util.Set;
 public interface ItemMap {
     /**
      * @return Names of the item commands which are provided by the response to the
-     *         {@link #getReadDataOutName(String) SOAP service command} of this map.
+     *         {@link #getItemArgumentName(String) SOAP service command} of this map.
      */
     Set<String> getItemCommands();
 
     /**
-     * @param itemCommand
-     * @return Name of the XML element in the service response which contains the value of the given command.
+     * Get the name of the XML element in the TR064 service call which contains the value of the given command.
+     * For writing calls, this is an element in the service request, for reading calls in the service response.
+     *
+     * @return Name of the XML element for the item value.
      */
-    String getReadDataOutName(String itemCommand);
+    String getItemArgumentName(String itemCommand);
 
     String getServiceId();
 

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/MultiItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/MultiItemMap.java
@@ -16,7 +16,7 @@ import java.util.function.Function;
 /**
  * {@link ItemMap} for a FritzBox SOAP service which returns the values of multiple items in
  * a single service response. The value of each {@link #getItemCommands() configured command} is
- * read from one {@link #getReadDataOutName(String)} XML element in the service response by
+ * read from one {@link #getItemArgumentName(String)} XML element in the service response by
  * a {@link SoapValueParser}.
  *
  * @author Michael Koch <tensberg@gmx.net>
@@ -40,7 +40,7 @@ public class MultiItemMap extends AbstractItemMap {
     }
 
     @Override
-    public String getReadDataOutName(String itemCommand) {
+    public String getItemArgumentName(String itemCommand) {
         if (!_itemCommands.contains(itemCommand)) {
             throw new IllegalArgumentException("unsupported itemCommand " + itemCommand);
         }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ParametrizedItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/ParametrizedItemMap.java
@@ -8,8 +8,10 @@
  */
 package org.openhab.binding.fritzboxtr064.internal;
 
+import java.util.List;
+
 /**
- * {@link ItemMap} for a SOAP service which takes an input parameter.
+ * {@link ItemMap} for a SOAP service which takes input arguments.
  *
  * @author Michael Koch <tensberg@gmx.net>
  * @since 1.11.0
@@ -17,8 +19,14 @@ package org.openhab.binding.fritzboxtr064.internal;
 public interface ParametrizedItemMap extends ItemMap {
 
     /**
-     * @return XML element name of the data in parameter of the SOAP service.
+     * Get the list of input arguments for a particular configuration.
+     * Creates the {@link InputArgument input arguments} list by combining the
+     * argument names of the item map with the {@link ItemConfiguration#getArgumentValues() argument values} configured
+     * by the user.
+     *
+     * @param config Configuration of the item.
+     * @return List of input arguments for the given configuration.
      */
-    String getReadDataInName();
+    List<InputArgument> getConfigInputArguments(ItemConfiguration config);
 
 }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SingleItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SingleItemMap.java
@@ -8,59 +8,55 @@
  */
 package org.openhab.binding.fritzboxtr064.internal;
 
-import static java.util.Collections.singleton;
+import static java.util.Collections.*;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * An item map for SOAP services which only return a single item command value per response.
- * This item map is more flexible than the {@link MultiItemMap} as it supports an optional
- * {@link #getReadDataInName() input parameter}, a custom {@link #getSoapValueParser() value parser}
- * and {@link WritableItemMap writable commands}.
+ * This item map is more flexible than the {@link MultiItemMap} as it supports
+ * a custom {@link #getSoapValueParser() value parser} and
+ * {@link ParametrizedItemMap read} and {@link WritableItemMap write parameters}.
  *
  * @author Michael Koch <tensberg@gmx.net>
  * @since 1.11.0
  */
 public class SingleItemMap extends AbstractItemMap implements ParametrizedItemMap, WritableItemMap {
+
+    private static final Logger logger = LoggerFactory.getLogger(SingleItemMap.class);
+
     // common parameters
     private final String _itemCommand; // matches itemconfig
 
-    // read specific
-    private final String _readDataInName; // name of parameter to put in soap request to read value
-    private String _readDataOutName; // name of parameter to extract from fbox soap response when reading value (is
-                                     // parsed as value)
+    private final String _itemArgumentName; // name of parameter to extract from fbox soap response when reading value
+                                            // (is parsed as value)
 
     // write specific
     private String _writeServiceCommand; // command to execute on fbox if value should be set
-    private String _writeDataInName; // name of parameter which is put in soap request when setting an option on fbox
-    private String _writeDataInNameAdditional; // additional Parameter to add to write request. e.g. id of TAM to set
 
-    public SingleItemMap(String _itemCommand, String _readServiceCommand, String _serviceId, String _getDataInName1,
-            String _getDataOutName1) {
-        this(_itemCommand, _readServiceCommand, _serviceId, _getDataInName1, _getDataOutName1, new SoapValueParser());
+    private final List<String> _configArgumentNames;
+
+    public SingleItemMap(String _itemCommand, String _readServiceCommand, String _serviceId, String _configArgumentName,
+            String _itemArgumentName) {
+        this(_itemCommand, _readServiceCommand, _serviceId, _configArgumentName, _itemArgumentName,
+                new SoapValueParser());
     }
 
-    public SingleItemMap(String _itemCommand, String _readServiceCommand, String _serviceId, String _getDataInName1,
-            String _getDataOutName1, SoapValueParser _soapValueParser) {
+    public SingleItemMap(String _itemCommand, String _readServiceCommand, String _serviceId, String _configArgumentName,
+            String _itemArgumentName, SoapValueParser _soapValueParser) {
         super(_readServiceCommand, _serviceId, _soapValueParser);
         this._itemCommand = _itemCommand;
-        _readDataInName = _getDataInName1;
-        _readDataOutName = _getDataOutName1;
-    }
-
-    @Override
-    public String getReadDataInName() {
-        return _readDataInName;
-    }
-
-    @Override
-    public String getWriteDataInNameAdditional() {
-        return _writeDataInNameAdditional;
-    }
-
-    public void setWriteDataInNameAdditional(String _writeDataInNameAdditional) {
-        this._writeDataInNameAdditional = _writeDataInNameAdditional;
+        this._configArgumentNames = _configArgumentName == null ? emptyList() : singletonList(_configArgumentName);
+        this._itemArgumentName = _itemArgumentName;
     }
 
     @Override
@@ -72,15 +68,6 @@ public class SingleItemMap extends AbstractItemMap implements ParametrizedItemMa
         this._writeServiceCommand = _writeServiceCommand;
     }
 
-    @Override
-    public String getWriteDataInName() {
-        return _writeDataInName;
-    }
-
-    public void setWriteDataInName(String _setDataInName) {
-        this._writeDataInName = _setDataInName;
-    }
-
     public String getItemCommand() {
         return _itemCommand;
     }
@@ -90,15 +77,47 @@ public class SingleItemMap extends AbstractItemMap implements ParametrizedItemMa
         return singleton(_itemCommand);
     }
 
-    public String getReadDataOutName() {
-        return _readDataOutName;
+    public String getItemArgumentName() {
+        return _itemArgumentName;
     }
 
     @Override
-    public String getReadDataOutName(String itemCommand) {
+    public String getItemArgumentName(String itemCommand) {
         if (!Objects.equals(itemCommand, _itemCommand)) {
             throw new IllegalArgumentException("unsupported itemCommand " + itemCommand);
         }
-        return _readDataOutName;
+        return _itemArgumentName;
     }
+
+    @Override
+    public List<InputArgument> getConfigInputArguments(ItemConfiguration config) {
+        List<String> parameterValues = config.getArgumentValues();
+        if (_configArgumentNames.size() != parameterValues.size()) {
+            logger.warn("item command {} requires {} parameters but {} parameters were configured",
+                    config.getItemCommand(), _configArgumentNames.size(), parameterValues.size());
+            return emptyList();
+        }
+
+        if (_configArgumentNames.size() == 0) {
+            return emptyList();
+        }
+
+        List<InputArgument> inputValues = new ArrayList<>(_configArgumentNames.size());
+        Iterator<String> names = _configArgumentNames.iterator();
+        Iterator<String> values = parameterValues.iterator();
+        while (names.hasNext()) {
+            inputValues.add(new InputArgument(names.next(), values.next()));
+        }
+
+        return inputValues;
+    }
+
+    @Override
+    public InputArgument getWriteInputArgument(Command cmd) {
+        // convert String command into numeric
+        assert cmd instanceof OnOffType : "unsupported Command type " + cmd.getClass().getName();
+        String value = cmd.toString().equalsIgnoreCase("on") ? "1" : "0";
+        return new InputArgument(_itemArgumentName, value);
+    }
+
 }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SingleItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SingleItemMap.java
@@ -11,6 +11,8 @@ package org.openhab.binding.fritzboxtr064.internal;
 import static java.util.Collections.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -31,6 +33,59 @@ import org.slf4j.LoggerFactory;
  * @since 1.11.0
  */
 public class SingleItemMap extends AbstractItemMap implements ParametrizedItemMap, WritableItemMap {
+    public static class Builder {
+        private String _serviceId;
+        private String _itemCommand;
+        private String _itemArgumentName;
+        private String[] _configArgumentNames;
+        private String _readServiceCommand;
+        private SoapValueParser _soapValueParser = new SoapValueParser();
+        private String _writeServiceCommand;
+
+        Builder() {
+        }
+
+        public Builder serviceId(String _serviceId) {
+            this._serviceId = _serviceId;
+            return this;
+        }
+
+        public Builder itemCommand(String _itemCommand) {
+            this._itemCommand = _itemCommand;
+            return this;
+        }
+
+        public Builder itemArgumentName(String _itemArgumentName) {
+            this._itemArgumentName = _itemArgumentName;
+            return this;
+        }
+
+        public Builder configArgumentNames(String... _configArgumentNames) {
+            this._configArgumentNames = _configArgumentNames;
+            return this;
+        }
+
+        public Builder readServiceCommand(String _readServiceCommand) {
+            this._readServiceCommand = _readServiceCommand;
+            return this;
+        }
+
+        public Builder soapValueParser(SoapValueParser _soapValueParser) {
+            this._soapValueParser = _soapValueParser;
+            return this;
+        }
+
+        public Builder writeServiceCommand(String _writeServiceCommand) {
+            this._writeServiceCommand = _writeServiceCommand;
+            return this;
+        }
+
+        public SingleItemMap build() {
+            return new SingleItemMap(_serviceId, _itemCommand, _itemArgumentName,
+                    _configArgumentNames == null ? Collections.emptyList() : Arrays.asList(_configArgumentNames),
+                    _readServiceCommand, _writeServiceCommand, _soapValueParser);
+        }
+    }
 
     private static final Logger logger = LoggerFactory.getLogger(SingleItemMap.class);
 
@@ -41,31 +96,27 @@ public class SingleItemMap extends AbstractItemMap implements ParametrizedItemMa
                                             // (is parsed as value)
 
     // write specific
-    private String _writeServiceCommand; // command to execute on fbox if value should be set
+    private final String _writeServiceCommand; // command to execute on fbox if value should be set
 
     private final List<String> _configArgumentNames;
 
-    public SingleItemMap(String _itemCommand, String _readServiceCommand, String _serviceId, String _configArgumentName,
-            String _itemArgumentName) {
-        this(_itemCommand, _readServiceCommand, _serviceId, _configArgumentName, _itemArgumentName,
-                new SoapValueParser());
+    public static Builder builder() {
+        return new Builder();
     }
 
-    public SingleItemMap(String _itemCommand, String _readServiceCommand, String _serviceId, String _configArgumentName,
-            String _itemArgumentName, SoapValueParser _soapValueParser) {
-        super(_readServiceCommand, _serviceId, _soapValueParser);
+    private SingleItemMap(String _serviceId, String _itemCommand, String _itemArgumentName,
+            List<String> _configArgumentNames, String _readAction, String _writeServiceCommand,
+            SoapValueParser _soapValueParser) {
+        super(_readAction, _serviceId, _soapValueParser);
         this._itemCommand = _itemCommand;
-        this._configArgumentNames = _configArgumentName == null ? emptyList() : singletonList(_configArgumentName);
         this._itemArgumentName = _itemArgumentName;
+        this._configArgumentNames = _configArgumentNames;
+        this._writeServiceCommand = _writeServiceCommand;
     }
 
     @Override
     public String getWriteServiceCommand() {
         return _writeServiceCommand;
-    }
-
-    public void setWriteServiceCommand(String _writeServiceCommand) {
-        this._writeServiceCommand = _writeServiceCommand;
     }
 
     public String getItemCommand() {

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SoapValueParser.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/SoapValueParser.java
@@ -129,7 +129,7 @@ public class SoapValueParser {
      */
     protected String parseValueFromSoapBody(ItemConfiguration itemConfiguration, SOAPBody soapBody, ItemMap mapping) {
         String value;
-        String readDataOutName = mapping.getReadDataOutName(itemConfiguration.getItemCommand());
+        String readDataOutName = mapping.getItemArgumentName(itemConfiguration.getItemCommand());
         NodeList nlDataOutNodes = soapBody.getElementsByTagName(readDataOutName);
         if (nlDataOutNodes != null && nlDataOutNodes.getLength() > 0) {
             // extract value from soap response
@@ -178,8 +178,7 @@ public class SoapValueParser {
     }
 
     private ItemConfiguration deriveConfiguration(String itemCommand, ItemConfiguration originalItemConfiguration) {
-        return new ItemConfiguration(itemCommand, originalItemConfiguration.getDataInValue(),
-                originalItemConfiguration.getAdditionalParameters());
+        return new ItemConfiguration(itemCommand, originalItemConfiguration.getArgumentValues());
     }
 
 }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
@@ -648,8 +648,10 @@ public class Tr064Comm {
         }
 
         // Mac Online Checker
-        SingleItemMap imMacOnline = new SingleItemMap("maconline", "GetSpecificHostEntry",
-                "urn:LanDeviceHosts-com:serviceId:Hosts1", "NewMACAddress", "NewActive", new SoapValueParser() {
+        SingleItemMap imMacOnline = SingleItemMap.builder().itemCommand("maconline")
+                .serviceId("urn:LanDeviceHosts-com:serviceId:Hosts1").itemArgumentName("NewActive")
+                .configArgumentNames("NewMACAddress").readServiceCommand("GetSpecificHostEntry")
+                .soapValueParser(new SoapValueParser() {
 
                     @Override
                     protected String parseValueFromSoapFault(ItemConfiguration itemConfiguration, SOAPFault soapFault,
@@ -672,15 +674,17 @@ public class Tr064Comm {
 
                         return value;
                     }
-                });
+                }).build();
         addItemMap(imMacOnline);
 
         addItemMap(new MultiItemMap(Arrays.asList("modelName", "manufacturerName", "softwareVersion", "serialNumber"),
                 "GetInfo", "urn:DeviceInfo-com:serviceId:DeviceInfo1", name -> "New" + WordUtils.capitalize(name)));
-        addItemMap(new SingleItemMap("wanip", "GetExternalIPAddress",
-                "urn:WANPPPConnection-com:serviceId:WANPPPConnection1", "", "NewExternalIPAddress"));
-        addItemMap(new SingleItemMap("externalWanip", "GetExternalIPAddress",
-                "urn:WANIPConnection-com:serviceId:WANIPConnection1", "", "NewExternalIPAddress"));
+        addItemMap(SingleItemMap.builder().itemCommand("wanip")
+                .serviceId("urn:WANPPPConnection-com:serviceId:WANPPPConnection1")
+                .itemArgumentName("NewExternalIPAddress").readServiceCommand("GetExternalIPAddress").build());
+        addItemMap(SingleItemMap.builder().itemCommand("externalWanip")
+                .serviceId("urn:WANIPConnection-com:serviceId:WANIPConnection1")
+                .itemArgumentName("NewExternalIPAddress").readServiceCommand("GetExternalIPAddress").build());
 
         // WAN Status
         addItemMap(new MultiItemMap(
@@ -688,10 +692,12 @@ public class Tr064Comm {
                         "wanPhysicalLinkStatus"),
                 "GetCommonLinkProperties", "urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1",
                 name -> name.replace("wan", "New")));
-        addItemMap(new SingleItemMap("wanTotalBytesSent", "GetTotalBytesSent",
-                "urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1", "", "NewTotalBytesSent"));
-        addItemMap(new SingleItemMap("wanTotalBytesReceived", "GetTotalBytesReceived",
-                "urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1", "", "NewTotalBytesReceived"));
+        addItemMap(SingleItemMap.builder().itemCommand("wanTotalBytesSent")
+                .serviceId("urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1")
+                .itemArgumentName("NewTotalBytesSent").readServiceCommand("GetTotalBytesSent").build());
+        addItemMap(SingleItemMap.builder().itemCommand("wanTotalBytesReceived")
+                .serviceId("urn:WANCIfConfig-com:serviceId:WANCommonInterfaceConfig1")
+                .itemArgumentName("NewTotalBytesReceived").readServiceCommand("GetTotalBytesReceived").build());
 
         // DSL Status
         addItemMap(new MultiItemMap(
@@ -704,20 +710,20 @@ public class Tr064Comm {
                 "urn:WANDSLIfConfig-com:serviceId:WANDSLInterfaceConfig1", name -> name.replace("dsl", "New")));
 
         // Wifi 2,4GHz
-        SingleItemMap imWifi24Switch = new SingleItemMap("wifi24Switch", "GetInfo",
-                "urn:WLANConfiguration-com:serviceId:WLANConfiguration1", "", "NewEnable");
-        imWifi24Switch.setWriteServiceCommand("SetEnable");
+        SingleItemMap imWifi24Switch = SingleItemMap.builder().itemCommand("wifi24Switch")
+                .serviceId("urn:WLANConfiguration-com:serviceId:WLANConfiguration1").itemArgumentName("NewEnable")
+                .readServiceCommand("GetInfo").writeServiceCommand("SetEnable").build();
         addItemMap(imWifi24Switch);
 
         // wifi 5GHz
-        SingleItemMap imWifi50Switch = new SingleItemMap("wifi50Switch", "GetInfo",
-                "urn:WLANConfiguration-com:serviceId:WLANConfiguration2", "", "NewEnable");
-        imWifi50Switch.setWriteServiceCommand("SetEnable");
+        SingleItemMap imWifi50Switch = SingleItemMap.builder().itemCommand("wifi50Switch")
+                .serviceId("urn:WLANConfiguration-com:serviceId:WLANConfiguration2").itemArgumentName("NewEnable")
+                .readServiceCommand("GetInfo").writeServiceCommand("SetEnable").build();
 
         // guest wifi
-        SingleItemMap imWifiGuestSwitch = new SingleItemMap("wifiGuestSwitch", "GetInfo",
-                "urn:WLANConfiguration-com:serviceId:WLANConfiguration3", "", "NewEnable");
-        imWifiGuestSwitch.setWriteServiceCommand("SetEnable");
+        SingleItemMap imWifiGuestSwitch = SingleItemMap.builder().itemCommand("wifiGuestSwitch")
+                .serviceId("urn:WLANConfiguration-com:serviceId:WLANConfiguration3").itemArgumentName("NewEnable")
+                .readServiceCommand("GetInfo").writeServiceCommand("SetEnable").build();
 
         // check if 5GHz wifi and/or guest wifi is available.
         Tr064Service svc5GHzWifi = determineServiceByItemMapping(imWifi50Switch);
@@ -744,21 +750,23 @@ public class Tr064Comm {
 
         // Phonebook Download
         // itemcommand is dummy: not a real item
-        ItemMap imPhonebook = new SingleItemMap("phonebook", "GetPhonebook",
-                "urn:X_AVM-DE_OnTel-com:serviceId:X_AVM-DE_OnTel1", "NewPhonebookID", "NewPhonebookURL");
+        ItemMap imPhonebook = SingleItemMap.builder().itemCommand("phonebook")
+                .serviceId("urn:X_AVM-DE_OnTel-com:serviceId:X_AVM-DE_OnTel1").configArgumentNames("NewPhonebookID")
+                .itemArgumentName("NewPhonebookURL").readServiceCommand("GetPhonebook").build();
         addItemMap(imPhonebook);
 
         // TAM (telephone answering machine) Switch
-        SingleItemMap imTamSwitch = new SingleItemMap("tamSwitch", "GetInfo",
-                "urn:X_AVM-DE_TAM-com:serviceId:X_AVM-DE_TAM1", "NewIndex", "NewEnable");
-        imTamSwitch.setWriteServiceCommand("SetEnable");
+        SingleItemMap imTamSwitch = SingleItemMap.builder().itemCommand("tamSwitch")
+                .serviceId("urn:X_AVM-DE_TAM-com:serviceId:X_AVM-DE_TAM1").configArgumentNames("NewIndex")
+                .itemArgumentName("NewEnable").readServiceCommand("GetInfo").writeServiceCommand("SetEnable").build();
         addItemMap(imTamSwitch);
 
         // New Messages per TAM ID
         // two requests needed: First gets URL to download tam info from, 2nd contains
         // info of messages
-        SingleItemMap imTamNewMessages = new SingleItemMap("tamNewMessages", "GetMessageList",
-                "urn:X_AVM-DE_TAM-com:serviceId:X_AVM-DE_TAM1", "NewIndex", "NewURL", new SoapValueParser() {
+        SingleItemMap imTamNewMessages = SingleItemMap.builder().itemCommand("tamNewMessages")
+                .serviceId("urn:X_AVM-DE_TAM-com:serviceId:X_AVM-DE_TAM1").configArgumentNames("NewIndex")
+                .itemArgumentName("NewURL").readServiceCommand("GetMessageList").soapValueParser(new SoapValueParser() {
 
                     @Override
                     protected String parseValueFromSoapBody(ItemConfiguration itemConfiguration, SOAPBody soapBody,
@@ -794,14 +802,16 @@ public class Tr064Comm {
 
                         return value;
                     }
-                });
+                }).build();
         addItemMap(imTamNewMessages);
 
         // Missed calls
         // two requests: 1st fetches URL to download call list, 2nd fetches xml call
         // list
-        SingleItemMap imMissedCalls = new SingleItemMap("missedCallsInDays", "GetCallList",
-                "urn:X_AVM-DE_OnTel-com:serviceId:X_AVM-DE_OnTel1", "NewDays", "NewCallListURL", new SoapValueParser() {
+        SingleItemMap imMissedCalls = SingleItemMap.builder().itemCommand("missedCallsInDays")
+                .serviceId("urn:X_AVM-DE_OnTel-com:serviceId:X_AVM-DE_OnTel1").itemArgumentName("NewCallListURL")
+                .readServiceCommand("GetCallList").configArgumentNames("NewDays")
+                .soapValueParser(new SoapValueParser() {
 
                     @Override
                     protected String parseValueFromSoapBody(ItemConfiguration itemConfiguration, SOAPBody soapBody,
@@ -814,8 +824,8 @@ public class Tr064Comm {
                         // extract how many days of call list should be examined for missed calls
                         String days = "3"; // default
                         if (!itemConfiguration.getArgumentValues().isEmpty()) {
-                            days = itemConfiguration.getArgumentValues().get(0); // set the days as defined in
-                                                                                 // item config.
+                            days = itemConfiguration.getArgumentValues().get(0); // set the days as defined in item
+                                                                                 // config.
                             // Otherwise default value of 3 is used
                         }
 
@@ -848,9 +858,8 @@ public class Tr064Comm {
 
                         return value;
                     }
-                });
+                }).build();
         addItemMap(imMissedCalls);
-
     }
 
     private void addItemMap(ItemMap itemMap) {

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Tr064Comm.java
@@ -860,6 +860,13 @@ public class Tr064Comm {
                     }
                 }).build();
         addItemMap(imMissedCalls);
+
+        // call deflection
+        SingleItemMap callDeflection = SingleItemMap.builder().itemCommand("callDeflectionSwitch")
+                .serviceId("urn:X_AVM-DE_OnTel-com:serviceId:X_AVM-DE_OnTel1").configArgumentNames("NewDeflectionId")
+                .itemArgumentName("NewEnable").readServiceCommand("GetDeflection")
+                .writeServiceCommand("SetDeflectionEnable").build();
+        addItemMap(callDeflection);
     }
 
     private void addItemMap(ItemMap itemMap) {

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/WritableItemMap.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/WritableItemMap.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.fritzboxtr064.internal;
 
+import org.openhab.core.types.Command;
+
 /**
  * {@link ItemMap} for a SOAP service which supports writing values to the FritzBox.
  *
@@ -16,10 +18,20 @@ package org.openhab.binding.fritzboxtr064.internal;
  */
 public interface WritableItemMap extends ItemMap {
 
+    /**
+     *
+     * @return TR064 service command for writing the item value.
+     */
     String getWriteServiceCommand();
 
-    String getWriteDataInName();
-
-    String getWriteDataInNameAdditional();
+    /**
+     * Get the input argument for the TR064 service command to set the item value.
+     * Combines the argument name for the service call with the value derived from
+     * the given command.
+     *
+     * @param cmd Command for which to set the new item value.
+     * @return Input argument for setting the item value corresponding to the command.
+     */
+    InputArgument getWriteInputArgument(Command cmd);
 
 }


### PR DESCRIPTION
Add a new command item type `callDeflectionSwitch` which reads and sets the current state of a call deflection entry in the FritzBox.

The first two commits are refactorings which unify the handling of input arguments for reading and writing calls to the FritzBox TR064 API and to simplify configuration of FritzBox items.