### PR TITLE
[Serial] Added setting to select charset for string encoding

### DIFF
--- a/bundles/binding/org.openhab.binding.serial/README.md
+++ b/bundles/binding/org.openhab.binding.serial/README.md
@@ -1,6 +1,6 @@
 # Serial Binding
 
-The Serial binding allows openHAB to communicate in ASCII over serial ports attached to the openHAB server.
+The Serial binding allows openHAB to communicate over serial ports attached to the openHAB server.
 
 | Item Type | Function |
 |-----------|----------|
@@ -64,9 +64,10 @@ where:
 * `<port>` is the identification of the serial port on the host system, e.g. `COM1` on Windows, `/dev/ttyS0` on Linux or `/dev/tty.PL2303-0000103D` on Mac.  The same `<port>` can be bound to multiple items.
 * `<baudrate>` is the baud rate of the port. If no baud rate is specified, the binding defaults to 9600 baud.
 * `REGEX(<regular expression>)` allows parsing for special strings or numbers in the serial stream. A capture group (e.g. REGEX(Position:([0-9.]*)) can be used to capture "12" in `Position:12` or substitution (e.g. REGEX(s/Position:100/ON/) or REGEX(s/Position:100/ON/g)) to replace (FIRST or ALL) "Position:100" strings in response with "ON". This is based on the [RegEx Service](https://github.com/openhab/openhab1-addons/wiki/Transformations#regex-transformation-service) and [ESH RegExTransformationService](https://github.com/eclipse/smarthome/tree/master/extensions/transform/org.eclipse.smarthome.transform.regex). This is optional.
-* `BASE64` enables the Base64 mode. With this mode all data received on the serial port is saved in Base64 format. All data that is sent to the serial port also has to be Base64 encoded. (This was implemented because some serial devices are using bytes that are not supported by the REST interface).
+* `BASE64()` enables the Base64 mode. With this mode all data received on the serial port is saved in Base64 format. All data that is sent to the serial port also has to be Base64 encoded. (This was implemented because some serial devices are using bytes that are not supported by the REST interface).
 * `ON(<On string>),OFF(<Off string>)` used in conjunction with a Switch, this mapping will send specific commands to serial port and also match a serial command to specific ON/OFF state. This makes it unnecessary to use a rule to send a command to serial.
 * `UP(<Up string>),DOWN(<Down string>),STOP(<Stop string>)` used in conjunction with a Rollershutter, this mapping will send specific commands to serial port. Use REGEX to parse Rollershutter postion (0-100%) coming as feedback over serial link.
+* `CHARSET(<charset>)` set's the charset to be used for converting to a String and back to bytes when writing. (e.g. UTF-8, ISO-8859-1, etc.)
 
 Base64 can be decoded in the rules by importing `javax.xml.bind.DatatypeConverter` and then decoding the value like this:
 

--- a/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialBinding.java
+++ b/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialBinding.java
@@ -189,6 +189,7 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
         String downCommand = null;
         String stopCommand = null;
         String format = null;
+        String charset = null;
 
         int parameterSplitterAt = bindingConfig.indexOf(",");
 
@@ -196,31 +197,38 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
             String[] split = bindingConfig.substring(parameterSplitterAt + 1, bindingConfig.length()).split("\\),");
             for (int i = 0; i < split.length; i++) {
                 String substring = split[i];
+                
+                //Remove the closing bracket on the last setting, because this isn't removed by the split.
+                if (i == split.length - 1 && substring.endsWith(")"))
+                	substring = substring.substring(0, substring.length() - 1);
 
                 if (substring.startsWith("REGEX(")) {
-                    pattern = substring.substring(6, substring.length()-1);
+                    pattern = substring.substring(6, substring.length());
                     logger.debug("REGEX: '{}'", pattern);
                 } else if (substring.startsWith("FORMAT(")) {
-                    format = substring.substring(7, substring.length()-1);
+                    format = substring.substring(7, substring.length());
                     logger.debug("FORMAT: '{}'", format);
-                } else if (substring.equals("BASE64")) {
+                } else if (substring.equals("BASE64") || substring.equals("BASE64(")) {
                     base64 = true;
                     logger.debug("Base64-Mode enabled");
                 } else if (substring.startsWith("ON(")) {
-                    onCommand = substring.substring(3, substring.length()-1);
+                    onCommand = substring.substring(3, substring.length());
                     logger.debug("ON: '{}'", onCommand);
                 } else if (substring.startsWith("OFF(")) {
-                    offCommand = substring.substring(4, substring.length()-1);
+                    offCommand = substring.substring(4, substring.length());
                     logger.debug("OFF: '{}'", offCommand);
                 } else if (substring.startsWith("UP(")) {
-                    upCommand = substring.substring(3, substring.length()-1);
+                    upCommand = substring.substring(3, substring.length());
                     logger.debug("UP: '{}'", upCommand);
                 } else if (substring.startsWith("DOWN(")) {
-                    downCommand = substring.substring(5, substring.length()-1);
+                    downCommand = substring.substring(5, substring.length());
                     logger.debug("DOWN: '{}'", downCommand);
                 } else if (substring.startsWith("STOP(")) {
-                    stopCommand = substring.substring(5, substring.length()-1);
+                    stopCommand = substring.substring(5, substring.length());
                     logger.debug("STOP: '{}'", stopCommand);
+                } else if (substring.startsWith("CHARSET(")) {
+                    charset = substring.substring(8, substring.length());
+                    logger.debug("CHARSET: '{}'", charset);
                 } else {
                     logger.warn("Unrecognized transform: {}", substring);
                 }
@@ -248,9 +256,9 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
         SerialDevice serialDevice = serialDevices.get(port);
         if (serialDevice == null) {
             if (baudRate > 0) {
-                serialDevice = new SerialDevice(port, baudRate);
+                serialDevice = new SerialDevice(port, baudRate, charset);
             } else {
-                serialDevice = new SerialDevice(port);
+                serialDevice = new SerialDevice(port, charset);
             }
 
             serialDevice.setEventPublisher(eventPublisher);


### PR DESCRIPTION
- Adds a new setting to select charset for string encoding.
- Problem parsing more than one setting is solved.
- The BASE64 setting can now also be written as BASE64() and then it
will be parsed correctly at any position inside the string.
- Readme updated regarding the new charset setting and the new BASE64
settings format.

Forum link: https://community.openhab.org/t/strange-problem-with-serial-binding/43230

Signed-off-by: David Masshardt <david@masshardt.ch> (github:
TheNetStriker)