### PR TITLE
[Persistence][Documentation] Small change to highlight the mandatory use of the everyMinute strategy

### DIFF
--- a/bundles/persistence/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/README.md
@@ -95,7 +95,11 @@ ctr5min.items=Item1,Item2
 ```
 
 All item- and event-related configuration is done in the file `persistence/rrd4j.persist`.
-The strategy `everyMinute` (60 seconds) has to be used, otherwise no data will be persisted (stored).
+
+**IMPORTANT**
+
+The strategy `everyMinute` (60 seconds) **MUST** be used, otherwise no data will be persisted (stored).
+Other strategies can be used too.
 
 rrd4j.persist:
 


### PR DESCRIPTION
I have hignlighted the fact that the `everyMinute` strategy must be used,
There have been a number of recent queries regarding non persisted data with the rrd4j database where the user had not set the everyMinute strategy.