### PR TITLE
[dynamodb] Introduce Karaf support

### DIFF
--- a/bundles/persistence/org.openhab.persistence.dynamodb/ESH-INF/config/config.xml
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/ESH-INF/config/config.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
+        http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+    <config-description uri="persistence:dynamodb">
+
+        <!-- 
+			############################ Amazon DynamoDB Persistence Service ##################################
+			#
+			# The following parameters are used to configure Amazon DynamoDB Persistence.
+			# 
+			# Further details at https://docs.openhab.org/addons/persistence/dynamodb/readme.html
+			#
+			
+			#
+			# CONNECTION SETTINGS (follow OPTION 1 or OPTION 2)
+			#
+			
+			# OPTION 1 (using accessKey and secretKey)
+			#accessKey=AKIAIOSFODNN7EXAMPLE
+			#secretKey=3+AAAAABBBbbbCCCCCCdddddd+7mnbIOLH
+			#region=eu-west-1
+			
+			# OPTION 2 (using profilesConfigFile and profile)
+			# where profilesConfigFile points to AWS credentials file 
+			#profilesConfigFile=/etc/openhab2/aws_creds
+			#profile=fooprofile
+			#region=eu-west-1
+			
+			# Credentials file example:
+			#
+			# [fooprofile]
+			# aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+			# aws_secret_access_key=3+AAAAABBBbbbCCCCCCdddddd+7mnbIOLH
+			
+			
+			#
+			# ADVANCED CONFIGURATION (OPTIONAL)
+			#
+			
+			# read capacity for the created tables
+			#readCapacityUnits=1
+			
+			# write capacity for the created tables
+			#writeCapacityUnits=1
+			
+			# table prefix used in the name of created tables
+			#tablePrefix=openhab-
+         -->
+        <parameter name="region" type="text" required="true">
+            <label>AWS region ID</label>
+            <description><![CDATA[AWS region ID as described in Step 2 in Setting up Amazon account.<br />
+            The region needs to match the region of the AWS user that will access Amazon DynamoDB.<br />
+            For example, eu-west-1.]]></description>
+        </parameter>
+
+        <parameter name="accessKey" type="text" required="false">
+            <label>AWS access key</label>
+            <description><![CDATA[AWS access key of the AWS user that will access Amazon DynamoDB.
+            <br />
+            Give either 1) access key and secret key, or 2) credentials file and profile name.
+            ]]></description>
+        </parameter>
+        
+        <parameter name="secretKey" type="text" required="false">
+            <label>AWS secret key</label>
+            <description><![CDATA[AWS secret key of the AWS user that will access Amazon DynamoDB.
+            <br />
+            Give either 1) access key and secret key, or 2) credentials file and profile name.
+            ]]></description>
+        </parameter>
+        
+        
+        <parameter name="profilesConfigFile" type="text" required="false">
+            <label>AWS credentials file</label>
+            <description><![CDATA[Path to the AWS credentials file. <br />
+            For example, /etc/openhab2/aws_creds. 
+            Please note that the user that runs openHAB must have approriate read rights to the credential file.
+            <br />
+            Give either 1) access key and secret key, or 2) credentials file and profile name.
+            ]]></description>
+        </parameter>
+        
+        <parameter name="profile" type="text" required="false">
+            <label>Profile name</label>
+            <description><![CDATA[Name of the profile to use in AWS credentials file
+            <br />
+            Give either 1) access key and secret key, or 2) credentials file and profile name.
+            ]]></description>
+        </parameter>
+        
+
+        
+        <parameter name="readCapacityUnits" type="integer" required="false" min="1">        
+            <description>Read capacity for the created tables. Default is 1.</description>
+            <label>Read capacity</label>
+            <advanced>true</advanced>
+        </parameter>
+       
+        <parameter name="writeCapacityUnits" type="integer" required="false" min="1">        
+            <label>Write capacity</label>
+            <description>Write capacity for the created tables. Default is 1.</description>
+            <advanced>true</advanced>
+        </parameter>
+        
+        <parameter name="tablePrefix" type="text" required="false">        
+            <label>Table prefix</label>
+            <description>Table prefix used in the name of created tables. Default is openhab-</description>
+            <advanced>true</advanced>
+        </parameter>
+        
+    </config-description>
+
+</config-description:config-descriptions>

--- a/bundles/persistence/org.openhab.persistence.dynamodb/OSGI-INF/dynamodb.xml
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/OSGI-INF/dynamodb.xml
@@ -18,4 +18,5 @@
    <property name="service.config.description.uri" type="String" value="persistence:dynamodb"/>
    <property name="service.config.label" type="String" value="Amazon DynamoDB Persistence"/>
    <property name="service.config.category" type="String" value="persistence"/>
+   <property name="service.pid" type="String" value="org.openhab.dynamodb"/>
 </scr:component>

--- a/bundles/persistence/org.openhab.persistence.dynamodb/OSGI-INF/dynamodb.xml
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/OSGI-INF/dynamodb.xml
@@ -15,4 +15,7 @@
       <provide interface="org.openhab.core.persistence.PersistenceService"/>
    </service>
    <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <property name="service.config.description.uri" type="String" value="persistence:dynamodb"/>
+   <property name="service.config.label" type="String" value="Amazon DynamoDB Persistence"/>
+   <property name="service.config.category" type="String" value="persistence"/>
 </scr:component>

--- a/bundles/persistence/org.openhab.persistence.dynamodb/OSGI-INF/dynamodb.xml
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/OSGI-INF/dynamodb.xml
@@ -9,7 +9,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" deactivate="deactivate" name="org.openhab.persistence.dynamodb" immediate="true" configuration-pid="org.openhab.dynamodb" configuration-policy="optional">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" deactivate="deactivate" name="org.openhab.persistence.dynamodb" configuration-pid="org.openhab.dynamodb">
    <implementation class="org.openhab.persistence.dynamodb.internal.DynamoDBPersistenceService"/>
    <service>
       <provide interface="org.openhab.core.persistence.PersistenceService"/>

--- a/bundles/persistence/org.openhab.persistence.dynamodb/build.properties
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/build.properties
@@ -1,6 +1,7 @@
 output.. = target/classes/
 bin.includes = META-INF/,\
                OSGI-INF/,\
+               ESH-INF/,\
                .,\
                lib/aws-java-sdk-core-1.11.213.jar,\
                lib/aws-java-sdk-dynamodb-1.11.213.jar,\

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfig.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfig.java
@@ -159,7 +159,12 @@ public class DynamoDBConfig {
     }
 
     private static void invalidRegionLogHelp(String region) {
+        Regions[] regions = Regions.values();
+        String[] regionNames = new String[regions.length];
+        for (int i = 0; i < regions.length; i++) {
+            regionNames[i] = regions[i].getName();
+        }
         logger.error("Specify valid AWS region to use, got {}. Valid values include: {}", region,
-                StringUtils.join(Regions.values(), ','));
+                StringUtils.join(regionNames, ','));
     }
 }

--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -43,6 +43,7 @@
                                 <artifact><file>src/main/resources/conf/dmx.cfg</file><type>cfg</type><classifier>dmx</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/dropbox.cfg</file><type>cfg</type><classifier>dropbox</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/dsmr.cfg</file><type>cfg</type><classifier>dsmr</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/dynamodb.cfg</file><type>cfg</type><classifier>dynamodb</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/ebus.cfg</file><type>cfg</type><classifier>ebus</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/ecobee.cfg</file><type>cfg</type><classifier>ecobee</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/ecotouch.cfg</file><type>cfg</type><classifier>ecotouch</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
@@ -5,6 +5,15 @@
 # Further details at https://docs.openhab.org/addons/persistence/dynamodb/readme.html
 #
 
+# PID SETTING
+#
+# When configuring the persistence using file (instead PaperUI),
+# make sure the first line in the configuration file is the 
+# pid definition (remove the comment prefix #)
+
+#pid:pid:org.openhab.dynamodb
+
+
 #
 # CONNECTION SETTINGS (follow OPTION 1 or OPTION 2)
 #

--- a/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
@@ -1,0 +1,42 @@
+############################ Amazon DynamoDB Persistence Service ##################################
+#
+# The following parameters are used to configure Amazon DynamoDB Persistence.
+# 
+# Further details at https://docs.openhab.org/addons/persistence/dynamodb/readme.html
+#
+
+#
+# CONNECTION SETTINGS (follow OPTION 1 or OPTION 2)
+#
+
+# OPTION 1 (using accessKey and secretKey)
+#accessKey=AKIAIOSFODNN7EXAMPLE
+#secretKey=3+AAAAABBBbbbCCCCCCdddddd+7mnbIOLH
+#region=eu-west-1
+
+# OPTION 2 (using profilesConfigFile and profile)
+# where profilesConfigFile points to AWS credentials file 
+# Please note that the user that runs openHAB must have approriate read rights to the credential file.
+#profilesConfigFile=/etc/openhab2/aws_creds
+#profile=fooprofile
+#region=eu-west-1
+
+# Credentials file example:
+#
+# [fooprofile]
+# aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+# aws_secret_access_key=3+AAAAABBBbbbCCCCCCdddddd+7mnbIOLH
+
+
+#
+# ADVANCED CONFIGURATION (OPTIONAL)
+#
+
+# read capacity for the created tables
+#readCapacityUnits=1
+
+# write capacity for the created tables
+#writeCapacityUnits=1
+
+# table prefix used in the name of created tables
+#tablePrefix=openhab-

--- a/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
@@ -2,7 +2,7 @@
 #
 # The following parameters are used to configure Amazon DynamoDB Persistence.
 # 
-# Further details at https://docs.openhab.org/addons/persistence/dynamodb/readme.html
+# Further details at https://www.openhab.org/addons/persistence/dynamodb/
 #
 
 # PID SETTING

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -670,6 +670,13 @@
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.influxdb/${project.version}</bundle>
     <configfile finalname="${openhab.conf}/services/influxdb.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/influxdb</configfile>
   </feature>
+  
+  <feature name="openhab-persistence-dynamodb" description="Amazon DynamoDB Persistence" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.dynamodb/${project.version}</bundle>
+    <configfile finalname="${openhab.conf}/services/dynamodb.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/dynamodb</configfile>
+  </feature>
 
   <feature name="openhab-persistence-gcal" description="Google Calendar Presence Simulator" version="${project.version}">
     <feature>openhab-runtime-base</feature>


### PR DESCRIPTION
This PR introduces the changes discussed in #5334. I highly recommend reading that thread for background.

Currently DynamoDB is not part of the official addon bundle since it not supporting up-to-par with new openHAB2 packaging requirements. It is working though without any issues using textual configuration.

To meet openHAB2 requirements, this PR introduces:
- Karaf feature `openhab-persistence-dynamodb`
- PaperUI configuration support (actually I think this might the first persistence to have this)

Furthermore, `service.pid` is now declared, which seems to help with the textual configuration (in case someone prefers it over UI). I also had to adjust some OSGI parameters to make configuration reloading work as it should with the UI (once again, details in #5334).

I hope that with these changes, the DynamoDB persistence would be once again as part of the official bundle.