### PR TITLE
[Documentation] Fixed mixed-content and added https urls and resources where possible

### DIFF
--- a/bundles/binding/org.openhab.binding.anel/README.md
+++ b/bundles/binding/org.openhab.binding.anel/README.md
@@ -4,15 +4,15 @@ Monitor and control Anel NET-PwrCtrl devices.
 
 | [Anel NET-PwrCtrl HUT](http://anel-elektronik.de/SITE/produkte/hut/hut.htm) | [Anel NET-PwrCtrl IO](http://anel-elektronik.de/SITE/produkte/io/io.htm) | [Anel NET-PwrCtrl HOME](http://anel-elektronik.de/SITE/produkte/home/home.htm) |
 | --- | --- | --- |
-| [![Anel NET-PwrCtrl HUT](http://anel-elektronik.de/SITE/image/leisten/HUT-120.gif)](http://anel-elektronik.de/SITE/produkte/hut/hut.htm) | [![Anel NET-PwrCtrl PRO](http://anel-elektronik.de/SITE/image/leisten/PRO-120.gif)](http://anel-elektronik.de/SITE/produkte/io/io.htm) | [![Anel NET-PwrCtrl HOME](http://anel-elektronik.de/SITE/image/leisten/HOME-DE-120.gif)](http://anel-elektronik.de/SITE/produkte/home/home.htm)
+| [![Anel NET-PwrCtrl HUT](https://anel-elektronik.de/SITE/image/leisten/HUT-120.gif)](http://anel-elektronik.de/SITE/produkte/hut/hut.htm) | [![Anel NET-PwrCtrl PRO](https://anel-elektronik.de/SITE/image/leisten/PRO-120.gif)](http://anel-elektronik.de/SITE/produkte/io/io.htm) | [![Anel NET-PwrCtrl HOME](https://anel-elektronik.de/SITE/image/leisten/HOME-DE-120.gif)](http://anel-elektronik.de/SITE/produkte/home/home.htm)
 
 NET-PwrCtrl devices are power sockets / relays that can be configured via browser but they can also be controlled over the network, e.g. with an Android or iPhone app - and also with openHAB via this binding.
 The NET-PwrCtrl HUT and NET-PwrCtrl IO also have 8 I/O pins which can either be used to directly switch the sockets, or they can be used as general input switches in openHAB.
 Here is a video demonstrating a switch and a dimmer (voice is German), explanation of the setup is given in the diagram below:
 
-[![Anel example](http://img.youtube.com/vi/31ycP53jZVs/0.jpg)](http://www.youtube.com/watch?v=31ycP53jZVs)
+[![Anel example](https://img.youtube.com/vi/31ycP53jZVs/0.jpg)](http://www.youtube.com/watch?v=31ycP53jZVs)
 
-[Anel demo setup](http://2.bp.blogspot.com/-XbiK9Fe1Ek0/VFPc2lwMKeI/AAAAAAAABDM/wEdTETUfo0w/s1600/Anel-demo-setup.png)
+[Anel demo setup](https://2.bp.blogspot.com/-XbiK9Fe1Ek0/VFPc2lwMKeI/AAAAAAAABDM/wEdTETUfo0w/s1600/Anel-demo-setup.png)
 
 **Note that the binding is still untested for other devices than the _NET-PwrCtrl HUT_, because I do not own any of the others. I suppose the binding works well with the _NET-PwrCtrl IO_ because it has the same features, but it may not yet work for the others!**
 

--- a/bundles/binding/org.openhab.binding.fritzaha/README.md
+++ b/bundles/binding/org.openhab.binding.fritzaha/README.md
@@ -2,7 +2,7 @@
 
 This binding provides access to AVM Home Automation devices, such as the Fritz!DECT 200 connected to a Fritz!Box or the Fritz!Powerline 546E. It is designed to allow for multiple hosts, for instance using both a Fritz!Box and a Fritz!Powerline.
 
-[![Fritz AHA](http://img.youtube.com/vi/qYrpPrLY868/0.jpg)](http://www.youtube.com/watch?v=qYrpPrLY868)
+[![Fritz AHA](https://img.youtube.com/vi/qYrpPrLY868/0.jpg)](http://www.youtube.com/watch?v=qYrpPrLY868)
 
 The binding interfaces with hosts using a choice of two different interfaces, the query script used in the Fritz!OS UI and a webservice designed for interfacing with external applications.
 

--- a/bundles/binding/org.openhab.binding.gc100ir/README.md
+++ b/bundles/binding/org.openhab.binding.gc100ir/README.md
@@ -2,7 +2,7 @@
 
 This page describes the Global Cache IR binding (1.x), which allows openHAB items to send commands to the corresponding IR devices from one or more instances of Global Cache. 
 
-![Global Cache Device](http://www.smarthome.com/media/catalog/product/8/1/8115big.jpg)
+![Global Cache Device](https://www.smarthome.com/media/catalog/product/8/1/8115big.jpg)
 
 There is also a binding specifically for openHAB 2 [here](https://www.openhab.org/addons/bindings/globalcache/).
 
@@ -35,13 +35,13 @@ Where
 * `<instance>` is prefixed by ‘#’, a named instance configured in the `services/gc100ir.cfg`.
 * `<module>` is the numeric value which specifies the module number of GC100.
 * `<connector>` is the numeric value which specifies the connector number of GC100.
-* `<code>` is the Global Cache format IR code which is to be sent over IR devices as a command through GC100. For conversion between Global Cache format IR codes and Hex (CCF) codes, you can download iConvert tool (Windows only) from [Global Cache](http://www.globalcache.com/downloads/) downloads page. You can also download different IR Hex (CCF) codes to control other devices from [http://www.remotecentral.com](http://www.remotecentral.com).
+* `<code>` is the Global Cache format IR code which is to be sent over IR devices as a command through GC100. For conversion between Global Cache format IR codes and Hex (CCF) codes, you can download iConvert tool (Windows only) from [Global Cache](https://www.globalcache.com/downloads/) downloads page. You can also download different IR Hex (CCF) codes to control other devices from [http://www.remotecentral.com](http://www.remotecentral.com).
 
 ### Example
 
 The following example is tested with DENON 1940CI DVD player to control it using IR receiver through global cache. IR receiver receives the IR pulse from Global Cache device and sends it as IR command to the DVD player.
 
-![DENON 1940CI DVD Player](http://static.trustedreviews.com/94/8d9886/6e1c/7077-dendvd1940bk.jpg)
+![DENON 1940CI DVD Player](https://static.trustedreviews.com/94/8d9886/6e1c/7077-dendvd1940bk.jpg)
 
 ```
 String	GC100_IR_DENON_DVD_LIVING_POWER_MODE_ON	{ gc100ir="[#living|4|1|38028,1,1,10,31,10,31,10,31,10,71,10,31,10,70,10,31,10,31,10,31,10,70,10,70,10,31,10,71,10,31,10,31,10,1765,10,31,10,31,10,31,10,71,10,31,10,31,10,71,10,70,10,71,10,31,10,31,10,70,10,31,10,71,10,71,10,1685,10,31,10,31,10,31,10,71,10,31,10,71,10,31,10,31,10,31,10,70,10,70,10,31,10,71,10,31,10,31,10,1764]" }
@@ -58,7 +58,7 @@ Switch 	item=GC100_IR_DENON_DVD_LIVING_PAUSE_STATE  label="Pause"  mappings=[PAU
 
 ### iTach IP2IR and WF2IR
 
-![](http://i0.wp.com/www.globalcache.com/wp-content/uploads/2009/10/iTachIP2IR-medtrans.png?resize=150%2C128)
+![](https://i0.wp.com/www.globalcache.com/wp-content/uploads/2009/10/iTachIP2IR-medtrans.png?resize=150%2C128)
 
 This binding works with the iTach devices. For configuration, use 1 for module and 1-3 for connectors, depending on which connector your IR emitter is connected.
 

--- a/bundles/binding/org.openhab.binding.lcn/README.md
+++ b/bundles/binding/org.openhab.binding.lcn/README.md
@@ -2,9 +2,9 @@
 
 This binding connects to one or more LCN-PCHK instances via TCP/IP. **This means 1 unused LCN-PCHK license is required!**
 
-![](http://3.bp.blogspot.com/-d5mm3HC7uic/VpO2ctrfWNI/AAAAAAAAJOI/a37JMGhC4IY/s600/openhab_lcn.jpg)
+![](https://3.bp.blogspot.com/-d5mm3HC7uic/VpO2ctrfWNI/AAAAAAAAJOI/a37JMGhC4IY/s600/openhab_lcn.jpg)
 
-The minimum recommended version is LCN-PCHK 2.8 (older versions will also work, but lack some functionality). Visit [http://www.lcn.de](http://www.lcn.de) for updates.
+The minimum recommended version is LCN-PCHK 2.8 (older versions will also work, but lack some functionality). Visit [https://www.lcn.eu](http://www.lcn.de) for updates.
 
 ## LCN Overview
 

--- a/bundles/binding/org.openhab.binding.nikobus/README.md
+++ b/bundles/binding/org.openhab.binding.nikobus/README.md
@@ -2,7 +2,7 @@
 
 This binding allows openHAB to interact with the [Nikobus](http://www.niko.eu/enus/niko/products/home-automation-with-nikobus/) home automation system. 
 
-[![Demo Video Nikobus](http://img.youtube.com/vi/QiNb-8QxXpo/0.jpg)](http://www.youtube.com/watch?v=QiNb-8QxXpo)
+[![Demo Video Nikobus](https://img.youtube.com/vi/QiNb-8QxXpo/0.jpg)](http://www.youtube.com/watch?v=QiNb-8QxXpo)
 
 More specifically, it allows openHAB to:
 


### PR DESCRIPTION
Hi,

I have clicked through the addons section and identified some images which are not loaded over `https` which causes the browser to throw a mixed content warning.
I have changed the urls where possible, to get rid of those warnings.

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>