### PR TITLE
[swegon] Added throttle support

### DIFF
--- a/bundles/binding/org.openhab.binding.swegonventilation/README.md
+++ b/bundles/binding/org.openhab.binding.swegonventilation/README.md
@@ -25,9 +25,10 @@ swegongw -v -d /dev/ttyUSB0 -a 192.168.1.10
 
 This binding can be configured in the file `services/swegonventilation.cfg`.
 
-| Property | Default | Required | Description |
-|----------|---------|:--------:|-------------|
-| udpPort  | 9998    |    No    | UDP port on which the binding will listen |
+| Property      | Default | Required | Description |
+|---------------|---------|:--------:|-------------|
+| udpPort       | 9998    |    No    | UDP port on which the binding will listen |
+| throttleTime  | 0       |    No    | Throttle received messages. 0 = throttle is disabled, otherwise throttle time in milliseconds. |
 
 ## Item Configuration
 

--- a/bundles/binding/org.openhab.binding.swegonventilation/src/main/java/org/openhab/binding/swegonventilation/internal/SwegonVentilationBinding.java
+++ b/bundles/binding/org.openhab.binding.swegonventilation/src/main/java/org/openhab/binding/swegonventilation/internal/SwegonVentilationBinding.java
@@ -53,6 +53,7 @@ public class SwegonVentilationBinding extends AbstractBinding<SwegonVentilationB
     private int udpPort = 9998;
     private String serialPort = null;
     private boolean simulator = false;
+    private int throttleTime = 0;
 
     /** Thread to handle messages from heat pump */
     private MessageListener messageListener = null;
@@ -111,6 +112,11 @@ public class SwegonVentilationBinding extends AbstractBinding<SwegonVentilationB
             String simulateString = (String) config.get("simulate");
             if (StringUtils.isNotBlank(simulateString)) {
                 simulator = Boolean.parseBoolean(simulateString);
+            }
+
+            String throttleTimeString = (String) config.get("throttleTime");
+            if (StringUtils.isNotBlank(throttleTimeString)) {
+                throttleTime = Integer.parseInt(throttleTimeString);
             }
         }
 
@@ -219,7 +225,7 @@ public class SwegonVentilationBinding extends AbstractBinding<SwegonVentilationB
                     logger.trace("Received data (len={}): {}", data.length, DatatypeConverter.printHexBinary(data));
 
                     HashMap<SwegonVentilationCommandType, Integer> regValues = SwegonVentilationDataParser
-                            .parseData(data);
+                            .parseData(data, throttleTime);
 
                     if (regValues != null) {
 

--- a/bundles/binding/org.openhab.binding.swegonventilation/src/main/java/org/openhab/binding/swegonventilation/protocol/SwegonVentilationDataParser.java
+++ b/bundles/binding/org.openhab.binding.swegonventilation/src/main/java/org/openhab/binding/swegonventilation/protocol/SwegonVentilationDataParser.java
@@ -12,6 +12,8 @@ import java.util.HashMap;
 
 import org.openhab.binding.swegonventilation.internal.SwegonVentilationCommandType;
 import org.openhab.binding.swegonventilation.internal.SwegonVentilationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class for parse data packets from Swegon ventilation system.
@@ -20,8 +22,20 @@ import org.openhab.binding.swegonventilation.internal.SwegonVentilationException
  * @since 1.4.0
  */
 public class SwegonVentilationDataParser {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SwegonVentilationDataParser.class);
 
-    public static HashMap<SwegonVentilationCommandType, Integer> parseData(byte[] data)
+    private static HashMap<Byte, Long> updateTimes = new HashMap<Byte, Long>();
+
+    private static long getLastUpdateTime(byte msgType) {
+        Long throttleTime = updateTimes.get(msgType);
+        return throttleTime != null ? throttleTime : 0;
+    }
+
+    private static void setLastUpdateTime(byte msgType, long time) {
+        updateTimes.put(msgType, time);
+    }
+
+    public static HashMap<SwegonVentilationCommandType, Integer> parseData(byte[] data, int throttleTime)
             throws SwegonVentilationException {
 
         if (data[0] == (byte) 0x64) {
@@ -41,15 +55,28 @@ public class SwegonVentilationDataParser {
                 d[i - 8] = data[i];
             }
 
-            switch (msgType) {
-                case (byte) 0x21:
-                    return parseMessage21(d);
-                case (byte) 0x71:
-                    return parseMessage71(d);
-                case (byte) 0x73:
-                    return parseMessage73(d);
+            boolean parse = true;
+
+            LOGGER.debug("Received message type '{}'", msgType);
+            if (throttleTime > 0) {
+                if ((getLastUpdateTime(msgType) + throttleTime) > System.currentTimeMillis()) {
+                    LOGGER.debug("Skipping message parsing");
+                    parse = false;
+                }
             }
 
+            if (parse) {
+                LOGGER.debug("Parsing message");
+                setLastUpdateTime(msgType, System.currentTimeMillis());
+                switch (msgType) {
+                    case (byte) 0x21:
+                        return parseMessage21(d);
+                    case (byte) 0x71:
+                        return parseMessage71(d);
+                    case (byte) 0x73:
+                        return parseMessage73(d);
+                }
+            }
         } else {
             throw new SwegonVentilationException("Illegal data received, first byte mismatch!");
         }


### PR DESCRIPTION
Swegon device can send messages at a high speed (e.g. every second) which can cause lot of item updates. Added throttle feature which can be used to skip some incoming messages. 

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>