### PR TITLE
[jdbc] Fix sqltype.table* options

### DIFF
--- a/bundles/persistence/org.openhab.persistence.jdbc/README.md
+++ b/bundles/persistence/org.openhab.persistence.jdbc/README.md
@@ -50,8 +50,8 @@ This service can be configured in the file `services/jdbc.cfg`.
 | sqltype.ROLLERSHUTTER	    | `TINYINT`        | No | see above |
 | sqltype.STRING		    | `VARCHAR(65500)` | No | see above |
 | sqltype.SWITCH		    | `VARCHAR(6)`     | No | see above |
-| sqltype.TABLEPRIMARYKEY   | `TIMESTAMP`      | No | see above |
-| sqltype.TABLEPRIMARYVALUE | `NOW()`          | No | see above |
+| sqltype.tablePrimaryKey   | `TIMESTAMP`      | No | type of `time` column for newly created item tables |
+| sqltype.tablePrimaryValue | `NOW()`          | No | value of `time` column for newly inserted rows  |
 | numberDecimalcount        | 3                | No | for Itemtype "Number" default decimal digit count |
 | tableNamePrefix           | `item`           | No | table name prefix. For Migration from MySQL Persistence, set to `Item`. |
 | tableUseRealItemNames     | `false`          | No | table name prefix generation.  When set to `true`, real item names are used for table names and `tableNamePrefix` is ignored.  When set to `false`, the `tableNamePrefix` is used to generate table names with sequential numbers. |

--- a/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
+++ b/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/db/JdbcBaseDAO.java
@@ -319,6 +319,7 @@ public class JdbcBaseDAO {
         String sql = StringUtilsExt.replaceArrayMerge(SQL_CREATE_ITEM_TABLE,
                 new String[] { "#tableName#", "#dbType#", "#tablePrimaryKey#" },
                 new String[] { vo.getTableName(), vo.getDbType(), sqlTypes.get("tablePrimaryKey") });
+        logger.debug("JDBC::doCreateItemTable sql={}", sql);
         Yank.execute(sql, null);
     }
 

--- a/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -264,7 +264,10 @@ public class JdbcConfiguration {
             if (!matcher.group(1).equals("sqltype")) {
                 continue;
             }
-            String itemType = matcher.group(2).toUpperCase() + "ITEM";
+            String itemType = matcher.group(2);
+            if (!itemType.startsWith("table")) {
+              itemType = itemType.toUpperCase() + "ITEM";
+            }
             String value = (String) configuration.get(key);
             logger.debug("JDBC::updateConfig: set sqlTypes: itemType={} value={}", itemType, value);
             dBDAO.sqlTypes.put(itemType, value);

--- a/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
+++ b/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
@@ -116,10 +116,10 @@ public class JdbcMapper {
      * MAPPERS ITEM *
      ****************/
     public void updateItemTableNames(List<ItemVO> vol) {
-        logger.debug("JDBC::createItemTable");
+        logger.debug("JDBC::updateItemTableNames");
         long timerStart = System.currentTimeMillis();
         conf.getDBDAO().doUpdateItemTableNames(vol);
-        logTime("createItemTable", timerStart, System.currentTimeMillis());
+        logTime("updateItemTableNames", timerStart, System.currentTimeMillis());
     }
 
     public ItemVO createItemTable(ItemVO vo) {


### PR DESCRIPTION
Options `sqltype.tablePrimaryKey` and `sqltype.tablePrimaryValue` were not read
correctly. They were treated as yet another item type which didn't match their use
in the code.

Also added debug log of sql query similar to other functions.

Second commit is just a "copy/paste" bug fix.