### PR TITLE
removed irrelevant implementations of autoUpdate feature as a cleanup…

### DIFF
--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/AlarmDecoderBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/AlarmDecoderBindingProvider.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 
 import org.openhab.binding.alarmdecoder.internal.ADMsgType;
 import org.openhab.binding.alarmdecoder.internal.AlarmDecoderBindingConfig;
-import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
+import org.openhab.core.binding.BindingProvider;
 
 /**
  * This interface is implemented by classes that provide per-item binding configuration
@@ -20,13 +20,13 @@ import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
  * @author Bernd Pfrommer
  * @since 1.6.0
  */
-public interface AlarmDecoderBindingProvider extends AutoUpdateBindingProvider {
+public interface AlarmDecoderBindingProvider extends BindingProvider {
 
     /**
      * Get the binding configuration for a given itemName. This method
      * is useful when sending a command, where the item name is known,
      * and the corresponding device must be determined
-     * 
+     *
      * @param itemName
      * @return the binding configuration for the item or null if not found
      */
@@ -37,9 +37,9 @@ public interface AlarmDecoderBindingProvider extends AutoUpdateBindingProvider {
      * If a null address is given, all configurations with the given message type
      * are returned. This method is useful to find the items that need to be
      * updated when a message comes in.
-     * 
-     * @param mt the message type to look for (or all types if null)
-     * @param addr the address to narrow it down to (or all addresses if null)
+     *
+     * @param mt      the message type to look for (or all types if null)
+     * @param addr    the address to narrow it down to (or all addresses if null)
      * @param feature the feature to narrow it down to (or all features if null)
      * @return a (potentially empty) list of binding configs that reference (mt, addr, feature)
      */

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderGenericBindingProvider.java
@@ -137,7 +137,7 @@ public class AlarmDecoderGenericBindingProvider extends AbstractGenericBindingPr
     /**
      * Removes existing item configurations
      *
-     * @param bcl array list of binding configs to be checked
+     * @param bcl  array list of binding configs to be checked
      * @param item item to be checked for
      */
     private static void removeExisting(ArrayList<AlarmDecoderBindingConfig> bcl, Item item) {
@@ -234,11 +234,6 @@ public class AlarmDecoderGenericBindingProvider extends AbstractGenericBindingPr
             default:
                 return (false);
         }
-    }
-
-    @Override
-    public Boolean autoUpdate(String itemName) {
-        return true;
     }
 
 }

--- a/bundles/binding/org.openhab.binding.hdanywhere/src/main/java/org/openhab/binding/hdanywhere/HDanywhereBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.hdanywhere/src/main/java/org/openhab/binding/hdanywhere/HDanywhereBindingProvider.java
@@ -11,7 +11,7 @@ package org.openhab.binding.hdanywhere;
 import java.util.HashMap;
 import java.util.List;
 
-import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
+import org.openhab.core.binding.BindingProvider;
 
 /**
  * Interface of the HDanywhere Binding Provider
@@ -19,7 +19,7 @@ import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
  * @author Karel Goderis
  * @since 1.4.0
  */
-public interface HDanywhereBindingProvider extends AutoUpdateBindingProvider {
+public interface HDanywhereBindingProvider extends BindingProvider {
 
     /**
      * Returns a <code>List</code> of host names/IP addresses associated to <code>itemName</code>.
@@ -34,7 +34,7 @@ public interface HDanywhereBindingProvider extends AutoUpdateBindingProvider {
      * Returns a <code>List</code> of HDanywhere matrix output port numbers associated to <code>host</code> and
      * <code>itemName</code>.
      *
-     * @param host the HDanywhere matrix to find matrix output ports for
+     * @param host     the HDanywhere matrix to find matrix output ports for
      * @param itemName the item for which to find matrix output ports for
      * @return a List of matching output port numbers or <code>null</code> if no port numbers
      *         could be found.

--- a/bundles/binding/org.openhab.binding.hdanywhere/src/main/java/org/openhab/binding/hdanywhere/internal/HDanywhereGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.hdanywhere/src/main/java/org/openhab/binding/hdanywhere/internal/HDanywhereGenericBindingProvider.java
@@ -110,7 +110,7 @@ public class HDanywhereGenericBindingProvider extends AbstractGenericBindingProv
 
     /**
      * Parses the configuration string and update the provided config
-     * 
+     *
      * @param config
      * @param item
      * @param bindingConfig
@@ -146,7 +146,7 @@ public class HDanywhereGenericBindingProvider extends AbstractGenericBindingProv
      * This is an internal data structure to track
      * {@link ProtocolBindingConfigElement }.
      */
-    static class HDanywhereBindingConfig extends ArrayList<HDanywhereBindingConfigElement>implements BindingConfig {
+    static class HDanywhereBindingConfig extends ArrayList<HDanywhereBindingConfigElement> implements BindingConfig {
 
         private static final long serialVersionUID = -7252828812548386063L;
     }
@@ -189,14 +189,6 @@ public class HDanywhereGenericBindingProvider extends AbstractGenericBindingProv
             return "HDanywhereBindingConfigElement [host=" + host + ", port=" + port + ", interval=" + interval + "]";
         }
 
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Boolean autoUpdate(String itemName) {
-        return false;
     }
 
     @Override

--- a/bundles/binding/org.openhab.binding.ihc/OSGI-INF/genericbindingprovider.xml
+++ b/bundles/binding/org.openhab.binding.ihc/OSGI-INF/genericbindingprovider.xml
@@ -14,6 +14,5 @@
    <service>
       <provide interface="org.openhab.model.item.binding.BindingConfigReader"/>
       <provide interface="org.openhab.binding.ihc.IhcBindingProvider"/>
-      <provide interface="org.openhab.core.autoupdate.AutoUpdateBindingProvider"/>
    </service>
 </scr:component>

--- a/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/IhcGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/IhcGenericBindingProvider.java
@@ -13,7 +13,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.openhab.binding.ihc.IhcBindingProvider;
-import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
 import org.openhab.core.binding.BindingConfig;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.ContactItem;
@@ -71,8 +70,7 @@ import org.slf4j.LoggerFactory;
  * @author Simon Merschjohann
  * @since 1.1.0
  */
-public class IhcGenericBindingProvider extends AbstractGenericBindingProvider
-        implements IhcBindingProvider, AutoUpdateBindingProvider {
+public class IhcGenericBindingProvider extends AbstractGenericBindingProvider implements IhcBindingProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(IhcGenericBindingProvider.class);
 
@@ -298,11 +296,6 @@ public class IhcGenericBindingProvider extends AbstractGenericBindingProvider
 
         }
 
-    }
-
-    @Override
-    public Boolean autoUpdate(String itemName) {
-        return null;
     }
 
     @Override

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMBindingProvider.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.insteonplm;
 
-import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
+import org.openhab.core.binding.BindingProvider;
 
 /**
  * Binding provider interface. Defines the methods to interact with the binding provider.
@@ -16,11 +16,11 @@ import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
  * @author Bernd Pfrommer
  * @since 1.5.0
  */
-public interface InsteonPLMBindingProvider extends AutoUpdateBindingProvider {
+public interface InsteonPLMBindingProvider extends BindingProvider {
     /**
      * Returns the binding configuration for the item with
      * this name.
-     * 
+     *
      * @param itemName the name to get the binding configuration for.
      * @return the binding configuration.
      */

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMGenericBindingProvider.java
@@ -84,19 +84,6 @@ public class InsteonPLMGenericBindingProvider extends AbstractGenericBindingProv
     }
 
     /**
-     * Inherited from AbstractGenericBindingProvider.
-     * {@inheritDoc}
-     */
-    @Override
-    public Boolean autoUpdate(String itemName) {
-        // By default, all features are auto-updating, i.e. we do not rely
-        // on the openhab environment to tell us the status of a device,
-        // but rather resort to polling and listening to update messages
-        // on the insteon network.
-        return true;
-    }
-
-    /**
      * Inherited from InsteonPLMBindingProvider.
      * {@inheritDoc}
      */
@@ -107,9 +94,9 @@ public class InsteonPLMGenericBindingProvider extends AbstractGenericBindingProv
 
     /**
      * Parses binding configuration string. The config string has the format:
-     * 
+     *
      * xx.xxx.xxx:productKey#feature,param1=yyy,param2=zzz
-     * 
+     *
      * @param bindingConfig string with binding parameters
      * @return String array with split arguments: [address,prodKey,features+params]
      * @throws BindingConfigParseException if parameters are invalid

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/PlugwiseBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/PlugwiseBindingProvider.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.openhab.binding.plugwise.internal.PlugwiseGenericBindingProvider.PlugwiseBindingConfigElement;
-import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
+import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.types.Command;
 
 /**
@@ -21,7 +21,7 @@ import org.openhab.core.types.Command;
  * @author Karel Goderis
  * @since 1.1.0
  */
-public interface PlugwiseBindingProvider extends AutoUpdateBindingProvider {
+public interface PlugwiseBindingProvider extends BindingProvider {
 
     /**
      * Returns a <code>List</code> of matching Plugwise IDs (associated to <code>itemName</code>.
@@ -36,7 +36,7 @@ public interface PlugwiseBindingProvider extends AutoUpdateBindingProvider {
      * Returns the matching Plugwise ID (associated to <code>itemName</code> and aCommand).
      *
      * @param itemName the item for which to find a Plugwise ID (the device MAC or name)
-     * @param command the a command
+     * @param command  the a command
      * @return a List of matching Plugwise IDs or <code>null</code> if no matching Plugwise ID
      *         could be found.
      */
@@ -46,7 +46,7 @@ public interface PlugwiseBindingProvider extends AutoUpdateBindingProvider {
      * Returns the matching Plugwise command (associated to <code>itemName</code> and aCommand).
      *
      * @param plugwiseID the Plugwise ID (the device MAC or name)
-     * @param type the type
+     * @param type       the type
      * @return a List of matching Plugwise IDs or <code>null</code> if no matching Plugwise ID
      *         could be found.
      */
@@ -67,7 +67,7 @@ public interface PlugwiseBindingProvider extends AutoUpdateBindingProvider {
     /**
      * Gets the commands by type.
      *
-     * @param itemName the item name
+     * @param itemName     the item name
      * @param commandClass the command class
      * @return the commands by type
      */
@@ -77,7 +77,7 @@ public interface PlugwiseBindingProvider extends AutoUpdateBindingProvider {
      * Gets the corresponding plugwise command type for a given Item and Command
      *
      * @param itemName the item name
-     * @param command the command
+     * @param command  the command
      * @return the plugwise command type
      */
     public PlugwiseCommandType getPlugwiseCommandType(String itemName, Command command);

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseGenericBindingProvider.java
@@ -202,7 +202,7 @@ public class PlugwiseGenericBindingProvider extends AbstractGenericBindingProvid
      *         information
      *
      * @throws BindingConfigParseException if the {@link TypeParser} couldn't
-     *             create a command appropriately
+     *                                         create a command appropriately
      *
      * @see {@link TypeParser}
      */
@@ -257,11 +257,6 @@ public class PlugwiseGenericBindingProvider extends AbstractGenericBindingProvid
                     + "]";
         }
 
-    }
-
-    @Override
-    public Boolean autoUpdate(String itemName) {
-        return false;
     }
 
     @Override

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingProvider.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.zwave;
 
-import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
+import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.items.Item;
 
 /**
@@ -18,7 +18,7 @@ import org.openhab.core.items.Item;
  * @author Victor Belov
  * @since 1.3.0
  */
-public interface ZWaveBindingProvider extends AutoUpdateBindingProvider {
+public interface ZWaveBindingProvider extends BindingProvider {
     /**
      * Returns the binding configuration for the item with
      * this name.

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveGenericBindingProvider.java
@@ -137,14 +137,6 @@ public class ZWaveGenericBindingProvider extends AbstractGenericBindingProvider 
      * {@inheritDoc}
      */
     @Override
-    public Boolean autoUpdate(String itemName) {
-        return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public Item getItem(String itemName) {
         return items.get(itemName);
     }


### PR DESCRIPTION
… in advent of https://github.com/eclipse/smarthome/pull/5011

Signed-off-by: Kai Kreuzer <kai@openhab.org>