### PR TITLE
[fritzboxtr064] replaced the trim method, to get rid of white spaces in between the tel numbers

### DIFF
--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/PhonebookManager.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/PhonebookManager.java
@@ -55,7 +55,7 @@ public class PhonebookManager {
                 if (phoneBookTel == null) {
                     continue;
                 }
-                String reversedPhonebookTel = new StringBuilder(phoneBookTel.trim()).reverse().toString();
+                String reversedPhonebookTel = new StringBuilder(phoneBookTel.replaceAll("\\s+","")).reverse().toString();
                 if (reversedPhonebookTel.length() == 0) {
                     continue;
                 }


### PR DESCRIPTION
fixed name resolution of address book entries.
the name resolution did not work 100% correct, if there are some white spaces in between the number, i.e. like this '+49 40 123 456 789'
