### PR TITLE
[ZWave] Added DHS manufacturer and DHS-WIN-BLW-DHS motor controller device

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/dhs/dhs-win-blw.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/dhs/dhs-win-blw.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+	<Model>DHS-WIN-BLW-DHS</Model>
+	<Label lang="en">Roller Shutter</Label>
+	<CommandClasses>
+		<Class><id>0x27</id></Class>
+		<Class><id>0x8e</id></Class>
+		<Class><id>0x70</id></Class>
+		<Class><id>0x72</id></Class>
+		<Class><id>0x75</id></Class>
+		<Class><id>0x77</id></Class>
+		<Class><id>0x86</id></Class>
+		<Class><id>0x25</id></Class>
+		<Class><id>0x20</id></Class>
+		<Class><id>0x26</id></Class>
+		<Class><id>0x87</id></Class>
+		<Class><id>0x85</id></Class>
+		<Class><id>0x2b</id></Class>
+		<Class><id>0x2c</id></Class>
+	</CommandClasses>
+	<Configuration>
+		<Parameter>
+			<Index>1</Index>
+			<Type>list</Type>
+			<Default>3</Default>
+			<Size>1</Size>
+			<Label lang="en">Buttons mode</Label>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">One push button</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Two paddles with Power and Direction</Label>
+			</Item>
+			<Item>
+				<Value>2</Value>
+				<Label lang="en">Two toggle switch</Label>
+			</Item>
+			<Item>
+				<Value>3</Value>
+				<Label lang="en">Two buttons with neutral position</Label>
+			</Item>
+			<Help lang="en">Controls number and function of buttons</Help>
+		</Parameter>
+
+		<Parameter>
+			<Index>2</Index>
+			<Type>word</Type>
+			<Default>0</Default>
+			<Size>2</Size>
+			<Help lang="en">Time period for the motor to continue operation.</Help>
+		</Parameter>
+		
+		<Parameter>
+			<Index>3</Index>
+			<Type>list</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Label lang="en">What to do on RF close command</Label>			
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">Close</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Ignore</Label>
+			</Item>
+			<Item>
+				<Value>2</Value>
+				<Label lang="en">Open</Label>
+			</Item>
+			<Item>
+				<Value>3</Value>
+				<Label lang="en">Open if closed, otherwise Close</Label>
+			</Item>
+			<Help lang="en">Defines how to interpret RF Off command. Can be used in conjunction with Auto Close function: Ignore - to open the door by motion detectors and close it back after some amount of time:</Help>
+		</Parameter>
+		<Parameter>
+			<Index>4</Index>
+			<Type>byte</Type>
+			<Default>50</Default>
+			<Size>1</Size>
+			<Label lang="en">Typical click timeout</Label>			
+			<Help lang="en">Typical time used to diff erentiate click, hold, double and triple clicks. 1-100ms in 10ms steps.</Help>
+		</Parameter>
+
+		<Parameter>
+			<Index>5</Index>
+			<Type>list</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">No</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Yes</Label>
+			</Item>
+			<Label lang="en">Invert buttons</Label>			
+			<Help lang="en"></Help>
+		</Parameter>
+
+		<Parameter>
+			<Index>6</Index>
+			<Type>list</Type>
+			<Default>1</Default>
+			<Size>1</Size>
+			<Label lang="en">Action on button press or hold</Label>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en"> Switch On, Off and dim using Basic Set and MultiLevel Start/Stop Changing</Label>
+			</Item>		
+			<Item>
+				<Value>2</Value>
+				<Label lang="en">Send Scene</Label>
+			</Item>		
+			<Help lang="en"> Deö nes which command should be sent to Association group on button press or hold. Scene mode will send 1 for Up event, 2 for Stop, 3 for Down</Help>
+		</Parameter>
+
+		<Parameter>
+			<Index>7</Index>
+			<Type>list</Type>
+			<Default>1</Default>
+			<Size>1</Size>
+			<Label lang="en">Set LED indication mode</Label>			
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">Disabled</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Show working state</Label>
+			</Item>
+			<Item>
+				<Value>2</Value>
+				<Label lang="en">Always on</Label>
+			</Item>
+			<Item>
+				<Value>3</Value>
+				<Label lang="en">Show opened state</Label>
+			</Item>
+			<Item>
+				<Value>4</Value>
+				<Label lang="en">Indicator command class</Label>
+			</Item>
+			<Help lang="en"></Help>
+		</Parameter>
+		<Parameter>
+			<Index>10</Index>
+			<Type>byte</Type>
+			<Default>60</Default>
+			<Size>1</Size>
+			<Label lang="en">Full close time</Label>			
+			<Help lang="en">Time to go from opened to closed state. Used to estimate the current level. Note that in Permanent motion mode the reported value would be Closed or Opened, while all Basic and Multilevel Set values (1-99, 255) would Open except 0 value that would Close.</Help>
+		</Parameter>		
+		<Parameter>
+			<Index>11</Index>
+			<Type>byte</Type>
+			<Default>60</Default>
+			<Size>1</Size>
+			<Label lang="en">Full open 	time</Label>			
+			<Help lang="en"> Time to go from closed to open state. This value may diff er from full close time for some blinds due to gravity. Used to estimate the current level. Note that in Permanent motion mode the reported value would be Closed or Opened, while all Basic and Multilevel Set values (1-99, 255) would Open except 0 value that would Close.</Help>
+		</Parameter>
+		<Parameter>
+			<Index>12</Index>
+			<Type>byte</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Label lang="en">Node Id of the blocking device</Label>			
+			<Help lang="en">: Id of the device which commands would be interpreted not as Open/Close, but as block/unblock. Useful with door opening detector: if the door is open, block the blind not to break shades while they move.</Help>
+		</Parameter>
+		<Parameter>
+			<Index>13</Index>
+			<Type>list</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">On</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Off</Label>
+			</Item>
+			<Label lang="en">On which command from blocking node to enable the protection</Label>			
+			<Help lang="en">Defines which command from blocking device to interpret as closed door and hence, unprotected.</Help>
+		</Parameter>
+		<Parameter>
+			<Index>14</Index>
+			<Type>list</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Label lang="en">Invert open and close relays</Label>			
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">No</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Yes</Label>
+			</Item>
+			<Help lang="en">Allow exchanging open and close relays if blind control is wired to the motor incorrectly</Help>
+		</Parameter>
+	</Configuration>
+
+	<Associations>
+		<Group>
+			<Index>1</Index>
+			<Maximum>10</Maximum>
+			<Label lang="en">Click</Label>
+			<Help lang="en">Click, press and hold of up/down buttons</Help>
+		</Group>
+		<Group>
+			<Index>2</Index>
+			<Maximum>10</Maximum>
+			<Label lang="en">Change</Label>
+			<Help lang="en">Send Reports on blind state change</Help>
+		</Group>
+	</Associations>
+</Product>
+

--- a/bundles/binding/org.openhab.binding.zwave/database/dhs/dhs-win-blw.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/dhs/dhs-win-blw.xml
@@ -24,7 +24,7 @@
 			<Type>list</Type>
 			<Default>3</Default>
 			<Size>1</Size>
-			<Label lang="en">Buttons mode</Label>
+			<Label lang="en">Button mode</Label>
 			<Item>
 				<Value>0</Value>
 				<Label lang="en">One push button</Label>
@@ -35,7 +35,7 @@
 			</Item>
 			<Item>
 				<Value>2</Value>
-				<Label lang="en">Two toggle switch</Label>
+				<Label lang="en">Two toggle switches</Label>
 			</Item>
 			<Item>
 				<Value>3</Value>
@@ -49,7 +49,7 @@
 			<Type>word</Type>
 			<Default>0</Default>
 			<Size>2</Size>
-			<Help lang="en">Time period for the motor to continue operation.</Help>
+			<Help lang="en">Time period for the motor to continue operation</Help>
 		</Parameter>
 		
 		<Parameter>
@@ -74,7 +74,7 @@
 				<Value>3</Value>
 				<Label lang="en">Open if closed, otherwise Close</Label>
 			</Item>
-			<Help lang="en">Defines how to interpret RF Off command. Can be used in conjunction with Auto Close function: Ignore - to open the door by motion detectors and close it back after some amount of time:</Help>
+			<Help lang="en">Defines how to interpret RF Off command. Can be used in conjunction with Auto Close function: Ignore - to open the door by motion detectors and close it back after some amount of time</Help>
 		</Parameter>
 		<Parameter>
 			<Index>4</Index>
@@ -82,7 +82,7 @@
 			<Default>50</Default>
 			<Size>1</Size>
 			<Label lang="en">Typical click timeout</Label>			
-			<Help lang="en">Typical time used to diff erentiate click, hold, double and triple clicks. 1-100ms in 10ms steps.</Help>
+			<Help lang="en">Typical time used to differentiate click, hold, double and triple clicks (1-100ms in 10ms steps)</Help>
 		</Parameter>
 
 		<Parameter>
@@ -110,13 +110,13 @@
 			<Label lang="en">Action on button press or hold</Label>
 			<Item>
 				<Value>1</Value>
-				<Label lang="en"> Switch On, Off and dim using Basic Set and MultiLevel Start/Stop Changing</Label>
+				<Label lang="en">Switch On, Off and dim using Basic Set and MultiLevel Start/Stop Changing</Label>
 			</Item>		
 			<Item>
 				<Value>2</Value>
 				<Label lang="en">Send Scene</Label>
 			</Item>		
-			<Help lang="en"> Deö nes which command should be sent to Association group on button press or hold. Scene mode will send 1 for Up event, 2 for Stop, 3 for Down</Help>
+			<Help lang="en">Defines which command should be sent to Association group on button press or hold. Scene mode will send 1 for Up event, 2 for Stop, 3 for Down</Help>
 		</Parameter>
 
 		<Parameter>
@@ -153,7 +153,7 @@
 			<Default>60</Default>
 			<Size>1</Size>
 			<Label lang="en">Full close time</Label>			
-			<Help lang="en">Time to go from opened to closed state. Used to estimate the current level. Note that in Permanent motion mode the reported value would be Closed or Opened, while all Basic and Multilevel Set values (1-99, 255) would Open except 0 value that would Close.</Help>
+			<Help lang="en">Time to go from opened to closed state. Used to estimate the current level. Note that in Permanent motion mode the reported value would be Closed or Opened, while all Basic and Multilevel Set values (1-99, 255) would Open except 0 value that would Close</Help>
 		</Parameter>		
 		<Parameter>
 			<Index>11</Index>
@@ -161,7 +161,7 @@
 			<Default>60</Default>
 			<Size>1</Size>
 			<Label lang="en">Full open 	time</Label>			
-			<Help lang="en"> Time to go from closed to open state. This value may diff er from full close time for some blinds due to gravity. Used to estimate the current level. Note that in Permanent motion mode the reported value would be Closed or Opened, while all Basic and Multilevel Set values (1-99, 255) would Open except 0 value that would Close.</Help>
+			<Help lang="en">Time to go from closed to open state. This value may differ from full close time for some blinds due to gravity. Used to estimate the current level. Note that in Permanent motion mode the reported value would be Closed or Opened, while all Basic and Multilevel Set values (1-99, 255) would Open except 0 value that would Close</Help>
 		</Parameter>
 		<Parameter>
 			<Index>12</Index>
@@ -169,7 +169,7 @@
 			<Default>0</Default>
 			<Size>1</Size>
 			<Label lang="en">Node Id of the blocking device</Label>			
-			<Help lang="en">: Id of the device which commands would be interpreted not as Open/Close, but as block/unblock. Useful with door opening detector: if the door is open, block the blind not to break shades while they move.</Help>
+			<Help lang="en">Id of the device which commands would be interpreted not as Open/Close, but as block/unblock. Useful with door opening detector: if the door is open, block the blind not to break shades while they move</Help>
 		</Parameter>
 		<Parameter>
 			<Index>13</Index>
@@ -185,7 +185,7 @@
 				<Label lang="en">Off</Label>
 			</Item>
 			<Label lang="en">On which command from blocking node to enable the protection</Label>			
-			<Help lang="en">Defines which command from blocking device to interpret as closed door and hence, unprotected.</Help>
+			<Help lang="en">Defines which command from blocking device to interpret as closed door and hence, unprotected</Help>
 		</Parameter>
 		<Parameter>
 			<Index>14</Index>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -4049,4 +4049,17 @@
 			<ConfigFile>fireangle/zst630.xml</ConfigFile>
 		</Product>
 	</Manufacturer>
-</Manufacturers>
+	<Manufacturer>
+		<Id>0097</Id>
+		<Name>DHS</Name>
+		<Product>
+			<Reference>
+				<Type>0055</Type>
+				<Id>0024</Id>
+			</Reference>
+			<Model>DHS-WIN-BLW-DHS</Model>
+			<Label lang="en">DHS Z-Wave Tubular Motor Controllerl</Label>
+			<ConfigFile>dhs/dhs-win-blw.xml</ConfigFile>
+		</Product>
+	</Manufacturer>
+	</Manufacturers>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -4054,8 +4054,8 @@
 		<Name>DHS</Name>
 		<Product>
 			<Reference>
-				<Type>0055</Type>
-				<Id>0024</Id>
+				<Type>0024</Type>
+				<Id>0055</Id>
 			</Reference>
 			<Model>DHS-WIN-BLW-DHS</Model>
 			<Label lang="en">DHS Z-Wave Tubular Motor Controllerl</Label>


### PR DESCRIPTION
Copied from Fibaro FGRM222 and update using manufacturer's documentation from [here](https://www.digitalhomesystems.com.au/documentation/DHS_Shutter_ACController_Manual.pdf).

I've assumed that "rangemapped" == "list" and "range" == "byte" when size==1 or "word" when size==2.