### PR TITLE
[Zibase] Update README with better sendCommand alternative

### DIFF
--- a/bundles/binding/org.openhab.binding.zibase/README.md
+++ b/bundles/binding/org.openhab.binding.zibase/README.md
@@ -148,7 +148,7 @@ rule "open kitchen shutter if it is the morning"
 when
     Item LightSensor changed from dark to light
 then   
-    sendCommand(KitchenShutter,ON)
+    KitchenShutter.sendCommand(ON)
 end
 ```
 
@@ -170,7 +170,7 @@ Launch a scenario from a rule:
 
 ```
 ...
-sendCommand(ZibaseScenario26,ON)
+ZibaseScenario26.sendCommand(ON)
 ...
 ```
 
@@ -199,6 +199,6 @@ Set the value 50 to the variable in a rule:
 
 ```
 ...
-sendCommand(Variable14,50)
+Variable14.sendCommand(50)
 ...
 ```


### PR DESCRIPTION
Please use the object method instead of the static method. :) see https://www.openhab.org/docs/configuration/rules-dsl.html#manipulating-item-states