### PR TITLE
[dsmr] Moved dsmr binding to legacy, replaced by openHAB 2 version.

### DIFF
--- a/features/openhab-addons-legacy/src/main/feature/feature.xml
+++ b/features/openhab-addons-legacy/src/main/feature/feature.xml
@@ -37,6 +37,14 @@
     <configfile finalname="${openhab.conf}/services/dmx.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/dmx</configfile>
   </feature>
 
+  <feature name="openhab-binding-dsmr1" description="DSMR Binding (1.x)" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <feature>openhab-transport-serial</feature>
+    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.dsmr/${project.version}</bundle>
+    <configfile finalname="${openhab.conf}/services/dsmr.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/dsmr</configfile>
+  </feature>
+
   <feature name="openhab-binding-exec1" description="Exec Binding (1.x)" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -169,14 +169,6 @@
     <configfile finalname="${openhab.conf}/services/denon.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/denon</configfile>
   </feature>
 
-  <feature name="openhab-binding-dsmr1" description="DSMR Binding" version="${project.version}">
-    <feature>openhab-runtime-base</feature>
-    <feature>openhab-runtime-compat1x</feature>
-    <feature>openhab-transport-serial</feature>
-    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.dsmr/${project.version}</bundle>
-    <configfile finalname="${openhab.conf}/services/dsmr.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/dsmr</configfile>
-  </feature>
-
   <feature name="openhab-binding-ebus1" description="eBUS Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>


### PR DESCRIPTION
This binding has been replaced by a openHAB version 2: https://github.com/openhab/openhab2-addons/pull/3720