### PR TITLE
[InsteonPLM] Add OnLevel feature to Insteon PLM 2477D dimmer

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -797,5 +797,16 @@
 	<command-handler default="true">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ExtStatusGroup -->
 </feature>
+<feature name="OnLevel">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x00" match_d2="0x01" low_byte="userData8">NumberMsgHandler</message-handler>
+	<!-- handles direct ack after poll-->
+	<message-handler cmd="0x19">TriggerPollMsgHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x2e" d1="0x01" d2="0x06" factor="1" value="userData3">NumberCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ExtStatusGroup -->
+</feature>
 
 </xml>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
@@ -158,6 +158,7 @@ Example entry:
      <feature_group name="ext_group" type="ExtStatusGroup">
           <feature name="ledbrightness">LEDBrightness</feature>
 	  <feature name="ramprate">RampRate</feature>
+          <feature name="onlevel">OnLevel</feature>
      </feature_group>
 
  </device>


### PR DESCRIPTION
This will add the ability to add on level items into OpenHAB for the Insteon PLM binding. Items should be number type with a range from 0 to 255. The feature works the same as other features in the binding (LEDBrightness and RampRate). 

RampRate is Insteon message 0x05. LEDBrightness is Insteon message 0x07. OnLevel (new) is Insteon message 0x06.