### PR TITLE
[vdr1] change logLevel for could not connect to DEBUG

### DIFF
--- a/bundles/binding/org.openhab.binding.vdr/src/main/java/org/openhab/binding/vdr/internal/VDRConnection.java
+++ b/bundles/binding/org.openhab.binding.vdr/src/main/java/org/openhab/binding/vdr/internal/VDRConnection.java
@@ -63,7 +63,7 @@ public class VDRConnection {
             res = connection.send(cmd);
             logger.debug("Received Message from VDR: {}", res.getMessage());
         } catch (Exception e) {
-            logger.error("Could not connect to VDR on {}: {}", mIp + ":" + mPort, e);
+            logger.debug("Could not connect to VDR on {}: {}", mIp + ":" + mPort, e);
         } finally {
             if (connection != null) {
                 try {


### PR DESCRIPTION
VDR is not a typical always on service, so it's very common that vdr is not available.

Signed-off-by: Udo Hartmann udo1toni@gmail.com