### PR TITLE
[PLCBus] Fix addon crash when two commands are sent in quick succession

### DIFF
--- a/bundles/binding/org.openhab.binding.plcbus/src/main/java/org/openhab/binding/plcbus/internal/protocol/AbstractReceiveFrameContainer.java
+++ b/bundles/binding/org.openhab.binding.plcbus/src/main/java/org/openhab/binding/plcbus/internal/protocol/AbstractReceiveFrameContainer.java
@@ -72,7 +72,7 @@ public abstract class AbstractReceiveFrameContainer implements IReceiveFrameCont
                 }
             }
         } catch (Exception e) {
-            logger.error("Error while parsing ReceiveFrame");
+            logger.warn("Error while parsing ReceiveFrame", e);
         }
     }
 

--- a/bundles/binding/org.openhab.binding.plcbus/src/main/java/org/openhab/binding/plcbus/internal/protocol/SerialPortGateway.java
+++ b/bundles/binding/org.openhab.binding.plcbus/src/main/java/org/openhab/binding/plcbus/internal/protocol/SerialPortGateway.java
@@ -34,8 +34,9 @@ public class SerialPortGateway implements ISerialPortGateway {
     }
 
     @Override
-    public void send(TransmitFrame frame, IReceiveFrameContainer receivedFrameContainer) {
+    public synchronized void send(TransmitFrame frame, IReceiveFrameContainer receivedFrameContainer) {
         try {
+            logger.debug("thread {} entering send", Thread.currentThread());
             byte[] paket = Convert.toByteArray(frame.getBytes());
 
             OutputStream out = serialPort.getOutputStream();
@@ -50,6 +51,8 @@ public class SerialPortGateway implements ISerialPortGateway {
 
         } catch (Exception e) {
             logger.info("Error in write method: " + e.getMessage());
+        } finally {
+            logger.debug("thread {} leaving send", Thread.currentThread());
         }
     }
 


### PR DESCRIPTION
This caused two different openhab threads to concurrently receive
bytes from the serial port. In turn, each thread received every other byte,
and so both threads saw corrupted frames. Even worse - threads would get
stuck waiting for response, and entire openhab was unresponsive until
restarted.

Adding synchronized helped. I've also improved logging of error (which is
now not being thrown in this scenario).