### PR TITLE
[Telegram] Add support for file protocol

### DIFF
--- a/bundles/action/org.openhab.action.telegram/README.md
+++ b/bundles/action/org.openhab.action.telegram/README.md
@@ -146,7 +146,7 @@ when
     Item Light_GF_Living_Table changed
 then
     var String base64Image = "data:image/jpeg;base64, LzlqLzRBQ..."
-    sendTelegramPhoto("bot1", base64Image, "sent from Openhab")
+    sendTelegramPhoto("bot1", base64Image, "sent from openHAB")
 end
 ```
 
@@ -159,7 +159,7 @@ rule "Send telegram with local image and caption"
 when
     Item Light_GF_Living_Table changed
 then
-    sendTelegramPhoto("bot1", "file///path/to/local/image.jpg", "sent from Openhab")
+    sendTelegramPhoto("bot1", "file:///path/to/local/image.jpg", "sent from openHAB")
 end
 ```
 
@@ -172,6 +172,6 @@ rule "Send telegram with Image Item image and caption"
 when
     Item Webcam_Image changed
 then
-    sendTelegramPhoto("bot1", Webcam_Image.state.toFullString, "sent from Openhab")
+    sendTelegramPhoto("bot1", Webcam_Image.state.toFullString, "sent from openHAB")
 end
 ```

--- a/bundles/action/org.openhab.action.telegram/README.md
+++ b/bundles/action/org.openhab.action.telegram/README.md
@@ -32,7 +32,8 @@ Each of the actions returns `true` on success or `false` on failure.
 
 - `sendTelegram(String group, String message)`: Sends a Telegram via Telegram REST API - direct message
 - `sendTelegram(String group, String format, Object... args)`: Sends a Telegram via Telegram REST API - build message with format and args
-- `sendTelegramPhoto(String group, String photoURL, String caption)`: Sends a Picture via Telegram REST API
+- `sendTelegramPhoto(String group, String photoURL, String caption)`: Sends a Picture via Telegram REST API.
+The URL can be specified using the http, https, and file protocols.
 - `sendTelegramPhoto(String group, String photoURL, String caption, Integer timeoutMillis)`: Sends a Picture via Telegram REST API, using custom HTTP timeout
 - `sendTelegramPhoto(String group, String photoURL, String caption, String username, String password)`: Sends a Picture, protected by username/password authentication, via Telegram REST API
 - `sendTelegramPhoto(String group, String photoURL, String caption, String username, String password, int timeoutMillis, int retries)`: Sends a Picture, protected by username/password authentication, using custom HTTP timeout and retries, via Telegram REST API
@@ -95,7 +96,7 @@ When sending an image from a URL, do not place the username/password in the URL 
 `http://<username>:<password>@server/image.png`; pass the credentials to the `sendTelegramPhoto`
 method instead.
 
-`http` and `https` are the only protocols allowed.
+`http`, `https`, and `file` are the only protocols allowed.
 
 telegram.rules
 
@@ -146,6 +147,19 @@ when
 then
     var String base64Image = "data:image/jpeg;base64, LzlqLzRBQ..."
     sendTelegramPhoto("bot1", base64Image, "sent from Openhab")
+end
+```
+
+To send an image that resides on the local computer file system:
+
+telegram.rules
+
+```java
+rule "Send telegram with local image and caption"
+when
+    Item Light_GF_Living_Table changed
+then
+    sendTelegramPhoto("bot1", "file///path/to/local/image.jpg", "sent from Openhab")
 end
 ```
 

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -233,14 +233,12 @@ public class Telegram {
             URL url;
             try {
                 url = new URL(photoURL);
+                image = Files.readAllBytes(Paths.get(url.getPath()));
             } catch (MalformedURLException e) {
                 logger.warn("File specification {} is not properly formed: {}", photoURL, e.getMessage());
                 return false;
-            }
-            try {
-                image = Files.readAllBytes(Paths.get(url.getPath()));
             } catch (IOException e) {
-                logger.warn("Unable to read file {} from local file system: {}", url.getPath(), e.getMessage());
+                logger.warn("Unable to read file {} from local file system: {}", photoURL, e.getMessage());
                 return false;
             }
         } else {


### PR DESCRIPTION
See https://github.com/openhab/openhab2-addons/issues/4286

Adds support for sending images contained on the local openHAB host's file system. Image files are specified using the file protocol (e.g. `file:///path/to/local/image.jpg`)

IDK why the README shows that the entire doc changed, as I only made several small additions.

Also the IDE forced several formatting changes in addition to the addition to the code for supporting the file protocol.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
