### PR TITLE
[Zibase] Cleaning the zibase message buffer: fix of #5623

### DIFF
--- a/bundles/binding/org.openhab.binding.zibase/src/main/java/org/openhab/binding/zibase/internal/ZibaseListener.java
+++ b/bundles/binding/org.openhab.binding.zibase/src/main/java/org/openhab/binding/zibase/internal/ZibaseListener.java
@@ -153,6 +153,12 @@ public class ZibaseListener extends Thread {
                     ZbResponse zbResponse = new ZbResponse(receivePacket.getData());
                     logger.debug("ZIBASE MESSAGE: " + zbResponse.getMessage());
                     publishEvents(zbResponse);
+
+                    // reset buffer
+                    for (int i = 0; i < receiveData.length; i++) {
+                        receiveData[i] = 0;
+                    }
+
                 }
                 zibase.hostUnregistering(listenerHost, listenerPort);
 

--- a/bundles/binding/org.openhab.binding.zibase/src/main/java/org/openhab/binding/zibase/internal/ZibaseListener.java
+++ b/bundles/binding/org.openhab.binding.zibase/src/main/java/org/openhab/binding/zibase/internal/ZibaseListener.java
@@ -13,6 +13,7 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/bundles/binding/org.openhab.binding.zibase/src/main/java/org/openhab/binding/zibase/internal/ZibaseListener.java
+++ b/bundles/binding/org.openhab.binding.zibase/src/main/java/org/openhab/binding/zibase/internal/ZibaseListener.java
@@ -155,10 +155,7 @@ public class ZibaseListener extends Thread {
                     publishEvents(zbResponse);
 
                     // reset buffer
-                    for (int i = 0; i < receiveData.length; i++) {
-                        receiveData[i] = 0;
-                    }
-
+                    Arrays.fill(receivePacket.getData(), 0, receivePacket.getLength(), (byte) 0);
                 }
                 zibase.hostUnregistering(listenerHost, listenerPort);
 


### PR DESCRIPTION
This is a fix of issue #5623: garbled zibase messages

The buffer was indeed not cleared, causing the previous messages to remain visible if longer.
