### PR TITLE
[Serial][Documentation] Add missing end quote to README example

### DIFF
--- a/bundles/binding/org.openhab.binding.serial/README.md
+++ b/bundles/binding/org.openhab.binding.serial/README.md
@@ -54,7 +54,7 @@ The format has the following variations:
 ```
 serial="<port>@<baudrate>" 
 serial="<port>@<baudrate>,REGEX(<regular expression>)" 
-serial="<port>@<baudrate>,BASE64 
+serial="<port>@<baudrate>,BASE64"
 serial="<port>@<baudrate>,ON(<On string>),OFF(<Off string>)" 
 serial="<port>@<baudrate>,REGEX(<regular expression>), UP(<Up string>),DOWN(<Down string>), STOP(<Stop string>)" 
 ```


### PR DESCRIPTION
Added " in Configuration example BASE64