### PR TITLE
[Twitter] Remove reference to Dropbox from README

### DIFF
--- a/bundles/action/org.openhab.action.twitter/README.md
+++ b/bundles/action/org.openhab.action.twitter/README.md
@@ -49,7 +49,7 @@ Typically a new Twitter account would be set up for openHAB, rather than using y
 ## Prerequisites
 
 You'll have to authorise openHAB to use Twitter.
-This is done using a two step process, similar to Dropbox authentication.
+This is done using a two step process.
 openHAB requests a token which is used as a one-time-password to get hold of an authentication token (second step) which will be used for all future requests to Twitter.
 
 ### Step 1


### PR DESCRIPTION
Since there is no official binding for "Dropbox", as far as I know, this information is not helpful because you can not make any reference.