### PR TITLE
[CalDAV-Personal] Make the calendar update even if the event is 'before now'

### DIFF
--- a/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavBinding.java
+++ b/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavBinding.java
@@ -167,12 +167,18 @@ public class CalDavBinding extends AbstractBinding<CalDavBindingProvider> implem
      */
     @Override
     public void eventBegins(CalDavEvent event) {
+        logger.debug("eventBegins() called for event '{}'", event.getShortName());
+
         if (!calendars.contains(event.getCalendarId())) {
+            logger.trace("event calendarId does not exist in calendars");
             return;
         }
 
+        logger.debug("check start of event '{}'", event.getShortName());
         if (event.getStart().isBeforeNow()) {
-            return;
+            logger.debug("event is before now; ignoring and updating anyway.");
+            logger.trace("event start time: {} ", event.getStart());
+            logger.trace("now:              {} ", DateTime.now());
         }
 
         logger.debug("adding event to map: {}", event.getShortName());


### PR DESCRIPTION
Change the logic in the eventBegins() method so that the update goes out even if the event is "before now".
It's not clear why this check ever existed, anyway.

Looks like this fixes #5744.