### PR TITLE
made item registry mandatory in persistence services

### DIFF
--- a/bundles/persistence/org.openhab.persistence.caldav/OSGI-INF/caldav.xml
+++ b/bundles/persistence/org.openhab.persistence.caldav/OSGI-INF/caldav.xml
@@ -16,5 +16,5 @@
       <provide interface="org.openhab.core.persistence.PersistenceService"/>
    </service>
    <reference bind="setCalDavLoader" cardinality="1..1" interface="org.openhab.io.caldav.CalDavLoader" name="CalDavLoader" policy="static" unbind="unsetCalDavLoader"/>
-   <reference bind="setItemRegistry" cardinality="0..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
 </scr:component>

--- a/bundles/persistence/org.openhab.persistence.dynamodb/OSGI-INF/dynamodb.xml
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/OSGI-INF/dynamodb.xml
@@ -14,7 +14,7 @@
    <service>
       <provide interface="org.openhab.core.persistence.PersistenceService"/>
    </service>
-   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
    <property name="service.config.description.uri" type="String" value="persistence:dynamodb"/>
    <property name="service.config.label" type="String" value="Amazon DynamoDB Persistence"/>
    <property name="service.config.category" type="String" value="persistence"/>

--- a/bundles/persistence/org.openhab.persistence.influxdb08/OSGI-INF/influxdb.xml
+++ b/bundles/persistence/org.openhab.persistence.influxdb08/OSGI-INF/influxdb.xml
@@ -15,5 +15,5 @@
       <provide interface="org.openhab.core.persistence.PersistenceService"/>
       <provide interface="org.openhab.core.persistence.QueryablePersistenceService"/>
    </service>
-   <reference bind="setItemRegistry" cardinality="0..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
 </scr:component>

--- a/bundles/persistence/org.openhab.persistence.jdbc/OSGI-INF/jdbc.xml
+++ b/bundles/persistence/org.openhab.persistence.jdbc/OSGI-INF/jdbc.xml
@@ -15,7 +15,7 @@
       <provide interface="org.openhab.core.persistence.PersistenceService"/>
       <provide interface="org.openhab.core.persistence.QueryablePersistenceService"/>
    </service>
-   <reference bind="setItemRegistry" cardinality="0..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
    <property name="service.config.description.uri" type="String" value="persistence:jdbc"/>
    <property name="service.config.label" type="String" value="JDBC Persistence"/>
    <property name="service.config.category" type="String" value="persistence"/>

--- a/bundles/persistence/org.openhab.persistence.jpa/OSGI-INF/jpa.xml
+++ b/bundles/persistence/org.openhab.persistence.jpa/OSGI-INF/jpa.xml
@@ -15,5 +15,5 @@
       <provide interface="org.openhab.core.persistence.PersistenceService"/>
       <provide interface="org.openhab.core.persistence.QueryablePersistenceService"/>
    </service>
-   <reference bind="setItemRegistry" cardinality="0..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
 </scr:component>

--- a/bundles/persistence/org.openhab.persistence.mongodb/OSGI-INF/mongodb.xml
+++ b/bundles/persistence/org.openhab.persistence.mongodb/OSGI-INF/mongodb.xml
@@ -14,5 +14,5 @@
    <service>
       <provide interface="org.openhab.core.persistence.PersistenceService"/>
    </service>
-   <reference bind="setItemRegistry" cardinality="0..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
 </scr:component>

--- a/bundles/persistence/org.openhab.persistence.mysql/OSGI-INF/mysql.xml
+++ b/bundles/persistence/org.openhab.persistence.mysql/OSGI-INF/mysql.xml
@@ -14,5 +14,5 @@
    <service>
       <provide interface="org.openhab.core.persistence.PersistenceService"/>
    </service>
-   <reference bind="setItemRegistry" cardinality="0..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
 </scr:component>

--- a/bundles/persistence/org.openhab.persistence.rrd4j/OSGI-INF/rrd4j.xml
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/OSGI-INF/rrd4j.xml
@@ -14,5 +14,5 @@
    <service>
     <provide interface="org.openhab.core.persistence.PersistenceService"/>
    </service>
-   <reference bind="setItemRegistry" cardinality="0..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
 </scr:component>


### PR DESCRIPTION
Same as https://github.com/openhab/openhab1-addons/pull/5659 for the other persistence services

Signed-off-by: Kai Kreuzer <kai@openhab.org>