### PR TITLE
[Telegram] Support for formatted messages

### DIFF
--- a/bundles/action/org.openhab.action.telegram/README.md
+++ b/bundles/action/org.openhab.action.telegram/README.md
@@ -42,11 +42,14 @@ The URL can be specified using the http, https, and file protocols.
 
 The action can be configured in `services/telegram.cfg`.
 
-| Property            | Default | Required | Description                           |
-|---------------------|---------|:--------:|---------------------------------------|
-| bots                |         | Yes      | Comma-separated list of `<bot-name>`s |
-| `<bot name>.chatId` |         | Yes      | chat id                               |
-| `<bot name>.token`  |         | Yes      | authentication token                  |
+| Property                | Default | Required | Description                                                  |
+|-------------------------|---------|:--------:|--------------------------------------------------------------|
+| bots                    |         | Yes      | Comma-separated list of `<bot-name>`s                        |
+| `<bot name>.chatId`     |         | Yes      | chat id                                                      |
+| `<bot name>.token`      |         | Yes      | authentication token                                         |
+| `<bot name>.parseMode`  |         | No       | Support for formatted messages, values: `Markdown` or `HTML` |
+
+See https://core.telegram.org/bots/api#markdown-style for formatting options
 
 ### Configuration example
 
@@ -55,6 +58,7 @@ bots=bot1,bot2
 
 bot1.chatId=22334455
 bot1.token=xxxxxxxxxxx
+bot1.parseMode=Markdown
 
 bot2.chatId=654321
 bot2.token=yyyyyyyyyyy

--- a/bundles/action/org.openhab.action.telegram/README.md
+++ b/bundles/action/org.openhab.action.telegram/README.md
@@ -42,14 +42,14 @@ The URL can be specified using the http, https, and file protocols.
 
 The action can be configured in `services/telegram.cfg`.
 
-| Property                | Default | Required | Description                                                  |
-|-------------------------|---------|:--------:|--------------------------------------------------------------|
-| bots                    |         | Yes      | Comma-separated list of `<bot-name>`s                        |
-| `<bot name>.chatId`     |         | Yes      | chat id                                                      |
-| `<bot name>.token`      |         | Yes      | authentication token                                         |
-| `<bot name>.parseMode`  |         | No       | Support for formatted messages, values: `Markdown` or `HTML` |
+| Property                | Default | Required | Description                                                                                  |
+|-------------------------|---------|:--------:|----------------------------------------------------------------------------------------------|
+| bots                    |         | Yes      | Comma-separated list of `<bot-name>`s                                                        |
+| `<bot name>.chatId`     |         | Yes      | chat id                                                                                      |
+| `<bot name>.token`      |         | Yes      | authentication token                                                                         |
+| `<bot name>.parseMode`  |         | No       | Support for formatted messages, values: `Markdown` or `HTML`. Default: no formatting is used |
 
-See https://core.telegram.org/bots/api#markdown-style for formatting options
+See https://core.telegram.org/bots/api#markdown-style for formatting options if `Markdown` or `HTML` is set as `parseMode`.
 
 ### Configuration example
 

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
@@ -9,6 +9,7 @@
 package org.openhab.action.telegram.internal;
 
 import java.util.Dictionary;
+import java.util.Objects;
 
 import org.openhab.core.scriptengine.action.ActionService;
 import org.osgi.service.cm.ConfigurationException;
@@ -62,16 +63,17 @@ public class TelegramActionService implements ActionService, ManagedService {
             for (String bot : bots) {
                 String chatIdKey = String.format("%s.chatId", bot);
                 String tokenKey = String.format("%s.token", bot);
-                String parseKey = String.format("%s.parseMode", bot);
+                String parseModeKey = String.format("%s.parseMode", bot);
 
-                if (config.get(chatIdKey) != null && config.get(tokenKey) != null) {
+                String chatId = getConfigValue(config, chatIdKey);
+                String token = getConfigValue(config, tokenKey);
+                String parseMode = getConfigValue(config, parseModeKey);
 
-                    String chatId = (String) config.get(chatIdKey);
-                    String token = (String) config.get(tokenKey);
-                    if (parseKey == null) {
+                if (chatId != null && token != null) {
+                    if (parseMode == null) {
                         Telegram.addToken(bot, chatId, token);
                     } else {
-                        Telegram.addToken(bot, chatId, token, (String) config.get(parseKey));
+                        Telegram.addToken(bot, chatId, token, parseMode);
                     }
                     logger.info("Bot {} loaded from config file", bot);
                 } else {
@@ -80,5 +82,9 @@ public class TelegramActionService implements ActionService, ManagedService {
             }
             isProperlyConfigured = true;
         }
+    }
+
+    private String getConfigValue(Dictionary<String, ?> config, String key) {
+        return Objects.toString(config.get(key));
     }
 }

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
@@ -62,8 +62,17 @@ public class TelegramActionService implements ActionService, ManagedService {
             for (String bot : bots) {
                 String chatIdKey = String.format("%s.chatId", bot);
                 String tokenKey = String.format("%s.token", bot);
+                String parseKey = String.format("%s.parseMode", bot);
+
                 if (config.get(chatIdKey) != null && config.get(tokenKey) != null) {
-                    Telegram.addToken(bot, (String) config.get(chatIdKey), (String) config.get(tokenKey));
+
+                    String chatId = (String) config.get(chatIdKey);
+                    String token = (String) config.get(tokenKey);
+                    if (parseKey == null) {
+                        Telegram.addToken(bot, chatId, token);
+                    } else {
+                        Telegram.addToken(bot, chatId, token, (String) config.get(parseKey));
+                    }
                     logger.info("Bot {} loaded from config file", bot);
                 } else {
                     logger.warn("Bot {} is misconfigured. Please check the configuration", bot);

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramActionService.java
@@ -65,9 +65,9 @@ public class TelegramActionService implements ActionService, ManagedService {
                 String tokenKey = String.format("%s.token", bot);
                 String parseModeKey = String.format("%s.parseMode", bot);
 
-                String chatId = getConfigValue(config, chatIdKey);
-                String token = getConfigValue(config, tokenKey);
-                String parseMode = getConfigValue(config, parseModeKey);
+                String chatId = Objects.toString(config.get(chatIdKey), null);
+                String token = Objects.toString(config.get(tokenKey), null);
+                String parseMode = Objects.toString(config.get(parseModeKey), null);
 
                 if (chatId != null && token != null) {
                     if (parseMode == null) {
@@ -82,9 +82,5 @@ public class TelegramActionService implements ActionService, ManagedService {
             }
             isProperlyConfigured = true;
         }
-    }
-
-    private String getConfigValue(Dictionary<String, ?> config, String key) {
-        return Objects.toString(config.get(key));
     }
 }

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramBot.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/TelegramBot.java
@@ -20,10 +20,17 @@ public class TelegramBot {
 
     private String chatId;
     private String token;
+    private String parseMode;
 
     public TelegramBot(String chatId, String token) {
         this.chatId = chatId;
         this.token = token;
+    }
+
+    public TelegramBot(String chatId, String token, String parseMode) {
+        this.chatId = chatId;
+        this.token = token;
+        this.parseMode = parseMode;
     }
 
     public String getChatId() {
@@ -32,5 +39,9 @@ public class TelegramBot {
 
     public String getToken() {
         return token;
+    }
+
+    public String getParseMode() {
+        return parseMode;
     }
 }

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -2493,6 +2493,7 @@ tcp:refreshinterval=250
 # telegram:bots=bot1,bot2
 # telegram:bot1.chatId=22334455
 # telegram:bot1.token=xxxxxx
+# telegram:bot1.parseMode=Markdown
 # telegram:bot2.chatId=654321
 # telegram:bot2.token=yyyyyyyyyyy
 

--- a/features/openhab-addons-external/src/main/resources/conf/telegram.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/telegram.cfg
@@ -1,5 +1,5 @@
 #
-# Read http://www.instructables.com/id/Telegram-Bots-for-beginners/
+# Read https://www.openhab.org/addons/actions/telegram/#telegram-actions
 # to see how to set up bots and find your chat ids
 #
 
@@ -7,6 +7,8 @@
 
 # bot1.chatId=22334455
 # bot1.token=xxxxxx
+# Optional: Either 'Markdown' or 'HTML' see https://core.telegram.org/bots/api#markdown-style
+# bot1.parseMode=Markdown
 
 # bot2.chatId=654321
 # bot2.token=yyyyyyyyyyy


### PR DESCRIPTION
This pull requests adds the ability to write messages that contain markdown or html tags, see https://core.telegram.org/bots/api#markdown-style.
It is configurable if a bot should use formatted messages in the `telegram.cfg`. This pull request is inspired by #5490 but since the other pull request is stale I started a complete rewrite.