### PR TITLE
[EpsonProjector] Adjustments for direct projector TCP/IP connection implemented

### DIFF
--- a/bundles/binding/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/connector/EpsonProjectorTcpConnector.java
+++ b/bundles/binding/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/connector/EpsonProjectorTcpConnector.java
@@ -51,6 +51,12 @@ public class EpsonProjectorTcpConnector implements EpsonProjectorConnector {
             socket = new Socket(ip, port);
             in = socket.getInputStream();
             out = socket.getOutputStream();
+
+            // send ip handshake to projector
+            byte[] handshake = { 0x45, 0x53, 0x43, 0x2F, 0x56, 0x50, 0x2E, 0x6E, 0x65, 0x74, 0x10, 0x03, 0x00, 0x00,
+                    0x00, 0x00 };
+            out.write(handshake);
+
         } catch (Exception e) {
             throw new EpsonProjectorException(e);
         }

--- a/bundles/binding/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
+++ b/bundles/binding/org.openhab.binding.epsonprojector/src/main/java/org/openhab/binding/epsonprojector/internal/EpsonProjectorDevice.java
@@ -401,6 +401,11 @@ public class EpsonProjectorDevice {
             throw new EpsonProjectorException("No response received");
         }
 
+        // filter tcp handshake response
+        if (response.contains("ESC/VP.net")) {
+            response = response.substring(16, response.length() - 1);
+        }
+
         response = response.replace("\r:", "");
         logger.debug("Response: '{}'", response);
 
@@ -443,6 +448,16 @@ public class EpsonProjectorDevice {
             try {
                 String[] pieces = response.split("=");
                 String str = pieces[1].trim();
+
+                // convert answer "ON", "OFF" to "00", "01" e.g. MUTE, VREVERSE, HREVERSE
+                switch (str) {
+                    case "ON":
+                        str = "00";
+                        break;
+                    case "OFF":
+                        str = "01";
+                        break;
+                }
 
                 return Integer.parseInt(str, radix);
 


### PR DESCRIPTION
Until now it was only possible to operate an Epson projector with a SERIAL2TCP adapter. Because of my changes this now also goes without adapter