### PR TITLE
[Denon] Update README with better sendCommand alternative

### DIFF
--- a/bundles/binding/org.openhab.binding.denon/README.md
+++ b/bundles/binding/org.openhab.binding.denon/README.md
@@ -82,7 +82,7 @@ Switch item=DenonCommand label="Surround Mode" mappings=[MSSTANDARD="Standard", 
 In scripts:
 
 ```
-sendCommand(DenonCommand, "MNMEN ON")
+DenonCommand.sendCommand("MNMEN ON")
 ```
 
 


### PR DESCRIPTION
Please always use the object method instead of the static method. This is safer and less confusing for newcomers. See https://www.openhab.org/docs/configuration/rules-dsl.html#manipulating-item-states