### PR TITLE
[Rwesmarthome] Update README with better sendCommand alternative

### DIFF
--- a/bundles/binding/org.openhab.binding.rwesmarthome/README.md
+++ b/bundles/binding/org.openhab.binding.rwesmarthome/README.md
@@ -145,10 +145,10 @@ when
 	Item rweSwitchLivingBtn1 changed to ON
 then
 	if(TV.state == ON)
-		sendCommand(TV, OFF)
+		TV.sendCommand(OFF)
 	else
-		sendCommand(TV, ON)
-end	
+		TV.sendCommand(ON)
+end
 ```
 
 ### Workaround for motiondetectors


### PR DESCRIPTION
Changed pre/indention to ``` for better readability on openhab.org

Please use the object method instead of the static method. :) see https://www.openhab.org/docs/configuration/rules-dsl.html#manipulating-item-states