### PR TITLE
[Pushbullet] Update pushbullet.cfg

### DIFF
--- a/features/openhab-addons-external/src/main/resources/conf/pushbullet.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/pushbullet.cfg
@@ -1,3 +1,7 @@
+# pid:org.openhab.action.pushbullet
+# Uncomment the first line to set the settings in this file as exclusive (for troubleshooting purposes only!)
+# 
+
 #
 # Pushbullet action configuration
 #
@@ -12,7 +16,8 @@
 #
 # Minimal setup, just one bot with the default name and token
 #
-accesstoken=1234abc
+# accesstoken=1234abc
+# devicename=DEFAULT
 
 #
 # Extended setup with multiple bots, each with its own access token


### PR DESCRIPTION
[+] Add the ConfigAdmin Persistent IDentity (PID) exclusive Marker on the first line to override existing/stored configurations
[-] Commented out the `accesstoken=1234abc` line to serve as an example (not to be activated when the Addon is installed)
[+] Added the default devicename in the config file

Refs:
1) https://github.com/openhab/openhab-distro/issues/396#issuecomment-332236729
2) https://github.com/eric-erki/smarthome/blob/e51fb052dc05a74358d948e904efe61b04c146fc/bundles/config/org.eclipse.smarthome.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java#L292

Signed-off-by: Angelos Fountoulakis agf@wired-net.gr (github: AngelosF)