### PR TITLE
Remove unused Maven properties and jdeb plugin

### DIFF
--- a/bundles/action/org.openhab.action.astro/pom.xml
+++ b/bundles/action/org.openhab.action.astro/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.astro</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.astro</bundle.namespace>
-		<deb.name>openhab-addon-action-astro</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.astro</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Astro Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.ciscospark/pom.xml
+++ b/bundles/action/org.openhab.action.ciscospark/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.ciscospark</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.ciscospark</bundle.namespace>
-		<deb.name>openhab-addon-action-ciscospark</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.ciscospark</artifactId>
@@ -21,14 +14,6 @@
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
     <dependencies>
         <dependency>
             <groupId>javax.json</groupId>

--- a/bundles/action/org.openhab.action.dscalarm/pom.xml
+++ b/bundles/action/org.openhab.action.dscalarm/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.dscalarm</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.dscalarm</bundle.namespace>
-		<deb.name>openhab-addon-action-dscalarm</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.dscalarm</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB DSC Alarm Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.ecobee/pom.xml
+++ b/bundles/action/org.openhab.action.ecobee/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.ecobee</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.ecobee</bundle.namespace>
-		<deb.name>openhab-addon-action-ecobee</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.ecobee</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Ecobee Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.harmonyhub/pom.xml
+++ b/bundles/action/org.openhab.action.harmonyhub/pom.xml
@@ -6,13 +6,6 @@
         <version>1.13.0-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <bundle.symbolicName>org.openhab.action.harmonyhub</bundle.symbolicName>
-        <bundle.namespace>org.openhab.action.harmonyhub</bundle.namespace>
-        <deb.name>openhab-addon-action-harmonyhub</deb.name>
-		<deb.description>${project.name}</deb.description>
-    </properties>
-
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.openhab.action</groupId>
     <artifactId>org.openhab.action.harmonyhub</artifactId>
@@ -20,15 +13,5 @@
     <name>openHAB HarmonyHub Action</name>
 
     <packaging>eclipse-plugin</packaging>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.vafer</groupId>
-                <artifactId>jdeb</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
 
 </project>

--- a/bundles/action/org.openhab.action.homematic/pom.xml
+++ b/bundles/action/org.openhab.action.homematic/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.homematic</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.homematic</bundle.namespace>
-		<deb.name>openhab-addon-action-homematic</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.homematic</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Homematic Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.mail/pom.xml
+++ b/bundles/action/org.openhab.action.mail/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.mail</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.mail</bundle.namespace>
-		<deb.name>openhab-addon-action-mail</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.mail</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Mail Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.mios/pom.xml
+++ b/bundles/action/org.openhab.action.mios/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.mios</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.mios</bundle.namespace>
-		<deb.name>openhab-addon-action-mios</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.mios</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB MiOS Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.mqtt/pom.xml
+++ b/bundles/action/org.openhab.action.mqtt/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.mqtt</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.mqtt</bundle.namespace>
-		<deb.name>openhab-addon-action-mqtt</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.mqtt</artifactId>
@@ -21,13 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/bundles/action/org.openhab.action.openwebif/pom.xml
+++ b/bundles/action/org.openhab.action.openwebif/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.openwebif</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.openwebif</bundle.namespace>
-		<deb.name>openhab-addon-action-openwebif</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.openwebif</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB OpenWebIf Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.pebble/pom.xml
+++ b/bundles/action/org.openhab.action.pebble/pom.xml
@@ -6,13 +6,6 @@
         <version>1.13.0-SNAPSHOT</version>
     </parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.pebble</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.pebble</bundle.namespace>
-		<deb.name>openhab-addon-action-pebble</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.pebble</artifactId>
@@ -21,13 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/bundles/action/org.openhab.action.prowl/pom.xml
+++ b/bundles/action/org.openhab.action.prowl/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.prowl</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.prowl</bundle.namespace>
-		<deb.name>openhab-addon-action-prowl</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.prowl</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Prowl Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.pushbullet/pom.xml
+++ b/bundles/action/org.openhab.action.pushbullet/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.pushbullet</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.pushbullet</bundle.namespace>
-		<deb.name>openhab-addon-action-pushbullet</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.pushbullet</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Pushbullet Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.pushover/pom.xml
+++ b/bundles/action/org.openhab.action.pushover/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.pushover</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.pushover</bundle.namespace>
-		<deb.name>openhab-addon-action-pushover</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.pushover</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Pushover Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.pushsafer/pom.xml
+++ b/bundles/action/org.openhab.action.pushsafer/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.pushsafer</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.pushsafer</bundle.namespace>
-		<deb.name>openhab-addon-action-pushsafer</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.pushsafer</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Pushsafer Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.satel/pom.xml
+++ b/bundles/action/org.openhab.action.satel/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.satel</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.satel</bundle.namespace>
-		<deb.name>openhab-addon-action-satel</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.satel</artifactId>
@@ -21,13 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/bundles/action/org.openhab.action.squeezebox/pom.xml
+++ b/bundles/action/org.openhab.action.squeezebox/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.squeezebox</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.squeezebox</bundle.namespace>
-		<deb.name>openhab-addon-action-squeezebox</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.squeezebox</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Squeezebox Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.telegram/pom.xml
+++ b/bundles/action/org.openhab.action.telegram/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.telegram</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.telegram</bundle.namespace>
-		<deb.name>openhab-addon-action-telegram</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.telegram</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Telegram Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.tinkerforge/pom.xml
+++ b/bundles/action/org.openhab.action.tinkerforge/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.tinkerforge</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.tinkerforge</bundle.namespace>
-		<deb.name>openhab-addon-action-tinkerforge</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.tinkerforge</artifactId>
@@ -21,13 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/bundles/action/org.openhab.action.twitter/pom.xml
+++ b/bundles/action/org.openhab.action.twitter/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.twitter</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.twitter</bundle.namespace>
-		<deb.name>openhab-addon-action-twitter</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.twitter</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Twitter Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.weather/pom.xml
+++ b/bundles/action/org.openhab.action.weather/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.weather</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.weather</bundle.namespace>
-		<deb.name>openhab-addon-action-weather</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.weather</artifactId>
@@ -21,13 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/bundles/action/org.openhab.action.xbmc/pom.xml
+++ b/bundles/action/org.openhab.action.xbmc/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.xbmc</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.xbmc</bundle.namespace>
-		<deb.name>openhab-addon-action-xbmc</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.xbmc</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB XBMC Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.xmpp/pom.xml
+++ b/bundles/action/org.openhab.action.xmpp/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.xmpp</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.xmpp</bundle.namespace>
-		<deb.name>openhab-addon-action-xmpp</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.xmpp</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB XMPP Action</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/action/org.openhab.action.xpl/pom.xml
+++ b/bundles/action/org.openhab.action.xpl/pom.xml
@@ -6,14 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.action.xpl</bundle.symbolicName>
-		<bundle.namespace>org.openhab.action.xpl</bundle.namespace>
-		<deb.name>openhab-addon-action-xpl</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-xpl</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.action</groupId>
 	<artifactId>org.openhab.action.xpl</artifactId>
@@ -22,13 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/bundles/binding/org.openhab.binding.akm868/pom.xml
+++ b/bundles/binding/org.openhab.binding.akm868/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.akm868</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.akm868</bundle.namespace>
-		<deb.name>openhab-addon-binding-akm868</deb.name>
-		<deb.description>openhab addon binding AKM868</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.akm868</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB AKM868 Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.alarmdecoder/pom.xml
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB AlarmDecoder Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.alarmdecoder</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.alarmdecoder</bundle.namespace>
-		<deb.name>openhab-addon-binding-alarmdecoder</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.alarmdecoder</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.anel/pom.xml
+++ b/bundles/binding/org.openhab.binding.anel/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.anel</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.anel</bundle.namespace>
-		<deb.name>openhab-addon-binding-anel</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.anel</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Anel Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.asterisk/pom.xml
+++ b/bundles/binding/org.openhab.binding.asterisk/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Asterisk Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.asterisk</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.asterisk</bundle.namespace>
-		<deb.name>openhab-addon-binding-asterisk</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.asterisk</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.astro/pom.xml
+++ b/bundles/binding/org.openhab.binding.astro/pom.xml
@@ -8,26 +8,10 @@
 
   <name>openHAB Astro Binding</name>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.binding.astro</bundle.symbolicName>
-    <bundle.namespace>org.openhab.binding.astro</bundle.namespace>
-    <deb.name>openhab-addon-binding-astro</deb.name>
-    <deb.description>${project.name}</deb.description>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.binding</groupId>
   <artifactId>org.openhab.binding.astro</artifactId>
 
   <packaging>eclipse-plugin</packaging>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.vafer</groupId>
-        <artifactId>jdeb</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.autelis/pom.xml
+++ b/bundles/binding/org.openhab.binding.autelis/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.autelis</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.autelis</bundle.namespace>
-		<deb.name>openhab-addon-binding-autelis</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.autelis</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Autelis Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.benqprojector/pom.xml
+++ b/bundles/binding/org.openhab.binding.benqprojector/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.benqprojector</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.benqprojector</bundle.namespace>
-		<deb.name>openhab-addon-binding-benqprojector</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.benqprojector</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB BenqProjector Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.bluetooth/pom.xml
+++ b/bundles/binding/org.openhab.binding.bluetooth/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Bluetooth Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.bluetooth</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.bluetooth</bundle.namespace>
-		<deb.name>openhab-addon-binding-bluetooth</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.bluetooth</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.bticino/pom.xml
+++ b/bundles/binding/org.openhab.binding.bticino/pom.xml
@@ -6,13 +6,6 @@
     <version>1.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.binding.bticino</bundle.symbolicName>
-    <bundle.namespace>org.openhab.binding.bticino</bundle.namespace>
-    <deb.name>openhab-addon-binding-bticino</deb.name>
-    <deb.description>${project.name}</deb.description>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.binding</groupId>
   <artifactId>org.openhab.binding.bticino</artifactId>
@@ -22,12 +15,4 @@
   <packaging>eclipse-plugin</packaging>
   <description>openHAB binding for Bticino Domotica / Legrand.</description>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.vafer</groupId>
-        <artifactId>jdeb</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/bundles/binding/org.openhab.binding.caldav-command/pom.xml
+++ b/bundles/binding/org.openhab.binding.caldav-command/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.caldav-command</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.caldav-command</bundle.namespace>
-		<deb.name>openhab-addon-binding-caldav-command</deb.name>
-		<deb.description>openhab addon binding caldav-command</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.caldav-command</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB CalDAV-Command Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.caldav-personal/pom.xml
+++ b/bundles/binding/org.openhab.binding.caldav-personal/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.caldav-personal</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.caldav-personal</bundle.namespace>
-		<deb.name>openhab-addon-binding-caldav-personal</deb.name>
-		<deb.description>openhab addon binding caldav-personal</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.caldav-personal</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB CalDAV-Personal Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.cardio2e/pom.xml
+++ b/bundles/binding/org.openhab.binding.cardio2e/pom.xml
@@ -8,13 +8,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.cardio2e</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.cardio2e</bundle.namespace>
-		<deb.name>openhab-addon-binding-Cardio2e</deb.name>
-		<deb.description>openhab addon binding Cardio2e</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.cardio2e</artifactId>
@@ -22,14 +15,5 @@
 	<name>openHAB Cardio2e Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.comfoair/pom.xml
+++ b/bundles/binding/org.openhab.binding.comfoair/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB ComfoAir Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.comfoair</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.comfoair</bundle.namespace>
-		<deb.name>openhab-addon-binding-comfoair</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.comfoair</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.configadmin/pom.xml
+++ b/bundles/binding/org.openhab.binding.configadmin/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB ConfigAdmin Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.configadmin</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.configadmin</bundle.namespace>
-		<deb.name>openhab-addon-binding-configadmin</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.configadmin</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.cups/pom.xml
+++ b/bundles/binding/org.openhab.binding.cups/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Cups Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.cups</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.cups</bundle.namespace>
-		<deb.name>openhab-addon-binding-cups</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.cups</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.daikin/pom.xml
+++ b/bundles/binding/org.openhab.binding.daikin/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Daikin Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.daikin</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.daikin</bundle.namespace>
-		<deb.name>openhab-addon-binding-daikin</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.daikin</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.davis/pom.xml
+++ b/bundles/binding/org.openhab.binding.davis/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB Davis Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.davis</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.davis</bundle.namespace>
-		<deb.name>openhab-addon-binding-davis</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.davis</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.ddwrt/pom.xml
+++ b/bundles/binding/org.openhab.binding.ddwrt/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB DD-WRT Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ddwrt</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ddwrt</bundle.namespace>
-		<deb.name>openhab-addon-binding-ddwrt</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ddwrt</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.denon/pom.xml
+++ b/bundles/binding/org.openhab.binding.denon/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.denon</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.denon</bundle.namespace>
-		<deb.name>openhab-addon-binding-denon</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.denon</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Denon Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.digitalstrom/pom.xml
+++ b/bundles/binding/org.openhab.binding.digitalstrom/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB DigitalSTROM Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.digitalstrom</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.digitalstrom</bundle.namespace>
-		<deb.name>openhab-addon-binding-digitalstrom</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.digitalstrom</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.diyonxbee/pom.xml
+++ b/bundles/binding/org.openhab.binding.diyonxbee/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.diyonxbee</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.diyonxbee</bundle.namespace>
-		<deb.name>openhab-addon-binding-DiyOnXBee</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.diyonxbee</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB DiyOnXBee Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.dmx.artnet/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx.artnet/pom.xml
@@ -9,26 +9,10 @@
 	<name>openHAB artnet interface for DMX Binding</name>
 	<description>artnet interface for the openHAB binding for DMX</description>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.dmx.artnet</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.dmx.artnet</bundle.namespace>
-		<deb.name>openhab-addon-binding-dmx-artnet</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.dmx.artnet</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.dmx.lib485/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx.lib485/pom.xml
@@ -9,26 +9,10 @@
 	<name>openHAB lib485 interface for DMX Binding</name>
 	<description>lib485 interface for the openHAB binding for DMX</description>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.dmx.lib485</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.dmx.lib485</bundle.namespace>
-		<deb.name>openhab-addon-binding-dmx-lib485</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.dmx.lib485</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.dmx.ola/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx.ola/pom.xml
@@ -9,26 +9,10 @@
 	<name>openHAB OLA inteface for DMX Binding</name>
 	<description>OLA interface for the openHAB binding for DMX</description>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.dmx.ola</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.dmx.ola</bundle.namespace>
-		<deb.name>openhab-addon-binding-dmx-ola</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.dmx.ola</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.dmx.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx.test/pom.xml
@@ -8,11 +8,6 @@
 
 	<name>openHAB DMX Binding Tests</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.dmx.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.dmx.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.dmx.test</artifactId>

--- a/bundles/binding/org.openhab.binding.dmx/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx/pom.xml
@@ -9,26 +9,10 @@
 	<name>openHAB DMX Binding</name>
 	<description>openHAB binding for DMX controlled devices like RGB leds.</description>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.dmx</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.dmx</bundle.namespace>
-		<deb.name>openhab-addon-binding-dmx</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.dmx</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.dscalarm/pom.xml
+++ b/bundles/binding/org.openhab.binding.dscalarm/pom.xml
@@ -9,26 +9,10 @@
 	<name>openHAB DSC Alarm Binding</name>
 	<description>openHAB binding for DSC Alarm.</description>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.dscalarm</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.dscalarm</bundle.namespace>
-		<deb.name>openhab-addon-binding-dscalarm</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.dscalarm</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.dsmr/pom.xml
+++ b/bundles/binding/org.openhab.binding.dsmr/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.dsmr</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.dsmr</bundle.namespace>
-		<deb.name>openhab-addon-binding-dsmr</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.dsmr</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB DSMR Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.ebus/pom.xml
+++ b/bundles/binding/org.openhab.binding.ebus/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB eBus Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ebus</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ebus</bundle.namespace>
-		<deb.name>openhab-addon-binding-ebus</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ebus</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.ecobee/pom.xml
+++ b/bundles/binding/org.openhab.binding.ecobee/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ecobee</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ecobee</bundle.namespace>
-		<deb.name>openhab-addon-binding-ecobee</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ecobee</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Ecobee Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.ecotouch/pom.xml
+++ b/bundles/binding/org.openhab.binding.ecotouch/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ecotouch</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ecotouch</bundle.namespace>
-		<deb.name>openhab-addon-binding-ecotouch</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ecotouch</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB EcoTouch Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.ehealth/pom.xml
+++ b/bundles/binding/org.openhab.binding.ehealth/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Libelium eHealth Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ehealth</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ehealth</bundle.namespace>
-		<deb.name>openhab-addon-binding-ehealth</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ehealth</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.ekey/pom.xml
+++ b/bundles/binding/org.openhab.binding.ekey/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ekey</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ekey</bundle.namespace>
-		<deb.name>openhab-addon-binding-ekey</deb.name>
-		<deb.description>openhab addon binding ekey</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ekey</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB eKey Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.em.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.em.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.em.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.em.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.em.test</artifactId>

--- a/bundles/binding/org.openhab.binding.em/pom.xml
+++ b/bundles/binding/org.openhab.binding.em/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB EM Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.em</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.em</bundle.namespace>
-		<deb.name>openhab-addon-binding-em</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-cul</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.em</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.energenie/pom.xml
+++ b/bundles/binding/org.openhab.binding.energenie/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.energenie</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.energenie</bundle.namespace>
-		<deb.name>openhab-addon-binding-energenie</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.energenie</artifactId>
@@ -21,14 +14,5 @@
 
 	<packaging>eclipse-plugin</packaging>
 
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.enigma2.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.enigma2.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.enigma2.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.enigma2.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.enigma2.test</artifactId>

--- a/bundles/binding/org.openhab.binding.enigma2/pom.xml
+++ b/bundles/binding/org.openhab.binding.enigma2/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.enigma2</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.enigma2</bundle.namespace>
-		<deb.name>openhab-addon-binding-enigma2</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.enigma2</artifactId>
@@ -21,12 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/bundles/binding/org.openhab.binding.enocean.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.enocean.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.enocean.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.enocean.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.enocean.test</artifactId>

--- a/bundles/binding/org.openhab.binding.enocean/pom.xml
+++ b/bundles/binding/org.openhab.binding.enocean/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB EnOcean Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.enocean</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.enocean</bundle.namespace>
-		<deb.name>openhab-addon-binding-enocean</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.enocean</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.enphaseenergy/pom.xml
+++ b/bundles/binding/org.openhab.binding.enphaseenergy/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Enphase Energy Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.enphaseenergy</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.enphaseenergy</bundle.namespace>
-		<deb.name>openhab-addon-binding-enphaseenergy</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.enphaseenergy</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.epsonprojector/pom.xml
+++ b/bundles/binding/org.openhab.binding.epsonprojector/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB Epson projector Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.epsonprojector</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.epsonprojector</bundle.namespace>
-		<deb.name>openhab-addon-binding-epsonprojector</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.epsonprojector</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.exec.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.exec.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.exec.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.exec.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.exec.test</artifactId>

--- a/bundles/binding/org.openhab.binding.exec/pom.xml
+++ b/bundles/binding/org.openhab.binding.exec/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Exec Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.exec</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.exec</bundle.namespace>
-		<deb.name>openhab-addon-binding-exec</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.exec</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.expire/pom.xml
+++ b/bundles/binding/org.openhab.binding.expire/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.expire</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.expire</bundle.namespace>
-		<deb.name>openhab-addon-binding-expire</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.expire</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Expire Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.fatekplc/pom.xml
+++ b/bundles/binding/org.openhab.binding.fatekplc/pom.xml
@@ -7,10 +7,6 @@
 	</parent>
 
 	<properties>
-		<bundle.symbolicName>org.openhab.binding.fatekplc</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.fatekplc</bundle.namespace>
-		<deb.name>openhab-addon-binding-fatekplc</deb.name>
-		<deb.description>openhab addon binding Fatek PLC</deb.description>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 	</properties>
@@ -22,14 +18,5 @@
 	<name>openHAB Fatek PLC Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.fht/pom.xml
+++ b/bundles/binding/org.openhab.binding.fht/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB FHT Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.fht</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.fht</bundle.namespace>
-		<deb.name>openhab-addon-binding-fht</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-cul</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.fht</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.freebox/pom.xml
+++ b/bundles/binding/org.openhab.binding.freebox/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.freebox</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.freebox</bundle.namespace>
-		<deb.name>openhab-addon-binding-freebox</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.freebox</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Freebox Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.freeswitch/pom.xml
+++ b/bundles/binding/org.openhab.binding.freeswitch/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.freeswitch</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.freeswitch</bundle.namespace>
-		<deb.name>openhab-addon-binding-freeswitch</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.freeswitch</artifactId>
@@ -21,13 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-        <plugins>
-            <plugin>
-                <groupId>org.vafer</groupId>
-                <artifactId>jdeb</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-    
 </project>

--- a/bundles/binding/org.openhab.binding.fritzaha/pom.xml
+++ b/bundles/binding/org.openhab.binding.fritzaha/pom.xml
@@ -10,26 +10,10 @@
 
 	<name>openHAB Fritz AVM Home Automation Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.fritzaha</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.fritzaha</bundle.namespace>
-		<deb.name>openhab-addon-binding-fritzaha</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.fritzaha</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.fritzbox/pom.xml
+++ b/bundles/binding/org.openhab.binding.fritzbox/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Fritzbox Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.fritzbox</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.fritzbox</bundle.namespace>
-		<deb.name>openhab-addon-binding-fritzbox</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.fritzbox</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/pom.xml
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.fritzboxtr064</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.fritzboxtr064</bundle.namespace>
-		<deb.name>openhab-addon-binding-FritzboxTr064</deb.name>
-		<deb.description>openhab addon binding FritzboxTr064</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.fritzboxtr064</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB FritzboxTr064 Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/pom.xml
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.frontiersiliconradio</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.frontiersiliconradio</bundle.namespace>
-		<deb.name>openhab-addon-binding-frontiersiliconradio</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.frontiersiliconradio</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB FrontierSiliconRadio Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.fs20/pom.xml
+++ b/bundles/binding/org.openhab.binding.fs20/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB FS20 Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.fs20</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.fs20</bundle.namespace>
-		<deb.name>openhab-addon-binding-fs20</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.fs20</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.garadget/pom.xml
+++ b/bundles/binding/org.openhab.binding.garadget/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.garadget</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.garadget</bundle.namespace>
-		<deb.name>openhab-addon-binding-garadget</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.garadget</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Garadget Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.gc100ir/pom.xml
+++ b/bundles/binding/org.openhab.binding.gc100ir/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB GC100IR Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.gc100ir</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.gc100ir</bundle.namespace>
-		<deb.name>openhab-addon-binding-gc100ir</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.gc100ir</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-	
 </project>

--- a/bundles/binding/org.openhab.binding.gpio/pom.xml
+++ b/bundles/binding/org.openhab.binding.gpio/pom.xml
@@ -6,14 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.gpio</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.gpio</bundle.namespace>
-		<deb.name>openhab-addon-binding-gpio</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-gpio</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.gpio</artifactId>
@@ -21,14 +13,5 @@
 	<name>openHAB GPIO Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.harmonyhub/pom.xml
+++ b/bundles/binding/org.openhab.binding.harmonyhub/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.harmonyhub</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.harmonyhub</bundle.namespace>
-		<deb.name>openhab-addon-binding-harmonyHub</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.harmonyhub</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB HarmonyHub Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.hdanywhere/pom.xml
+++ b/bundles/binding/org.openhab.binding.hdanywhere/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.hdanywhere</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.hdanywhere</bundle.namespace>
-		<deb.name>openhab-addon-binding-hdanywhere</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.hdanywhere</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB HDanywhere Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.heatmiser/pom.xml
+++ b/bundles/binding/org.openhab.binding.heatmiser/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Heatmiser Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.heatmiser</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.heatmiser</bundle.namespace>
-		<deb.name>openhab-addon-binding-heatmiser</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.heatmiser</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.hms/pom.xml
+++ b/bundles/binding/org.openhab.binding.hms/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.hms</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.hms</bundle.namespace>
-		<deb.name>openhab-addon-binding-hms</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.hms</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB HMS Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.homematic.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.homematic.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.homematic.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.homematic.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.homematic.test</artifactId>

--- a/bundles/binding/org.openhab.binding.homematic/pom.xml
+++ b/bundles/binding/org.openhab.binding.homematic/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Homematic Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.homematic</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.homematic</bundle.namespace>
-		<deb.name>openhab-addon-binding-homematic</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.homematic</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.horizon/pom.xml
+++ b/bundles/binding/org.openhab.binding.horizon/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.horizon</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.horizon</bundle.namespace>
-		<deb.name>openhab-addon-binding-horizon</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.horizon</artifactId>
@@ -20,13 +13,4 @@
 	<name>openHAB Horizon Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/bundles/binding/org.openhab.binding.http.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.http.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.http.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.http.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.http.test</artifactId>

--- a/bundles/binding/org.openhab.binding.http/pom.xml
+++ b/bundles/binding/org.openhab.binding.http/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB HTTP Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.http</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.http</bundle.namespace>
-		<deb.name>openhab-addon-binding-http</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.http</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.hue/pom.xml
+++ b/bundles/binding/org.openhab.binding.hue/pom.xml
@@ -8,27 +8,11 @@
 
 	<name>openHAB Hue Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.hue</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.hue</bundle.namespace>
-		<deb.name>openhab-addon-binding-hue</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.hue</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 	<dependencies>
 		<dependency>

--- a/bundles/binding/org.openhab.binding.iec6205621meter/pom.xml
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/pom.xml
@@ -6,14 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.iec6205621meter</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.iec6205621meter</bundle.namespace>
-		<deb.name>openhab-addon-binding-iec6205621meter</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.iec6205621meter</artifactId>
@@ -21,15 +13,6 @@
 	<name>openHAB IEC 62056-21 Meter Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 	<description>This binding is used to communicate to metering devices supporting serial communication according mode C master. It can be used to read metering data from slaves such as gas, water, heat, or electricity meters.</description>
 </project>

--- a/bundles/binding/org.openhab.binding.ihc/pom.xml
+++ b/bundles/binding/org.openhab.binding.ihc/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB IHC / ELKO LS Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ihc</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ihc</bundle.namespace>
-		<deb.name>openhab-addon-binding-ihc</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ihc</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.insteonhub/pom.xml
+++ b/bundles/binding/org.openhab.binding.insteonhub/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB InsteonHub Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.insteonhub</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.insteonhub</bundle.namespace>
-		<deb.name>openhab-addon-binding-insteonhub</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.insteonhub</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.insteonplm/pom.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/pom.xml
@@ -6,14 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.insteonplm</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.insteonplm</bundle.namespace>
-		<deb.name>openhab-addon-binding-insteonplm</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.insteonplm</artifactId>
@@ -21,14 +13,5 @@
 	<name>openHAB Insteon PLM Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 	
 </project>

--- a/bundles/binding/org.openhab.binding.intertechno/pom.xml
+++ b/bundles/binding/org.openhab.binding.intertechno/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB CULIntertechno Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.intertechno</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.intertechno</bundle.namespace>
-		<deb.name>openhab-addon-binding-intertechno</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.intertechno</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.ipx800/pom.xml
+++ b/bundles/binding/org.openhab.binding.ipx800/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ipx800</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ipx800</bundle.namespace>
-		<deb.name>openhab-addon-binding-Ipx800</deb.name>
-		<deb.description>openhab addon binding Ipx800</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ipx800</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Ipx800 Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.irtrans/pom.xml
+++ b/bundles/binding/org.openhab.binding.irtrans/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.irtrans</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.irtrans</bundle.namespace>
-		<deb.name>openhab-addon-binding-irtrans</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.irtrans</artifactId>
@@ -21,13 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/bundles/binding/org.openhab.binding.isy/pom.xml
+++ b/bundles/binding/org.openhab.binding.isy/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.isy</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.isy</bundle.namespace>
-		<deb.name>openhab-addon-binding-isy</deb.name>
-		<deb.description>openhab addon binding isy</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.isy</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Universal Devices ISY 994i Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.jointspace/pom.xml
+++ b/bundles/binding/org.openhab.binding.jointspace/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.jointspace</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.jointspace</bundle.namespace>
-		<deb.name>openhab-addon-binding-jointspace</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.jointspace</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB JointSpace Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.k8055/pom.xml
+++ b/bundles/binding/org.openhab.binding.k8055/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.k8055</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.k8055</bundle.namespace>
-		<deb.name>openhab-addon-binding-k8055</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.k8055</artifactId>
@@ -21,13 +14,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-	
 </project>

--- a/bundles/binding/org.openhab.binding.km200/pom.xml
+++ b/bundles/binding/org.openhab.binding.km200/pom.xml
@@ -8,25 +8,9 @@
 
 	<name>openHAB KM200 Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.km200</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.km200</bundle.namespace>
-		<deb.name>openhab-addon-binding-km200</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.km200</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/bundles/binding/org.openhab.binding.knx.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.knx.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.knx.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.knx.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.knx.test</artifactId>

--- a/bundles/binding/org.openhab.binding.knx/META-INF/maven/org.openhab.binding.knx/core/pom.xml
+++ b/bundles/binding/org.openhab.binding.knx/META-INF/maven/org.openhab.binding.knx/core/pom.xml
@@ -8,16 +8,11 @@
     <version>0.3.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.binding.knx</bundle.symbolicName>
-    <bundle.namespace>org.openhab.binding.knx</bundle.namespace>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.binding.knx</groupId>
   <artifactId>core</artifactId>
 
-  <name>${bundle.symbolicName}</name>
+  <name>org.openhab.binding.knx</name>
 
   <packaging>bundle</packaging>
 

--- a/bundles/binding/org.openhab.binding.knx/META-INF/maven/org.openhab.connector.knx/core/pom.xml
+++ b/bundles/binding/org.openhab.binding.knx/META-INF/maven/org.openhab.connector.knx/core/pom.xml
@@ -8,16 +8,11 @@
     <version>0.3.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.connector.knx.core</bundle.symbolicName>
-    <bundle.namespace>org.openhab.connector.knx.core</bundle.namespace>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.connector.knx</groupId>
   <artifactId>core</artifactId>
 
-  <name>${bundle.symbolicName}</name>
+  <name>org.openhab.connector.knx.core</name>
 
   <packaging>bundle</packaging>
 

--- a/bundles/binding/org.openhab.binding.knx/pom.xml
+++ b/bundles/binding/org.openhab.binding.knx/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB KNX Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.knx</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.knx</bundle.namespace>
-		<deb.name>openhab-addon-binding-knx</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.knx</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.koubachi/pom.xml
+++ b/bundles/binding/org.openhab.binding.koubachi/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Koubachi Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.koubachi</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.koubachi</bundle.namespace>
-		<deb.name>openhab-addon-binding-koubachi</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.koubachi</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.lcn/pom.xml
+++ b/bundles/binding/org.openhab.binding.lcn/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB LCN Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.lcn</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.lcn</bundle.namespace>
-		<deb.name>openhab-addon-binding-lcn</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.lcn</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.lgtv/pom.xml
+++ b/bundles/binding/org.openhab.binding.lgtv/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.lgtv</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.lgtv</bundle.namespace>
-		<deb.name>openhab-addon-binding-lgtv</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.lgtv</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Lgtv Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.lightwaverf.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.lightwaverf.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.lightwaverf.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.lightwaverf.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.lightwaverf.test</artifactId>

--- a/bundles/binding/org.openhab.binding.lightwaverf/pom.xml
+++ b/bundles/binding/org.openhab.binding.lightwaverf/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.lightwaverf</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.lightwaverf</bundle.namespace>
-		<deb.name>openhab-addon-binding-lightwaverf</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.lightwaverf</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB LightwaveRf Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.mailcontrol/pom.xml
+++ b/bundles/binding/org.openhab.binding.mailcontrol/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mailcontrol</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mailcontrol</bundle.namespace>
-		<deb.name>openhab-addon-binding-mailcontrol</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mailcontrol</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB MailControl Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.maxcube.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.maxcube.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.maxcube.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.maxcube.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.maxcube.test</artifactId>

--- a/bundles/binding/org.openhab.binding.maxcube/pom.xml
+++ b/bundles/binding/org.openhab.binding.maxcube/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB MaxCube Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.maxcube</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.maxcube</bundle.namespace>
-		<deb.name>openhab-addon-binding-maxcube</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.maxcube</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.maxcul/pom.xml
+++ b/bundles/binding/org.openhab.binding.maxcul/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.maxcul</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.maxcul</bundle.namespace>
-		<deb.name>openhab-addon-binding-maxcul</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.maxcul</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB MaxCul Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.mcp23017/pom.xml
+++ b/bundles/binding/org.openhab.binding.mcp23017/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mcp23017</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mcp23017</bundle.namespace>
-		<deb.name>openhab-addon-binding-mcp23017</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mcp23017</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB mcp23017 Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.mcp3424/pom.xml
+++ b/bundles/binding/org.openhab.binding.mcp3424/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mcp3424</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mcp3424</bundle.namespace>
-		<deb.name>openhab-addon-binding-mcp3424</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mcp3424</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB mcp3424 Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.milight/pom.xml
+++ b/bundles/binding/org.openhab.binding.milight/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Milight Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.milight</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.milight</bundle.namespace>
-		<deb.name>openhab-addon-binding-milight</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.milight</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.mios/pom.xml
+++ b/bundles/binding/org.openhab.binding.mios/pom.xml
@@ -8,25 +8,10 @@
 
 	<name>openHAB MiOS Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mios</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mios</bundle.namespace>
-		<deb.name>openhab-addon-binding-mios</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mios</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/bundles/binding/org.openhab.binding.mochadx10/pom.xml
+++ b/bundles/binding/org.openhab.binding.mochadx10/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Mochad X10 Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mochadx10</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mochadx10</bundle.namespace>
-		<deb.name>openhab-addon-binding-mochadx10</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mochadx10</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.modbus.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.modbus.test/pom.xml
@@ -8,11 +8,6 @@
 
 	<name>openHAB Modbus Binding Tests</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.modbus.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.modbus.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.modbus.test</artifactId>

--- a/bundles/binding/org.openhab.binding.modbus/pom.xml
+++ b/bundles/binding/org.openhab.binding.modbus/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB Modbus Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.modbus</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.modbus</bundle.namespace>
-		<deb.name>openhab-addon-binding-modbus</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.modbus</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.mpd/pom.xml
+++ b/bundles/binding/org.openhab.binding.mpd/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB MPD Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mpd</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mpd</bundle.namespace>
-		<deb.name>openhab-addon-binding-mpd</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mpd</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.mqtt.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.mqtt.test/pom.xml
@@ -9,11 +9,6 @@
 		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mqtt.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mqtt.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mqtt.test</artifactId>

--- a/bundles/binding/org.openhab.binding.mqtt/pom.xml
+++ b/bundles/binding/org.openhab.binding.mqtt/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB MQTT Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mqtt</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mqtt</bundle.namespace>
-		<deb.name>openhab-addon-binding-mqtt</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mqtt</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.mqttitude/pom.xml
+++ b/bundles/binding/org.openhab.binding.mqttitude/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Mqttitude Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mqttitude</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mqttitude</bundle.namespace>
-		<deb.name>openhab-addon-binding-mqttitude</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mqttitude</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.myq/pom.xml
+++ b/bundles/binding/org.openhab.binding.myq/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.myq</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.myq</bundle.namespace>
-		<deb.name>openhab-addon-binding-myq</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.myq</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB myq Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.mystromecopower/pom.xml
+++ b/bundles/binding/org.openhab.binding.mystromecopower/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.mystromecopower</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.mystromecopower</bundle.namespace>
-		<deb.name>openhab-addon-binding-mystromecopower</deb.name>
-		<deb.description>openhab addon binding MyStromEcoPower</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.mystromecopower</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB MyStromEcoPower Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.neohub/pom.xml
+++ b/bundles/binding/org.openhab.binding.neohub/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB neohub Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.neohub</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.neohub</bundle.namespace>
-		<deb.name>openhab-addon-binding-neohub</deb.name>
-		<deb.description>openhab addon binding neohub</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.neohub</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.nest/pom.xml
+++ b/bundles/binding/org.openhab.binding.nest/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.nest</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.nest</bundle.namespace>
-		<deb.name>openhab-addon-binding-nest</deb.name>
-		<deb.description>openhab addon binding Nest</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.nest</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Nest Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.netatmo.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.netatmo.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.netatmo.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.netatmo.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.netatmo.test</artifactId>

--- a/bundles/binding/org.openhab.binding.netatmo/pom.xml
+++ b/bundles/binding/org.openhab.binding.netatmo/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Netatmo Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.netatmo</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.netatmo</bundle.namespace>
-		<deb.name>openhab-addon-binding-netatmo</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.netatmo</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.networkhealth/pom.xml
+++ b/bundles/binding/org.openhab.binding.networkhealth/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB NetworkHealth Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.networkhealth</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.networkhealth</bundle.namespace>
-		<deb.name>openhab-addon-binding-networkhealth</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.networkhealth</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.networkupstools/pom.xml
+++ b/bundles/binding/org.openhab.binding.networkupstools/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.networkupstools</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.networkupstools</bundle.namespace>
-		<deb.name>openhab-addon-binding-networkupstools</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.networkupstools</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB NetworkUpsTools Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.nibeheatpump/pom.xml
+++ b/bundles/binding/org.openhab.binding.nibeheatpump/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Nibe heat pump Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.nibeheatpump</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.nibeheatpump</bundle.namespace>
-		<deb.name>openhab-addon-binding-nibeheatpump</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.nibeheatpump</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.nikobus.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.nikobus.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.nikobus.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.nikobus.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.nikobus.test</artifactId>

--- a/bundles/binding/org.openhab.binding.nikobus/pom.xml
+++ b/bundles/binding/org.openhab.binding.nikobus/pom.xml
@@ -9,27 +9,10 @@
 	<name>openHAB Nikobus Binding</name>
 	<description>Binding for the Nikobus home automation system.</description>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.nikobus</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.nikobus</bundle.namespace>
-		<deb.name>openhab-addon-binding-nikobus</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.nikobus</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.novelanheatpump/pom.xml
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/pom.xml
@@ -7,26 +7,10 @@
 	</parent>
 	<name>openHAB Novelan Heatpump Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.novelanheatpump</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.novelanheatpump</bundle.namespace>
-		<deb.name>openhab-addon-binding-novelanheatpump</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.novelanheatpump</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.ntp/pom.xml
+++ b/bundles/binding/org.openhab.binding.ntp/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB NTP Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ntp</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ntp</bundle.namespace>
-		<deb.name>openhab-addon-binding-ntp</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ntp</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.oceanic/pom.xml
+++ b/bundles/binding/org.openhab.binding.oceanic/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB Oceanic Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.oceanic</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.oceanic</bundle.namespace>
-		<deb.name>openhab-addon-binding-oceanic</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.oceanic</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.octoller/pom.xml
+++ b/bundles/binding/org.openhab.binding.octoller/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.octoller</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.octoller</bundle.namespace>
-		<deb.name>openhab-addon-binding-octoller</deb.name>
-		<deb.description>openhab addon binding octoller</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.octoller</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB octoller Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.omnilink/pom.xml
+++ b/bundles/binding/org.openhab.binding.omnilink/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.omnilink</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.omnilink</bundle.namespace>
-		<deb.name>openhab-addon-binding-omnilink</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.omnilink</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB OmniLink Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.onewire/pom.xml
+++ b/bundles/binding/org.openhab.binding.onewire/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB 1-Wire Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.onewire</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.onewire</bundle.namespace>
-		<deb.name>openhab-addon-binding-onewire</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.onewire</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.onkyo/pom.xml
+++ b/bundles/binding/org.openhab.binding.onkyo/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Onkyo Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.onkyo</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.onkyo</bundle.namespace>
-		<deb.name>openhab-addon-binding-onkyo</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.onkyo</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.openenergymonitor/pom.xml
+++ b/bundles/binding/org.openhab.binding.openenergymonitor/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB Open Energy Monitor Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.openenergymonitor</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.openenergymonitor</bundle.namespace>
-		<deb.name>openhab-addon-binding-openenergymonitor</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.openenergymonitor</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.openpaths/pom.xml
+++ b/bundles/binding/org.openhab.binding.openpaths/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB OpenPaths Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.openpaths</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.openpaths</bundle.namespace>
-		<deb.name>openhab-addon-binding-openpaths</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.openpaths</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.opensprinkler/pom.xml
+++ b/bundles/binding/org.openhab.binding.opensprinkler/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB OpenSprinkler Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.opensprinkler</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.opensprinkler</bundle.namespace>
-		<deb.name>openhab-addon-binding-opensprinkler</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.opensprinkler</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.owserver/pom.xml
+++ b/bundles/binding/org.openhab.binding.owserver/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB OWServer Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.owserver</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.owserver</bundle.namespace>
-		<deb.name>openhab-addon-binding-owserver</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.owserver</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.panasonictv/pom.xml
+++ b/bundles/binding/org.openhab.binding.panasonictv/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.panasonictv</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.panasonictv</bundle.namespace>
-		<deb.name>openhab-addon-binding-panasonictv</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.panasonictv</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB PanasonicTV Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.panstamp/pom.xml
+++ b/bundles/binding/org.openhab.binding.panstamp/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.panstamp</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.panstamp</bundle.namespace>
-		<deb.name>openhab-addon-binding-panstamp</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.panstamp</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB PanStamp Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.piface/pom.xml
+++ b/bundles/binding/org.openhab.binding.piface/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Piface Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.piface</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.piface</bundle.namespace>
-		<deb.name>openhab-addon-binding-piface</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.piface</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.pilight.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.pilight.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.pilight.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.pilight.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.pilight.test</artifactId>

--- a/bundles/binding/org.openhab.binding.pilight/pom.xml
+++ b/bundles/binding/org.openhab.binding.pilight/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.pilight</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.pilight</bundle.namespace>
-		<deb.name>openhab-addon-binding-pilight</deb.name>
-		<deb.description>openhab addon binding pilight</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.pilight</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB pilight Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.pioneeravr/pom.xml
+++ b/bundles/binding/org.openhab.binding.pioneeravr/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Pioneer AVR Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.pioneeravr</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.pioneeravr</bundle.namespace>
-		<deb.name>openhab-addon-binding-pioneeravr</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.pioneeravr</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.plcbus/pom.xml
+++ b/bundles/binding/org.openhab.binding.plcbus/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB PLCBus Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.plcbus</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.plcbus</bundle.namespace>
-		<deb.name>openhab-addon-binding-plcbus</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.plcbus</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.plclogo/pom.xml
+++ b/bundles/binding/org.openhab.binding.plclogo/pom.xml
@@ -8,13 +8,6 @@
 
 	<name>openHAB PlcLogo Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.plclogo</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.plclogo</bundle.namespace>
-		<deb.name>openhab-addon-binding-plclogo</deb.name>
-		<deb.description>openhab addon binding PlcLogo</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.plclogo</artifactId>
@@ -28,14 +21,5 @@
 			<version>1.5</version>
 		</dependency>
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.plex/pom.xml
+++ b/bundles/binding/org.openhab.binding.plex/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.plex</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.plex</bundle.namespace>
-		<deb.name>openhab-addon-binding-plex</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.plex</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Plex Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.plugwise/pom.xml
+++ b/bundles/binding/org.openhab.binding.plugwise/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB Plugwise Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.plugwise</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.plugwise</bundle.namespace>
-		<deb.name>openhab-addon-binding-plugwise</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.plugwise</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.powerdoglocalapi/pom.xml
+++ b/bundles/binding/org.openhab.binding.powerdoglocalapi/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.powerdoglocalapi</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.powerdoglocalapi</bundle.namespace>
-		<deb.name>openhab-addon-binding-powerdoglocalapi</deb.name>
-		<deb.description>openhab addon binding PowerDogLocalApi</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.powerdoglocalapi</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB PowerDogLocalApi Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.powermax/pom.xml
+++ b/bundles/binding/org.openhab.binding.powermax/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.powermax</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.powermax</bundle.namespace>
-		<deb.name>openhab-addon-binding-powermax</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.powermax</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB PowerMax Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.primare/pom.xml
+++ b/bundles/binding/org.openhab.binding.primare/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Primare Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.primare</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.primare</bundle.namespace>
-		<deb.name>openhab-addon-binding-primare</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.primare</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.pulseaudio/pom.xml
+++ b/bundles/binding/org.openhab.binding.pulseaudio/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Pulseaudio Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.pulseaudio</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.pulseaudio</bundle.namespace>
-		<deb.name>openhab-addon-binding-pulseaudio</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.pulseaudio</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.rfxcom.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.rfxcom.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.rfxcom.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.rfxcom.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.rfxcom.test</artifactId>

--- a/bundles/binding/org.openhab.binding.rfxcom/pom.xml
+++ b/bundles/binding/org.openhab.binding.rfxcom/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB RFXCOM Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.rfxcom</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.rfxcom</bundle.namespace>
-		<deb.name>openhab-addon-binding-rfxcom</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.rfxcom</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.rme/pom.xml
+++ b/bundles/binding/org.openhab.binding.rme/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB RME Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.rme</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.rme</bundle.namespace>
-		<deb.name>openhab-addon-binding-rme</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.rme</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.rpircswitch/pom.xml
+++ b/bundles/binding/org.openhab.binding.rpircswitch/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Raspberry Pi RC Switch Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.rpircswitch</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.rpircswitch</bundle.namespace>
-		<deb.name>openhab-addon-binding-rpircswitch</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.rpircswitch</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.rwesmarthome/pom.xml
+++ b/bundles/binding/org.openhab.binding.rwesmarthome/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.rwesmarthome</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.rwesmarthome</bundle.namespace>
-		<deb.name>openhab-addon-binding-RWESmarthome</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.rwesmarthome</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB RWE Smarthome Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.s300th.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.s300th.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.s300th.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.s300th.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.s300th.test</artifactId>

--- a/bundles/binding/org.openhab.binding.s300th/pom.xml
+++ b/bundles/binding/org.openhab.binding.s300th/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB S300TH Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.s300th</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.s300th</bundle.namespace>
-		<deb.name>openhab-addon-binding-s300th</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.s300th</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.sagercaster/pom.xml
+++ b/bundles/binding/org.openhab.binding.sagercaster/pom.xml
@@ -8,13 +8,6 @@
 		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.sagercaster</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.sagercaster</bundle.namespace>
-		<deb.name>openhab-addon-binding-SagerCaster</deb.name>
-		<deb.description>openhab addon binding SagerCaster</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.sagercaster</artifactId>
@@ -22,14 +15,5 @@
 	<name>openHAB Sager WeatherCaster Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.sallegra/pom.xml
+++ b/bundles/binding/org.openhab.binding.sallegra/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.sallegra</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.sallegra</bundle.namespace>
-		<deb.name>openhab-addon-binding-sallegra</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.sallegra</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Sallegra Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.samsungac.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.samsungac.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.samsungac.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.samsungac.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.samsungac.test</artifactId>

--- a/bundles/binding/org.openhab.binding.samsungac/pom.xml
+++ b/bundles/binding/org.openhab.binding.samsungac/pom.xml
@@ -8,28 +8,10 @@
 
 	<name>openHAB Samsung Air Conditioner Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.samsungac</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.samsungac</bundle.namespace>
-		<deb.name>openhab-addon-binding-samsungac</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.samsungac</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.vafer</groupId>
-					<artifactId>jdeb</artifactId>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.samsungtv/pom.xml
+++ b/bundles/binding/org.openhab.binding.samsungtv/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Samsung TV Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.samsungtv</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.samsungtv</bundle.namespace>
-		<deb.name>openhab-addon-binding-samsungtv</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.samsungtv</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.sapp/pom.xml
+++ b/bundles/binding/org.openhab.binding.sapp/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.sapp</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.sapp</bundle.namespace>
-		<deb.name>openhab-addon-binding-sapp</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.sapp</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Sapp Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.satel/pom.xml
+++ b/bundles/binding/org.openhab.binding.satel/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Satel Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.satel</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.satel</bundle.namespace>
-		<deb.name>openhab-addon-binding-satel</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.satel</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.serial/pom.xml
+++ b/bundles/binding/org.openhab.binding.serial/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB Serial Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.serial</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.serial</bundle.namespace>
-		<deb.name>openhab-addon-binding-serial</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.serial</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.smarthomatic/pom.xml
+++ b/bundles/binding/org.openhab.binding.smarthomatic/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.smarthomatic</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.smarthomatic</bundle.namespace>
-		<deb.name>openhab-addon-binding-Smarthomatic</deb.name>
-		<deb.description>openhab addon binding Smarthomatic</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.smarthomatic</artifactId>
@@ -23,10 +16,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
 			<plugin>
 			  <groupId>org.codehaus.mojo</groupId>
 			  <artifactId>jaxb2-maven-plugin</artifactId>

--- a/bundles/binding/org.openhab.binding.snmp/pom.xml
+++ b/bundles/binding/org.openhab.binding.snmp/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB SNMP Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.snmp</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.snmp</bundle.namespace>
-		<deb.name>openhab-addon-binding-snmp</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.snmp</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.sonance/pom.xml
+++ b/bundles/binding/org.openhab.binding.sonance/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.sonance</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.sonance</bundle.namespace>
-		<deb.name>openhab-addon-binding-Sonance</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.sonance</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Sonance Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.sonos/pom.xml
+++ b/bundles/binding/org.openhab.binding.sonos/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Sonos Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.sonos</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.sonos</bundle.namespace>
-		<deb.name>openhab-addon-binding-sonos</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.sonos</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.souliss/pom.xml
+++ b/bundles/binding/org.openhab.binding.souliss/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>Souliss - Arduino based SmartHome - openHAB Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.souliss</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.souliss</bundle.namespace>
-		<deb.name>openhab-addon-binding-souliss</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.souliss</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.squeezebox/pom.xml
+++ b/bundles/binding/org.openhab.binding.squeezebox/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Squeezebox Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.squeezebox</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.squeezebox</bundle.namespace>
-		<deb.name>openhab-addon-binding-squeezebox</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.squeezebox</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.stiebelheatpump.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.stiebelheatpump.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.stiebelheatpump.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.stiebelheatpump.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.stiebelheatpump.test</artifactId>

--- a/bundles/binding/org.openhab.binding.stiebelheatpump/pom.xml
+++ b/bundles/binding/org.openhab.binding.stiebelheatpump/pom.xml
@@ -6,14 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.stiebelheatpump</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.stiebelheatpump</bundle.namespace>
-		<deb.name>openhab-addon-binding-stiebelheatpump</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.stiebelheatpump</artifactId>

--- a/bundles/binding/org.openhab.binding.swegonventilation/pom.xml
+++ b/bundles/binding/org.openhab.binding.swegonventilation/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB Swegon ventilation Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.swegonventilation</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.swegonventilation</bundle.namespace>
-		<deb.name>openhab-addon-binding-swegonventilation</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.swegonventilation</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.systeminfo.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/pom.xml
@@ -9,11 +9,6 @@
 		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.systeminfo.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.systeminfo.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.systeminfo.test</artifactId>

--- a/bundles/binding/org.openhab.binding.systeminfo/pom.xml
+++ b/bundles/binding/org.openhab.binding.systeminfo/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Systeminfo Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.systeminfo</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.systeminfo</bundle.namespace>
-		<deb.name>openhab-addon-binding-systeminfo</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.systeminfo</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.tacmi/pom.xml
+++ b/bundles/binding/org.openhab.binding.tacmi/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.tacmi</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.tacmi</bundle.namespace>
-		<deb.name>openhab-addon-binding-TACmi</deb.name>
-		<deb.description>openhab addon binding TACmi</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.tacmi</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB TACmi Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.tcp/pom.xml
+++ b/bundles/binding/org.openhab.binding.tcp/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB TCP/UDP Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.tcp</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.tcp</bundle.namespace>
-		<deb.name>openhab-addon-binding-tcp</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.tcp</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.tellstick/pom.xml
+++ b/bundles/binding/org.openhab.binding.tellstick/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.tellstick</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.tellstick</bundle.namespace>
-		<deb.name>openhab-addon-binding-tellstick</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.tellstick</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Tellstick Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.tinkerforge/pom.xml
+++ b/bundles/binding/org.openhab.binding.tinkerforge/pom.xml
@@ -8,25 +8,10 @@
 
 	<name>openHAB Tinkerforge Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.tinkerforge</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.tinkerforge</bundle.namespace>
-		<deb.name>openhab-addon-binding-tinkerforge</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.tinkerforge</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/bundles/binding/org.openhab.binding.tivo/pom.xml
+++ b/bundles/binding/org.openhab.binding.tivo/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB TiVo Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.tivo</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.tivo</bundle.namespace>
-		<deb.name>openhab-addon-binding-tivo</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.tivo</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.ucprelayboard/pom.xml
+++ b/bundles/binding/org.openhab.binding.ucprelayboard/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB UCProjects.eu RelayBoard Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.ucprelayboard</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.ucprelayboard</bundle.namespace>
-		<deb.name>openhab-addon-binding-ucprelayboard</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.ucprelayboard</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.upb/pom.xml
+++ b/bundles/binding/org.openhab.binding.upb/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.upb</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.upb</bundle.namespace>
-		<deb.name>openhab-addon-binding-upb</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.upb</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB UPB Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.urtsi/pom.xml
+++ b/bundles/binding/org.openhab.binding.urtsi/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB Somfy URTSI II Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.urtsi</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.urtsi</bundle.namespace>
-		<deb.name>openhab-addon-binding-urtsi</deb.name>
-		<deb.description>${project.name}</deb.description>
-		<deb.depends>openhab-addon-io-serial</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.urtsi</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-	
 </project>

--- a/bundles/binding/org.openhab.binding.vdr/pom.xml
+++ b/bundles/binding/org.openhab.binding.vdr/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB VDR Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.vdr</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.vdr</bundle.namespace>
-		<deb.name>openhab-addon-binding-vdr</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.vdr</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.velux/pom.xml
+++ b/bundles/binding/org.openhab.binding.velux/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Velux Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.velux</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.velux</bundle.namespace>
-		<deb.name>openhab-addon-binding-velux</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.velux</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.wago/pom.xml
+++ b/bundles/binding/org.openhab.binding.wago/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.wago</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.wago</bundle.namespace>
-		<deb.name>openhab-addon-binding-wago</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.wago</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Wago Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.weather/pom.xml
+++ b/bundles/binding/org.openhab.binding.weather/pom.xml
@@ -8,26 +8,10 @@
 
   <name>openHAB Weather Binding</name>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.binding.weather</bundle.symbolicName>
-    <bundle.namespace>org.openhab.binding.weather</bundle.namespace>
-    <deb.name>openhab-addon-binding-weather</deb.name>
-    <deb.description>${project.name}</deb.description>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.binding</groupId>
   <artifactId>org.openhab.binding.weather</artifactId>
 
   <packaging>eclipse-plugin</packaging>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.vafer</groupId>
-        <artifactId>jdeb</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.wemo/pom.xml
+++ b/bundles/binding/org.openhab.binding.wemo/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.wemo</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.wemo</bundle.namespace>
-		<deb.name>openhab-addon-binding-wemo</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.wemo</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Wemo Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.withings/pom.xml
+++ b/bundles/binding/org.openhab.binding.withings/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.withings</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.withings</bundle.namespace>
-		<deb.name>openhab-addon-binding-withings</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.withings</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB Withings Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.wol/pom.xml
+++ b/bundles/binding/org.openhab.binding.wol/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Wake-on-LAN binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.wol</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.wol</bundle.namespace>
-		<deb.name>openhab-addon-binding-wol</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.wol</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.wr3223/pom.xml
+++ b/bundles/binding/org.openhab.binding.wr3223/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.wr3223</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.wr3223</bundle.namespace>
-		<deb.name>openhab-addon-binding-WR3223</deb.name>
-		<deb.description>openhab addon binding WR3223</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.wr3223</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB WR3223 Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.xbmc/pom.xml
+++ b/bundles/binding/org.openhab.binding.xbmc/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB XBMC Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.xbmc</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.xbmc</bundle.namespace>
-		<deb.name>openhab-addon-binding-xbmc</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.xbmc</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-	
 </project>

--- a/bundles/binding/org.openhab.binding.xpl/pom.xml
+++ b/bundles/binding/org.openhab.binding.xpl/pom.xml
@@ -6,14 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.xpl</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.xpl</bundle.namespace>
-		<deb.name>openhab-addon-binding-xpl</deb.name>
-		<deb.description>openhab addon binding xPL</deb.description>
-		<deb.depends>openhab-addon-io-xpl</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.xpl</artifactId>
@@ -21,14 +13,5 @@
 	<name>openHAB xPL Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.yamahareceiver/pom.xml
+++ b/bundles/binding/org.openhab.binding.yamahareceiver/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB YamahaReceiver Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.yamahareceiver</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.yamahareceiver</bundle.namespace>
-		<deb.name>openhab-addon-binding-yamahareceiver</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.yamahareceiver</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-	
 </project>

--- a/bundles/binding/org.openhab.binding.zibase/pom.xml
+++ b/bundles/binding/org.openhab.binding.zibase/pom.xml
@@ -6,13 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.zibase</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.zibase</bundle.namespace>
-		<deb.name>openhab-addon-binding-zibase</deb.name>
-		<deb.description>openhab addon binding zibase</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.zibase</artifactId>
@@ -20,14 +13,5 @@
 	<name>openHAB zibase Binding</name>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/binding/org.openhab.binding.zwave/pom.xml
+++ b/bundles/binding/org.openhab.binding.zwave/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB ZWave Binding</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.binding.zwave</bundle.symbolicName>
-		<bundle.namespace>org.openhab.binding.zwave</bundle.namespace>
-		<deb.name>openhab-addon-binding-zwave</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.binding</groupId>
 	<artifactId>org.openhab.binding.zwave</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/io/org.openhab.io.caldav/pom.xml
+++ b/bundles/io/org.openhab.io.caldav/pom.xml
@@ -6,13 +6,6 @@
     <version>1.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-  	<bundle.symbolicName>org.openhab.io.caldav</bundle.symbolicName>
-  	<bundle.namespace>org.openhab.io.caldav</bundle.namespace>
-  	<deb.name>openhab-addon-io-caldav</deb.name>
-	<deb.description>${project.name}</deb.description>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.io</groupId>
   <artifactId>org.openhab.io.caldav</artifactId>
@@ -21,13 +14,4 @@
 
   <packaging>eclipse-plugin</packaging>
   
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.vafer</groupId>
-        <artifactId>jdeb</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/bundles/io/org.openhab.io.gcal.test/pom.xml
+++ b/bundles/io/org.openhab.io.gcal.test/pom.xml
@@ -6,11 +6,6 @@
     <version>1.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-  	<bundle.symbolicName>org.openhab.io.gcal.test</bundle.symbolicName>
-  	<bundle.namespace>org.openhab.io.gcal.test</bundle.namespace>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.io</groupId>
   <artifactId>org.openhab.io.gcal.test</artifactId>

--- a/bundles/io/org.openhab.io.gcal/pom.xml
+++ b/bundles/io/org.openhab.io.gcal/pom.xml
@@ -6,11 +6,6 @@
     <version>1.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-  	<bundle.symbolicName>org.openhab.io.gcal</bundle.symbolicName>
-  	<bundle.namespace>org.openhab.io.gcal</bundle.namespace>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.io</groupId>
   <artifactId>org.openhab.io.gcal</artifactId>

--- a/bundles/io/org.openhab.io.gpio/pom.xml
+++ b/bundles/io/org.openhab.io.gpio/pom.xml
@@ -6,14 +6,6 @@
     <version>1.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-  	<bundle.symbolicName>org.openhab.io.gpio</bundle.symbolicName>
-  	<bundle.namespace>org.openhab.io.gpio</bundle.namespace>
-  	<deb.name>openhab-addon-io-gpio</deb.name>
-  	<deb.description>${project.name}</deb.description>
-  	<deb.depends>openhab-runtime</deb.depends>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.io</groupId>
   <artifactId>org.openhab.io.gpio</artifactId>
@@ -21,14 +13,5 @@
   <name>openHAB GPIO IO Module</name>
 
   <packaging>eclipse-plugin</packaging>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.vafer</groupId>
-        <artifactId>jdeb</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/bundles/io/org.openhab.io.harmonyhub/pom.xml
+++ b/bundles/io/org.openhab.io.harmonyhub/pom.xml
@@ -9,24 +9,9 @@
 
   <name>openHAB Harmony Client IO</name>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.io.harmonyhub</bundle.symbolicName>
-    <bundle.namespace>org.openhab.io.harmonyhub</bundle.namespace>
-    <deb.name>openhab-addon-io-harmonyhub</deb.name>
-    <deb.description>${project.name}</deb.description>
-  </properties>
-
   <groupId>org.openhab.io</groupId>
   <artifactId>org.openhab.io.harmonyhub</artifactId>
 
   <packaging>eclipse-plugin</packaging>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.vafer</groupId>
-        <artifactId>jdeb</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/bundles/io/org.openhab.io.multimedia.tts.freetts/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.freetts/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Multimedia FreeTTS</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.io.multimedia.tts.freetts</bundle.symbolicName>
-		<bundle.namespace>org.openhab.io.multimedia.tts.freetts</bundle.namespace>
-		<deb.name>openhab-addon-io-multimedia-freetts</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.io</groupId>
 	<artifactId>org.openhab.io.multimedia.tts.freetts</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/io/org.openhab.io.multimedia.tts.googletts.test/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.googletts.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.io.multimedia.tts.googletts.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.io.multimedia.tts.googletts.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.io</groupId>
 	<artifactId>org.openhab.io.multimedia.tts.googletts.test</artifactId>

--- a/bundles/io/org.openhab.io.multimedia.tts.googletts/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.googletts/pom.xml
@@ -9,11 +9,7 @@
 	<name>openHAB Multimedia GoogleTTS</name>
 
 	<properties>
-		<bundle.symbolicName>org.openhab.io.multimedia.tts.googletts</bundle.symbolicName>
-		<bundle.namespace>org.openhab.io.multimedia.tts.googletts</bundle.namespace>
 		<project.dependencyDirectory>${basedir}/resources</project.dependencyDirectory>
-		<deb.name>openhab-addon-io-multimedia-googletts</deb.name>
-		<deb.description>${project.name}</deb.description>
 	</properties>
 
 	<modelVersion>4.0.0</modelVersion>
@@ -22,13 +18,4 @@
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-	
 </project>

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Multimedia MacinTalk</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.io.multimedia.tts.macintalk</bundle.symbolicName>
-		<bundle.namespace>org.openhab.io.multimedia.tts.macintalk</bundle.namespace>
-		<deb.name>openhab-addon-io-multimedia-macintalk</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.io</groupId>
 	<artifactId>org.openhab.io.multimedia.tts.macintalk</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/io/org.openhab.io.multimedia.tts.marytts/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.marytts/pom.xml
@@ -9,11 +9,7 @@
 	<name>openHAB Multimedia MaryTTS</name>
 
 	<properties>
-		<bundle.symbolicName>org.openhab.io.multimedia.tts.marytts</bundle.symbolicName>
-		<bundle.namespace>org.openhab.io.multimedia.tts.marytts</bundle.namespace>
 		<project.dependencyDirectory>${basedir}/resources</project.dependencyDirectory>
-		<deb.name>openhab-addon-io-multimedia-marytts</deb.name>
-		<deb.description>${project.name}</deb.description>
 	</properties>
 
 	<modelVersion>4.0.0</modelVersion>
@@ -198,10 +194,6 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
 			</plugin>
 		</plugins>
 

--- a/bundles/io/org.openhab.io.multimedia.tts.speechdispatcher/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.speechdispatcher/pom.xml
@@ -8,25 +8,10 @@
 
 	<name>openHAB Multimedia SpeechDispatcher</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.io.multimedia.tts.speechdispatcher</bundle.symbolicName>
-		<bundle.namespace>org.openhab.io.multimedia.tts.speechdispatcher</bundle.namespace>
-		<deb.name>openhab-addon-io-multimedia-speechdispatcher</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.io</groupId>
 	<artifactId>org.openhab.io.multimedia.tts.speechdispatcher</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/bundles/io/org.openhab.io.squeezeserver/pom.xml
+++ b/bundles/io/org.openhab.io.squeezeserver/pom.xml
@@ -9,25 +9,9 @@
 
 	<name>openHAB Squeeze Server</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.io.squeezeserver</bundle.symbolicName>
-		<bundle.namespace>org.openhab.io.squeezeserver</bundle.namespace>
-		<deb.name>openhab-addon-io-squeezeserver</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<groupId>org.openhab.io</groupId>
 	<artifactId>org.openhab.io.squeezeserver</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/io/org.openhab.io.transport.cul.test/pom.xml
+++ b/bundles/io/org.openhab.io.transport.cul.test/pom.xml
@@ -6,11 +6,6 @@
     <version>1.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-  	<bundle.symbolicName>org.openhab.io.transport.cul.test</bundle.symbolicName>
-  	<bundle.namespace>org.openhab.io.transport.cul.test</bundle.namespace>
-  </properties>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.io</groupId>
   <artifactId>org.openhab.io.transport.cul.test</artifactId>

--- a/bundles/io/org.openhab.io.transport.cul/pom.xml
+++ b/bundles/io/org.openhab.io.transport.cul/pom.xml
@@ -7,25 +7,11 @@
   	<version>1.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.io.transport.cul</bundle.symbolicName>
-    <bundle.namespace>org.openhab.io.transport.cul</bundle.namespace>
-    <deb.name>openhab-addon-io-cul</deb.name>
-    <deb.description>${project.name}</deb.description>
- </properties>
-
   <groupId>org.openhab.io</groupId>
   <artifactId>org.openhab.io.transport.cul</artifactId>
 
   <name>openHAB CUL Transport</name>
 
   <packaging>eclipse-plugin</packaging>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+
 </project>

--- a/bundles/io/org.openhab.io.transport.mqtt/pom.xml
+++ b/bundles/io/org.openhab.io.transport.mqtt/pom.xml
@@ -7,11 +7,6 @@
   	<version>1.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.io.transport.mqtt</bundle.symbolicName>
-    <bundle.namespace>org.openhab.io.transport.mqtt</bundle.namespace>
-  </properties>
-
   <groupId>org.openhab.io</groupId>
   <artifactId>org.openhab.io.transport.mqtt</artifactId>
 

--- a/bundles/io/org.openhab.io.transport.xpl/pom.xml
+++ b/bundles/io/org.openhab.io.transport.xpl/pom.xml
@@ -7,17 +7,11 @@
   	<version>1.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <bundle.symbolicName>org.openhab.io.transport.xpl</bundle.symbolicName>
-    <bundle.namespace>org.openhab.io.transport.xpl</bundle.namespace>
-    <deb.name>openhab-addon-io-xpl</deb.name>
-    <deb.description>${project.name}</deb.description>
- </properties>
-
   <groupId>org.openhab.io</groupId>
   <artifactId>org.openhab.io.transport.xpl</artifactId>
 
   <name>openHAB xPL Transport</name>
 
   <packaging>eclipse-plugin</packaging>
+
 </project>

--- a/bundles/persistence/org.openhab.persistence.caldav/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.caldav/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB calDAV Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.caldav</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.caldav</bundle.namespace>
-		<deb.name>openhab-addon-persistence-caldav</deb.name>
-		<deb.description>${project.name}</deb.description>
-  		<deb.depends>openhab-runtime</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.caldav</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.cosm/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.cosm/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Cosm Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.cosm</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.cosm</bundle.namespace>
-		<deb.name>openhab-addon-persistence-cosm</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.cosm</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.db4o.test/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.db4o.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.db4o.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.db4o.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.db4o.test</artifactId>

--- a/bundles/persistence/org.openhab.persistence.db4o/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.db4o/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB db4o Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.db4o</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.db4o</bundle.namespace>
-		<deb.name>openhab-addon-persistence-db4o</deb.name>
-		<deb.description>${project.name}</deb.description>
-  		<deb.depends>openhab-runtime</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.db4o</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.dynamodb.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.dynamodb.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.dynamodb.test</artifactId>

--- a/bundles/persistence/org.openhab.persistence.dynamodb/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB dynamodb Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.dynamodb</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.dynamodb</bundle.namespace>
-		<deb.name>openhab-addon-persistence-dynamodb</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.dynamodb</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.exec.test/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.exec.test/pom.xml
@@ -6,11 +6,6 @@
 		<version>1.13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.exec.test</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.exec.test</bundle.namespace>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.exec.test</artifactId>

--- a/bundles/persistence/org.openhab.persistence.exec/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.exec/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Exec Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.exec</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.exec</bundle.namespace>
-		<deb.name>openhab-addon-persistence-exec</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.exec</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.gcal/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.gcal/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Google Calendar Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.gcal</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.gcal</bundle.namespace>
-		<deb.name>openhab-addon-persistence-gcal</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.gcal</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.influxdb/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.influxdb/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB InfluxDB Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.influxdb</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.influxdb</bundle.namespace>
-		<deb.name>openhab-addon-persistence-influxdb</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.influxdb</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.influxdb08/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.influxdb08/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB InfluxDB 0.8 Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.influxdb08</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.influxdb08</bundle.namespace>
-		<deb.name>openhab-addon-persistence-influxdb08</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.influxdb08</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.jdbc/pom.xml
@@ -20,11 +20,7 @@
 		<hikari.version>2.4.7</hikari.version>
 		<dbutils.version>1.6</dbutils.version>
 		<yank.version>3.2.0</yank.version>
-		<bundle.symbolicName>org.openhab.persistence.jdbc</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.jdbc</bundle.namespace>
 		<classpath.ext>lib/</classpath.ext>
-		<deb.name>openhab-addon-persistence-jdbc</deb.name>
-		<deb.description>${project.name}</deb.description>
 	</properties>
 
 	<dependencies>
@@ -83,14 +79,4 @@
 
 	</dependencies>
 
-	<build>
-		<plugins>
-
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-
-		</plugins>
-	</build>
 </project>

--- a/bundles/persistence/org.openhab.persistence.jpa/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.jpa/pom.xml
@@ -8,13 +8,6 @@
 
     <name>openHAB JPA Persistence</name>
 
-    <properties>
-        <bundle.symbolicName>org.openhab.persistence.jpa</bundle.symbolicName>
-        <bundle.namespace>org.openhab.persistence.jpa</bundle.namespace>
-        <deb.name>openhab-addon-persistence-jpa</deb.name>
-        <deb.description>${project.name}</deb.description>
-    </properties>
-
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.openhab.persistence</groupId>
     <artifactId>org.openhab.persistence.jpa</artifactId>
@@ -23,10 +16,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.vafer</groupId>
-                <artifactId>jdeb</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.apache.openjpa</groupId>
                 <artifactId>openjpa-maven-plugin</artifactId>

--- a/bundles/persistence/org.openhab.persistence.logging/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.logging/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Logging Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.logging</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.logging</bundle.namespace>
-		<deb.name>openhab-addon-persistence-logging</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.logging</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.mapdb/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.mapdb/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB MapDB Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.mapdb</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.mapdb</bundle.namespace>
-		<deb.name>openhab-addon-persistence-mapdb</deb.name>
-		<deb.description>${project.name}</deb.description>
-  		<deb.depends>openhab-runtime</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.mapdb</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.mongodb/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.mongodb/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB mongodb Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.mongodb</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.mongodb</bundle.namespace>
-		<deb.name>openhab-addon-persistence-mongodb</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.mongodb</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.mqtt/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.mqtt/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB MQTT Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.mqtt</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.mqtt</bundle.namespace>
-		<deb.name>openhab-addon-persistence-mqtt</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.mqtt</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.mysql/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.mysql/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB mySQL Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.mysql</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.mysql</bundle.namespace>
-		<deb.name>openhab-addon-persistence-mysql</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.mysql</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.rrd4j/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB RRD4j Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.rrd4j</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.rrd4j</bundle.namespace>
-		<deb.name>openhab-addon-persistence-rrd4j</deb.name>
-		<deb.description>${project.name}</deb.description>
-  		<deb.depends>openhab-runtime</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.rrd4j</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.sense/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.sense/pom.xml
@@ -8,26 +8,10 @@
 
 	<name>openHAB Open.Sen.se Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.sense</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.sense</bundle.namespace>
-		<deb.name>openhab-addon-persistence-sense</deb.name>
-		<deb.description>${project.name}</deb.description>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.sense</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/bundles/persistence/org.openhab.persistence.sitewhere/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.sitewhere/pom.xml
@@ -8,27 +8,10 @@
 
 	<name>openHAB SiteWhere Persistence</name>
 
-	<properties>
-		<bundle.symbolicName>org.openhab.persistence.sitewhere</bundle.symbolicName>
-		<bundle.namespace>org.openhab.persistence.sitewhere</bundle.namespace>
-		<deb.name>openhab-addon-persistence-sitewhere</deb.name>
-		<deb.description>${project.name}</deb.description>
-  		<deb.depends>openhab-runtime</deb.depends>
-	</properties>
-
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhab.persistence</groupId>
 	<artifactId>org.openhab.persistence.sitewhere</artifactId>
 
 	<packaging>eclipse-plugin</packaging>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.vafer</groupId>
-				<artifactId>jdeb</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,6 @@
                         </execution>
                     </executions>
                 </plugin>
-                <plugin>
-                    <groupId>org.vafer</groupId>
-                    <artifactId>jdeb</artifactId>
-                    <version>1.5</version>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
* Removes unused Maven properties from POM files:
  * bundle.symbolicName
  * bundle.namespace
  * deb.name
  * deb.description
  * deb.depends
* Removes the unused org.vafer:jdeb plugin and its executions from POM files

Fixes #5642 

In a follow up PR we could also run the sortpom-maven-plugin to apply the POM conventions we use in other projects. That would fix the mix of all sorts of spaces and tab variations.