### PR TITLE
[Plex] Eliminate a potential Null Pointer Exception in the getHost method

### DIFF
--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnector.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnector.java
@@ -414,6 +414,11 @@ public class PlexConnector extends Thread {
             clientCache = getDocument(clientsUrl, MediaContainer.class);
         }
 
+        if (clientCache == null) {
+            logger.debug("clientCache is null. Unable to get host.");
+            return null;
+        }
+
         Server server = clientCache.getServer(machineIdentifier);
         if (server != null) {
             return server;


### PR DESCRIPTION
Eliminates a potential Null Pointer Exception in the getHost method, as described in #5668.
This showed up due to a user configuration pointing to an unresolvable hostname.
