### PR TITLE
[Horizon] Update README with better sendCommand alternative

### DIFF
--- a/bundles/binding/org.openhab.binding.horizon/README.md
+++ b/bundles/binding/org.openhab.binding.horizon/README.md
@@ -88,9 +88,9 @@ when
 then
 	var ret_val = sendHttpGetRequest('http://192.168.1.206:62137/DeviceDescription.xml')
 	if (ret_val != null) {
-		postUpdate(horizon_power, ON)
+		horizon_power.postUpdate(ON)
 	} else {
-		postUpdate(horizon_power, OFF)
+		horizon_power.postUpdate(OFF)
 	}
 end
 ```


### PR DESCRIPTION
Please use the object method instead of the static method. :) see https://www.openhab.org/docs/configuration/rules-dsl.html#manipulating-item-states

Furthermore, it should be considered whether the sendCommand method should be used.