### PR TITLE
[oem] throttle support

### DIFF
--- a/bundles/binding/org.openhab.binding.openenergymonitor/README.md
+++ b/bundles/binding/org.openhab.binding.openenergymonitor/README.md
@@ -27,10 +27,11 @@ execution:
 
 This binding can be configured in the file `services/openenergymonitor.cfg`.
 
-| Property | Default | Required | Description |
-|----------|---------|:--------:|-------------|
-| udpPort  | 9997    |   No     | UDP port of the Open Energy Monitor devices |
-| `<rule>` |         |   No     | `<node address>:<data type(byte indexes)>` |
+| Property      | Default | Required | Description |
+|---------------|---------|:--------:|-------------|
+| udpPort       | 9997    |   No     | UDP port of the Open Energy Monitor devices |
+| throttleTime  | 0       |   No     | Throttle received messages. 0 = throttle is disabled, otherwise throttle time in milliseconds. |
+| `<rule>`      |         |   No     | `<node address>:<data type(byte indexes)>` |
 
 where `<rule>` is in the format used in this example:
 

--- a/bundles/binding/org.openhab.binding.openenergymonitor/src/main/java/org/openhab/binding/openenergymonitor/internal/OpenEnergyMonitorBinding.java
+++ b/bundles/binding/org.openhab.binding.openenergymonitor/src/main/java/org/openhab/binding/openenergymonitor/internal/OpenEnergyMonitorBinding.java
@@ -52,6 +52,7 @@ public class OpenEnergyMonitorBinding extends AbstractBinding<OpenEnergyMonitorB
     private int udpPort = 9997;
     private String serialPort = null;
     private boolean simulate = false;
+    private int throttleTime = 0;
 
     private OpenEnergyMonitorDataParser dataParser = null;
 
@@ -114,6 +115,10 @@ public class OpenEnergyMonitorBinding extends AbstractBinding<OpenEnergyMonitorB
                     if (StringUtils.isNotBlank(value)) {
                         simulate = Boolean.parseBoolean(value);
                     }
+                } else if ("throttleTime".equals(key)) {
+                    if (StringUtils.isNotBlank(value)) {
+                        throttleTime = Integer.parseInt(value);
+                    }
                 } else {
 
                     // process all data parsing rules
@@ -127,10 +132,7 @@ public class OpenEnergyMonitorBinding extends AbstractBinding<OpenEnergyMonitorB
 
             }
 
-            if (parsingRules != null) {
-
-                dataParser = new OpenEnergyMonitorDataParser(parsingRules);
-            }
+            dataParser = new OpenEnergyMonitorDataParser(parsingRules, throttleTime);
 
             if (messageListener != null) {
 


### PR DESCRIPTION
Open energy monitor devices can send messages at a high speed (e.g. every second) which can cause lot of item updates. Added throttle feature which can be used to skip some incoming messages. 

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>