### PR TITLE
moved OneWire binding to legacy add-ons

### DIFF
--- a/features/openhab-addons-legacy/src/main/feature/feature.xml
+++ b/features/openhab-addons-legacy/src/main/feature/feature.xml
@@ -116,6 +116,14 @@
     <configfile finalname="${openhab.conf}/services/nibeheatpump.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/nibeheatpump</configfile>
   </feature>
 
+  <feature name="openhab-binding-onewire1" description="OneWire Binding (1.x)" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.onewire/${project.version}</bundle>
+    <configfile finalname="${openhab.conf}/services/onewire.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/onewire</configfile>
+  </feature>
+
+
   <feature name="openhab-binding-onkyo1" description="Onkyo Binding (1.x)" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -503,13 +503,6 @@
     <configfile finalname="${openhab.conf}/services/openenergymonitor.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/openenergymonitor</configfile>
   </feature>
 
-  <feature name="openhab-binding-onewire1" description="OneWire Binding" version="${project.version}">
-    <feature>openhab-runtime-base</feature>
-    <feature>openhab-runtime-compat1x</feature>
-    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.onewire/${project.version}</bundle>
-    <configfile finalname="${openhab.conf}/services/onewire.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/onewire</configfile>
-  </feature>
-
   <feature name="openhab-binding-owserver1" description="OWServer Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>