### PR TITLE
[dynamodb] Performance optimizations

### DIFF
--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
@@ -56,7 +56,7 @@ public class AbstractDynamoDBItemSerializationTest {
      * Generic function testing serialization of item state to internal format in DB. In other words, conversion of
      * Item with state to DynamoDBItem
      *
-     * @param state item state
+     * @param state         item state
      * @param expectedState internal format in DB representing the item state
      * @return dynamo db item
      * @throws IOException
@@ -68,8 +68,10 @@ public class AbstractDynamoDBItemSerializationTest {
         assertEquals("item1", dbItem.getName());
         assertEquals(date, dbItem.getTime());
         if (expectedState instanceof BigDecimal) {
-            assertTrue(DynamoDBBigDecimalItem.loseDigits(((BigDecimal) expectedState))
-                    .compareTo((((DynamoDBItem<BigDecimal>) dbItem).getState())) == 0);
+            BigDecimal expectedDigitsLost = DynamoDBBigDecimalItem.loseDigits(((BigDecimal) expectedState));
+            BigDecimal actual = ((DynamoDBItem<BigDecimal>) dbItem).getState();
+            assertTrue(String.format("Expected state %s (%s but with some digits lost) did not match actual state %s",
+                    expectedDigitsLost, expectedState, actual), expectedDigitsLost.compareTo(actual) == 0);
         } else {
             assertEquals(expectedState, dbItem.getState());
         }
@@ -79,8 +81,8 @@ public class AbstractDynamoDBItemSerializationTest {
     /**
      * Test state deserialization, that is DynamoDBItem conversion to HistoricItem
      *
-     * @param dbItem dynamo db item
-     * @param item parameter for DynamoDBItem.asHistoricItem
+     * @param dbItem        dynamo db item
+     * @param item          parameter for DynamoDBItem.asHistoricItem
      * @param expectedState Expected state of the historic item. DecimalTypes are compared with reduced accuracy
      * @return
      * @throws IOException
@@ -181,33 +183,33 @@ public class AbstractDynamoDBItemSerializationTest {
 
     @Test
     public void testDecimalTypeWithNumberItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new DecimalType(3.2), new BigDecimal(3.2));
+        DynamoDBItem<?> dbitem = testStateGeneric(new DecimalType(3.2), new BigDecimal("3.2"));
         testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType(3.2));
     }
 
     @Test
     public void testPercentTypeWithColorItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal(3.2)), new BigDecimal(3.2));
-        testAsHistoricGeneric(dbitem, new ColorItem("foo"), new PercentType(new BigDecimal(3.2)));
+        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal("3.2")), new BigDecimal("3.2"));
+        testAsHistoricGeneric(dbitem, new ColorItem("foo"), new PercentType(new BigDecimal("3.2")));
     }
 
     @Test
     public void testPercentTypeWithDimmerItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal(3.2)), new BigDecimal(3.2));
-        testAsHistoricGeneric(dbitem, new DimmerItem("foo"), new PercentType(new BigDecimal(3.2)));
+        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal("3.2")), new BigDecimal("3.2"));
+        testAsHistoricGeneric(dbitem, new DimmerItem("foo"), new PercentType(new BigDecimal("3.2")));
     }
 
     @Test
     public void testPercentTypeWithRollerShutterItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal(3.2)), new BigDecimal(3.2));
-        testAsHistoricGeneric(dbitem, new RollershutterItem("foo"), new PercentType(new BigDecimal(3.2)));
+        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal("3.2")), new BigDecimal("3.2"));
+        testAsHistoricGeneric(dbitem, new RollershutterItem("foo"), new PercentType(new BigDecimal("3.2")));
     }
 
     @Test
     public void testPercentTypeWithNumberItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal(3.2)), new BigDecimal(3.2));
+        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal("3.2")), new BigDecimal("3.2"));
         // note: comes back as DecimalType instead of the original PercentType
-        testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType(new BigDecimal(3.2)));
+        testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType(new BigDecimal("3.2")));
     }
 
     @Test

--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/BaseIntegrationTest.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/BaseIntegrationTest.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
 
 /**
- * 
+ *
  * @author Sami Salonen
  *
  */
@@ -111,6 +111,9 @@ public class BaseIntegrationTest {
         config.put("accessKey", System.getProperty("DYNAMODBTEST_ACCESS"));
         config.put("secretKey", System.getProperty("DYNAMODBTEST_SECRET"));
         config.put("tablePrefix", "dynamodb-integration-tests-");
+
+        // Disable buffering
+        config.put("bufferSize", "0");
 
         for (Entry<String, Object> entry : config.entrySet()) {
             if (entry.getValue() == null) {

--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfigTest.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfigTest.java
@@ -57,6 +57,8 @@ public class DynamoDBConfigTest {
         assertEquals(true, fromConfig.isCreateTable());
         assertEquals(1, fromConfig.getReadCapacityUnits());
         assertEquals(1, fromConfig.getWriteCapacityUnits());
+        assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(1000, fromConfig.getBufferSize());
     }
 
     @Test
@@ -72,6 +74,8 @@ public class DynamoDBConfigTest {
         assertEquals(true, fromConfig.isCreateTable());
         assertEquals(1, fromConfig.getReadCapacityUnits());
         assertEquals(1, fromConfig.getWriteCapacityUnits());
+        assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(1000, fromConfig.getBufferSize());
     }
 
     @Test
@@ -115,6 +119,8 @@ public class DynamoDBConfigTest {
         assertEquals(true, fromConfig.isCreateTable());
         assertEquals(1, fromConfig.getReadCapacityUnits());
         assertEquals(1, fromConfig.getWriteCapacityUnits());
+        assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(1000, fromConfig.getBufferSize());
     }
 
     @Test
@@ -128,6 +134,8 @@ public class DynamoDBConfigTest {
         assertEquals(false, fromConfig.isCreateTable());
         assertEquals(1, fromConfig.getReadCapacityUnits());
         assertEquals(1, fromConfig.getWriteCapacityUnits());
+        assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(1000, fromConfig.getBufferSize());
     }
 
     @Test
@@ -141,6 +149,8 @@ public class DynamoDBConfigTest {
         assertEquals(true, fromConfig.isCreateTable());
         assertEquals(5, fromConfig.getReadCapacityUnits());
         assertEquals(1, fromConfig.getWriteCapacityUnits());
+        assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(1000, fromConfig.getBufferSize());
     }
 
     @Test
@@ -154,6 +164,8 @@ public class DynamoDBConfigTest {
         assertEquals(true, fromConfig.isCreateTable());
         assertEquals(1, fromConfig.getReadCapacityUnits());
         assertEquals(5, fromConfig.getWriteCapacityUnits());
+        assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(1000, fromConfig.getBufferSize());
     }
 
     @Test
@@ -167,5 +179,24 @@ public class DynamoDBConfigTest {
         assertEquals(true, fromConfig.isCreateTable());
         assertEquals(3, fromConfig.getReadCapacityUnits());
         assertEquals(5, fromConfig.getWriteCapacityUnits());
+        assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(1000, fromConfig.getBufferSize());
+    }
+
+    @Test
+    public void testRegionWithAccessKeysWithPrefixWithReadWriteCapacityUnitsWithBufferSettings() throws Exception {
+        DynamoDBConfig fromConfig = DynamoDBConfig.fromConfig(
+                ImmutableMap.<String, Object> builder().put("region", "eu-west-1").put("accessKey", "access1")
+                        .put("secretKey", "secret1").put("readCapacityUnits", "3").put("writeCapacityUnits", "5")
+                        .put("bufferCommitIntervalMillis", "501").put("bufferSize", "112").build());
+        assertEquals(Regions.EU_WEST_1, fromConfig.getRegion());
+        assertEquals("access1", fromConfig.getCredentials().getAWSAccessKeyId());
+        assertEquals("secret1", fromConfig.getCredentials().getAWSSecretKey());
+        assertEquals("openhab-", fromConfig.getTablePrefix());
+        assertEquals(true, fromConfig.isCreateTable());
+        assertEquals(3, fromConfig.getReadCapacityUnits());
+        assertEquals(5, fromConfig.getWriteCapacityUnits());
+        assertEquals(501L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(112, fromConfig.getBufferSize());
     }
 }

--- a/bundles/persistence/org.openhab.persistence.dynamodb/ESH-INF/config/config.xml
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/ESH-INF/config/config.xml
@@ -112,6 +112,24 @@
             <advanced>true</advanced>
         </parameter>
         
+        <parameter name="bufferCommitIntervalMillis" type="integer" min="0">        
+            <label>Buffer commit interval (ms)</label>
+            <description><![CDATA[Interval to commit (write) buffered data. In milliseconds.
+            <br />
+            <br />Use zero to commit buffered data only when buffer gets full (not recommended).]]></description>
+            <default>1000</default>
+            <advanced>true</advanced>
+        </parameter>
+        
+        <parameter name="bufferSize" type="integer" min="0">        
+            <label>Buffer size</label>
+            <description><![CDATA[Internal buffer size which is used to batch writes to DynamoDB every bufferCommitIntervalMillis.
+            <br />
+            <br />Use zero to disable buffering, and write data immediately to DynamoDB. Please note this might have adverse impact to openHAB performance.]]></description>
+            <default>1000</default>
+            <advanced>true</advanced>
+        </parameter>
+        
     </config-description>
 
 </config-description:config-descriptions>

--- a/bundles/persistence/org.openhab.persistence.dynamodb/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.14.0.qualifier
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 DynamicImport-Package: *
-Import-Package: com.google.common.collect;version="10.0.1",
+Import-Package: com.google.common.collect,
  org.apache.commons.lang,
  org.openhab.core.items,
  org.openhab.core.library.items,

--- a/bundles/persistence/org.openhab.persistence.dynamodb/README.md
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/README.md
@@ -55,21 +55,21 @@ This service can be configured in the file `services/dynamodb.cfg`.
 
 ### Basic configuration
 
-| Property | Default | Required | Description |
-|----------|---------|:--------:|-------------|
-| accessKey |        |    Yes   | access key as shown in [Setting up Amazon account](#setting-up-amazon-account). |
-| secretKey |        |    Yes   | secret key as shown in [Setting up Amazon account](#setting-up-amazon-account). |
-| region   |         |    Yes   | AWS region ID as described in [Setting up Amazon account](#setting-up-amazon-account). The region needs to match the region that was used to create the user. |
+| Property  | Default | Required | Description                                                                                                                                                   |
+| --------- | ------- | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| accessKey |         |   Yes    | access key as shown in [Setting up Amazon account](#setting-up-amazon-account).                                                                               |
+| secretKey |         |   Yes    | secret key as shown in [Setting up Amazon account](#setting-up-amazon-account).                                                                               |
+| region    |         |   Yes    | AWS region ID as described in [Setting up Amazon account](#setting-up-amazon-account). The region needs to match the region that was used to create the user. |
 
 ### Configuration Using Credentials File
 
 Alternatively, instead of specifying `accessKey` and `secretKey`, one can configure a configuration profile file.
 
-| Property | Default | Required | Description |
-|----------|---------|:--------:|-------------|
-| profilesConfigFile | |  Yes   | path to the credentials file.  For example, `/etc/openhab2/aws_creds`. Please note that the user that runs openHAB must have approriate read rights to the credential file. For more details on the Amazon credential file format, see [Amazon documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html). |
-| profile  |         |    Yes   | name of the profile to use |
-| region   |         |    Yes   | AWS region ID as described in Step 2 in [Setting up Amazon account](#setting-up-amazon-account). The region needs to match the region that was used to create the user. |
+| Property           | Default | Required | Description                                                                                                                                                                                                                                                                                                                                    |
+| ------------------ | ------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| profilesConfigFile |         |   Yes    | path to the credentials file.  For example, `/etc/openhab2/aws_creds`. Please note that the user that runs openHAB must have approriate read rights to the credential file. For more details on the Amazon credential file format, see [Amazon documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html). |
+| profile            |         |   Yes    | name of the profile to use                                                                                                                                                                                                                                                                                                                     |
+| region             |         |   Yes    | AWS region ID as described in Step 2 in [Setting up Amazon account](#setting-up-amazon-account). The region needs to match the region that was used to create the user.                                                                                                                                                                        |
 
 Example of service configuration file (`services/dynamodb.cfg`):
 
@@ -91,11 +91,15 @@ aws_secret_access_key=testSecretKey
 
 In addition to the configuration properties above, the following are also available:
 
-| Property | Default | Required | Description |
-|----------|---------|:--------:|-------------|
-| readCapacityUnits | 1 |  No   | read capacity for the created tables |
-| writeCapacityUnits | 1 | No   | write capacity for the created tables |
-| tablePrefix | `openhab-` | No | table prefix used in the name of created tables |
+| Property                   | Default    | Required | Description                                                                                        |
+| -------------------------- | ---------- | :------: | -------------------------------------------------------------------------------------------------- |
+| readCapacityUnits          | 1          |    No    | read capacity for the created tables                                                               |
+| writeCapacityUnits         | 1          |    No    | write capacity for the created tables                                                              |
+| tablePrefix                | `openhab-` |    No    | table prefix used in the name of created tables                                                    |
+| bufferCommitIntervalMillis | 1000       |    No    | Interval to commit (write) buffered data. In milliseconds.                                         |
+| bufferSize                 | 1000       |    No    | Internal buffer size which is used to batch writes to DynamoDB every `bufferCommitIntervalMillis`. |
+
+Typically you should not need to modify parameters related to buffering. 
 
 Refer to Amazon documentation on [provisioned throughput](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html) for details on read/write capacity.
 
@@ -105,9 +109,19 @@ All item- and event-related configuration is done in the file `persistence/dynam
 
 ### Tables Creation
 
-When an item is persisted via this service, a table is created (if necessary). Currently, the service will create at most two tables for different item types. The tables will be named `<prefix><item-type>`, where `<prefix>` matches the `tablePrefix` configuration property; while the `<item-type>` is either `bigdecimal` (numeric items) or `string` (string and complex items).
+When an item is persisted via this service, a table is created (if necessary). Currently, the service will create at most two tables for different item types. The tables will be named `<tablePrefix><item-type>`, where the `<item-type>` is either `bigdecimal` (numeric items) or `string` (string and complex items).
 
 Each table will have three columns: `itemname` (item name), `timeutc` (in ISO 8601 format with millisecond accuracy), and `itemstate` (either a number or string representing item state).
+
+## Buffering
+
+By default, the service is asynchronous which means that data is not written immediately to DynamoDB but instead buffered in-memory.
+The size of the buffer, in terms of datapoints, can be configured with `bufferSize`.
+Every `bufferCommitIntervalMillis` the whole buffer of data is flushed to DynamoDB.
+
+It is recommended to have the buffering enabled since the synchronous behaviour (writing data immediately) might have adverse impact to the whole system when there is many items persisted at the same time. The buffering can be disabled by setting `bufferSize` to zero.
+
+The defaults should be suitable in many use cases.
 
 ### Caveats
 

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractBufferedPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractBufferedPersistenceService.java
@@ -17,7 +17,7 @@ public abstract class AbstractBufferedPersistenceService<T> implements Persisten
 
     private static final long BUFFER_OFFER_TIMEOUT_MILLIS = 500;
 
-    private final Logger logger = LoggerFactory.getLogger(DynamoDBPersistenceService.class);
+    private final Logger logger = LoggerFactory.getLogger(AbstractBufferedPersistenceService.class);
     protected BlockingQueue<T> buffer;
 
     private boolean writeImmediately;

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractBufferedPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractBufferedPersistenceService.java
@@ -85,7 +85,7 @@ public abstract class AbstractBufferedPersistenceService<T> implements Persisten
                             System.currentTimeMillis() - bufferStart, uuid);
                 } else {
                     // The unlikely case happened -- buffer got full again immediately
-                    logger.error("Buffering failed for the second time -- Too small bufferSize? Discarding data [{}]",
+                    logger.warn("Buffering failed for the second time -- Too small bufferSize? Discarding data [{}]",
                             uuid);
                 }
             }
@@ -96,7 +96,7 @@ public abstract class AbstractBufferedPersistenceService<T> implements Persisten
         try {
             return buffer.offer(persistenceItem, BUFFER_OFFER_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
-            logger.error("Interrupted when trying to buffer data! Dropping data");
+            logger.warn("Interrupted when trying to buffer data! Dropping data");
             return false;
         }
     }

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractBufferedPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractBufferedPersistenceService.java
@@ -1,0 +1,103 @@
+package org.openhab.persistence.dynamodb.internal;
+
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.openhab.core.items.Item;
+import org.openhab.core.persistence.PersistenceService;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractBufferedPersistenceService<T> implements PersistenceService {
+
+    private static final long BUFFER_OFFER_TIMEOUT_MILLIS = 500;
+
+    private final Logger logger = LoggerFactory.getLogger(DynamoDBPersistenceService.class);
+    protected BlockingQueue<T> buffer;
+
+    private boolean writeImmediately;
+
+    protected void resetWithBufferSize(int bufferSize) {
+        int capacity = Math.max(1, bufferSize);
+        buffer = new ArrayBlockingQueue<T>(capacity, true);
+        writeImmediately = bufferSize == 0;
+    }
+
+    protected abstract T persistenceItemFromState(String name, State state, Date time);
+
+    protected abstract boolean isReadyToStore();
+
+    protected abstract void flushBufferedData();
+
+    @Override
+    public void store(Item item) {
+        store(item, null);
+    }
+
+    @Override
+    public void store(Item item, String alias) {
+        long storeStart = System.currentTimeMillis();
+        String uuid = UUID.randomUUID().toString();
+        if (item.getState() instanceof UnDefType) {
+            logger.debug("Undefined item state received. Not storing item {}.", item.getName());
+            return;
+        }
+        if (!isReadyToStore()) {
+            return;
+        }
+        if (buffer == null) {
+            throw new IllegalStateException("Buffer not initialized with resetWithBufferSize. Bug?");
+        }
+        Date time = new Date(storeStart);
+        String realName = item.getName();
+        String name = (alias != null) ? alias : realName;
+        State state = item.getState();
+        T persistenceItem = persistenceItemFromState(name, state, time);
+        logger.trace("store() called with item {}, which was converted to {} [{}]", item, persistenceItem, uuid);
+        if (writeImmediately) {
+            logger.debug("Writing immediately item {} [{}]", realName, uuid);
+            // We want to write everything immediately
+            // Synchronous behaviour to ensure buffer does not get full.
+            synchronized (this) {
+                boolean buffered = addToBuffer(persistenceItem);
+                assert buffered;
+                flushBufferedData();
+            }
+        } else {
+            long bufferStart = System.currentTimeMillis();
+            boolean buffered = addToBuffer(persistenceItem);
+            if (buffered) {
+                logger.debug("Buffered item {} in {} ms. Total time for store(): {} [{}]", realName,
+                        System.currentTimeMillis() - bufferStart, System.currentTimeMillis() - storeStart, uuid);
+            } else {
+                logger.debug(
+                        "Buffer is full. Writing buffered data immediately and trying again. Consider increasing bufferSize");
+                // Buffer is full, commit it immediately
+                flushBufferedData();
+                boolean buffered2 = addToBuffer(persistenceItem);
+                if (buffered2) {
+                    logger.debug("Buffered item in {} ms (2nd try, flushed buffer in-between) [{}]",
+                            System.currentTimeMillis() - bufferStart, uuid);
+                } else {
+                    // The unlikely case happened -- buffer got full again immediately
+                    logger.error("Buffering failed for the second time -- Too small bufferSize? Discarding data [{}]",
+                            uuid);
+                }
+            }
+        }
+    }
+
+    protected boolean addToBuffer(T persistenceItem) {
+        try {
+            return buffer.offer(persistenceItem, BUFFER_OFFER_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            logger.error("Interrupted when trying to buffer data! Dropping data");
+            return false;
+        }
+    }
+}

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfig.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfig.java
@@ -31,6 +31,8 @@ public class DynamoDBConfig {
     public static final boolean DEFAULT_CREATE_TABLE_ON_DEMAND = true;
     public static final long DEFAULT_READ_CAPACITY_UNITS = 1;
     public static final long DEFAULT_WRITE_CAPACITY_UNITS = 1;
+    public static final long DEFAULT_BUFFER_COMMIT_INTERVAL_MILLIS = 1000;
+    public static final int DEFAULT_BUFFER_SIZE = 1000;
 
     private static final Logger logger = LoggerFactory.getLogger(DynamoDBConfig.class);
 
@@ -40,6 +42,8 @@ public class DynamoDBConfig {
     private boolean createTable = DEFAULT_CREATE_TABLE_ON_DEMAND;
     private long readCapacityUnits = DEFAULT_READ_CAPACITY_UNITS;
     private long writeCapacityUnits = DEFAULT_WRITE_CAPACITY_UNITS;
+    private long bufferCommitIntervalMillis = DEFAULT_BUFFER_COMMIT_INTERVAL_MILLIS;
+    private int bufferSize = DEFAULT_BUFFER_SIZE;
 
     /**
      *
@@ -117,7 +121,26 @@ public class DynamoDBConfig {
                 writeCapacityUnits = Long.parseLong(writeCapacityUnitsParam);
             }
 
-            return new DynamoDBConfig(region, credentials, table, createTable, readCapacityUnits, writeCapacityUnits);
+            final long bufferCommitIntervalMillis;
+            String bufferCommitIntervalMillisParam = (String) config.get("bufferCommitIntervalMillis");
+            if (isBlank(bufferCommitIntervalMillisParam)) {
+                logger.debug("Buffer commit interval millis: {}", DEFAULT_BUFFER_COMMIT_INTERVAL_MILLIS);
+                bufferCommitIntervalMillis = DEFAULT_BUFFER_COMMIT_INTERVAL_MILLIS;
+            } else {
+                bufferCommitIntervalMillis = Long.parseLong(bufferCommitIntervalMillisParam);
+            }
+
+            final int bufferSize;
+            String bufferSizeParam = (String) config.get("bufferSize");
+            if (isBlank(bufferSizeParam)) {
+                logger.debug("Buffer size: {}", DEFAULT_BUFFER_SIZE);
+                bufferSize = DEFAULT_BUFFER_SIZE;
+            } else {
+                bufferSize = Integer.parseInt(bufferSizeParam);
+            }
+
+            return new DynamoDBConfig(region, credentials, table, createTable, readCapacityUnits, writeCapacityUnits,
+                    bufferCommitIntervalMillis, bufferSize);
         } catch (Exception e) {
             logger.error("Error with configuration", e);
             return null;
@@ -125,13 +148,15 @@ public class DynamoDBConfig {
     }
 
     public DynamoDBConfig(Regions region, AWSCredentials credentials, String table, boolean createTable,
-            long readCapacityUnits, long writeCapacityUnits) {
+            long readCapacityUnits, long writeCapacityUnits, long bufferCommitIntervalMillis, int bufferSize) {
         this.region = region;
         this.credentials = credentials;
         this.tablePrefix = table;
         this.createTable = createTable;
         this.readCapacityUnits = readCapacityUnits;
         this.writeCapacityUnits = writeCapacityUnits;
+        this.bufferCommitIntervalMillis = bufferCommitIntervalMillis;
+        this.bufferSize = bufferSize;
     }
 
     public AWSCredentials getCredentials() {
@@ -156,6 +181,14 @@ public class DynamoDBConfig {
 
     public long getWriteCapacityUnits() {
         return writeCapacityUnits;
+    }
+
+    public long getBufferCommitIntervalMillis() {
+        return bufferCommitIntervalMillis;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
     }
 
     private static void invalidRegionLogHelp(String region) {

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBPersistenceService.java
@@ -109,7 +109,7 @@ public class DynamoDBPersistenceService extends AbstractBufferedPersistenceServi
             if (unprocessedItems.isEmpty()) {
                 logger.debug("After {} retries successfully wrote all unprocessed items", retry);
             } else {
-                logger.error(
+                logger.warn(
                         "Even after retries failed to write some items. Last exception: {} {}, unprocessed items: {}",
                         lastException == null ? "null" : lastException.getClass().getName(),
                         lastException == null ? "null" : lastException.getMessage(), unprocessedItems);
@@ -127,7 +127,7 @@ public class DynamoDBPersistenceService extends AbstractBufferedPersistenceServi
                 Thread.sleep(sleepTime);
                 return true;
             } catch (InterruptedException e) {
-                logger.error("Interrupted while writing data!");
+                logger.debug("Interrupted while writing data!");
                 return false;
             }
         }

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBPersistenceService.java
@@ -8,25 +8,31 @@
  */
 package org.openhab.persistence.dynamodb.internal;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
-import org.openhab.core.library.types.OnOffType;
-import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.persistence.FilterCriteria;
-import org.openhab.core.persistence.FilterCriteria.Operator;
-import org.openhab.core.persistence.FilterCriteria.Ordering;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.QueryablePersistenceService;
 import org.openhab.core.types.State;
-import org.openhab.core.types.UnDefType;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,41 +40,115 @@ import org.slf4j.LoggerFactory;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.PaginationLoadingStrategy;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
-import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.amazonaws.services.dynamodbv2.document.BatchWriteItemOutcome;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.amazonaws.services.dynamodbv2.model.TableStatus;
-import com.google.common.collect.ImmutableMap;
+import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 
 /**
  * This is the implementation of the DynamoDB {@link PersistenceService}. It persists item values
  * using the <a href="https://aws.amazon.com/dynamodb/">Amazon DynamoDB</a> database. The states (
- * {@link State}) of an {@link Item} are persisted in a time series with names equal to the name of
- * the item. All values are stored using integers or doubles, {@link OnOffType} and
- * {@link OpenClosedType} are stored using 0 or 1.
+ * {@link State}) of an {@link Item} are persisted in DynamoDB tables.
  *
- * The default database name is "openhab"
+ * The service creates tables automatically, one for numbers, and one for strings.
+ *
+ * @see AbstractDynamoDBItem.fromState for details how different items are persisted
  *
  * @author Sami Salonen
  *
  */
-public class DynamoDBPersistenceService implements QueryablePersistenceService {
+public class DynamoDBPersistenceService extends AbstractBufferedPersistenceService<DynamoDBItem<?>>
+        implements QueryablePersistenceService {
+
+    private class ExponentialBackoffRetry implements Runnable {
+        private int retry;
+        private Map<String, List<WriteRequest>> unprocessedItems;
+        private Exception lastException;
+
+        public ExponentialBackoffRetry(Map<String, List<WriteRequest>> unprocessedItems) {
+            this.unprocessedItems = unprocessedItems;
+        }
+
+        @Override
+        public void run() {
+            logger.debug("Error storing object to dynamo, unprocessed items: {}. Retrying with exponential back-off",
+                    unprocessedItems);
+            lastException = null;
+            while (!unprocessedItems.isEmpty() && retry < WAIT_MILLIS_IN_RETRIES.length) {
+                if (!sleep()) {
+                    // Interrupted
+                    return;
+                }
+                retry++;
+                try {
+                    BatchWriteItemOutcome outcome = DynamoDBPersistenceService.this.db.getDynamoDB()
+                            .batchWriteItemUnprocessed(unprocessedItems);
+                    unprocessedItems = outcome.getUnprocessedItems();
+                    lastException = null;
+                } catch (AmazonServiceException e) {
+                    if (e instanceof ResourceNotFoundException) {
+                        logger.debug(
+                                "DynamoDB query raised unexpected exception: {}. This might happen if table was recently created",
+                                e.getMessage());
+                    } else {
+                        logger.debug("DynamoDB query raised unexpected exception: {}.", e.getMessage());
+                    }
+                    lastException = e;
+                    continue;
+                }
+            }
+            if (unprocessedItems.isEmpty()) {
+                logger.debug("After {} retries successfully wrote all unprocessed items", retry);
+            } else {
+                logger.error(
+                        "Even after retries failed to write some items. Last exception: {} {}, unprocessed items: {}",
+                        lastException == null ? "null" : lastException.getClass().getName(),
+                        lastException == null ? "null" : lastException.getMessage(), unprocessedItems);
+            }
+        }
+
+        private boolean sleep() {
+            try {
+                long sleepTime;
+                if (retry == 1 && lastException != null && lastException instanceof ResourceNotFoundException) {
+                    sleepTime = WAIT_ON_FIRST_RESOURCE_NOT_FOUND_MILLIS;
+                } else {
+                    sleepTime = WAIT_MILLIS_IN_RETRIES[retry];
+                }
+                Thread.sleep(sleepTime);
+                return true;
+            } catch (InterruptedException e) {
+                logger.error("Interrupted while writing data!");
+                return false;
+            }
+        }
+
+        public Map<String, List<WriteRequest>> getUnprocessedItems() {
+            return unprocessedItems;
+        }
+    }
+
+    private static final int WAIT_ON_FIRST_RESOURCE_NOT_FOUND_MILLIS = 5000;
+    private static final int[] WAIT_MILLIS_IN_RETRIES = new int[] { 100, 100, 200, 300, 500 };
+    private static final String DYNAMODB_THREADPOOL_NAME = "dynamodbPersistenceService";
 
     private ItemRegistry itemRegistry;
     private DynamoDBClient db;
-    private static final Logger logger = LoggerFactory.getLogger(DynamoDBPersistenceService.class);
+    private final Logger logger = LoggerFactory.getLogger(DynamoDBPersistenceService.class);
     private boolean isProperlyConfigured;
     private DynamoDBConfig dbConfig;
     private DynamoDBTableNameResolver tableNameResolver;
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1, new NamedThreadFactory());
+    private ScheduledFuture<?> writeBufferedDataFuture;
 
     /**
      * For testing. Allows access to underlying DynamoDBClient.
@@ -98,19 +178,25 @@ public class DynamoDBPersistenceService implements QueryablePersistenceService {
 
         tableNameResolver = new DynamoDBTableNameResolver(dbConfig.getTablePrefix());
         try {
-            boolean connectionOK = maybeConnectAndCheckConnection();
-            if (db == null) {
+            if (!ensureClient()) {
                 logger.error("Error creating dynamodb database client. Aborting service activation.");
                 return;
-            }
-            if (!connectionOK) {
-                // client creation succeeded but connection is not OK.
-                logger.warn("Failed to establish the dynamodb database connection. "
-                        + "Connection will be retried later on persistence service query/store.");
             }
         } catch (Exception e) {
             logger.error("Error constructing dynamodb client", e);
             return;
+        }
+
+        writeBufferedDataFuture = null;
+        resetWithBufferSize(dbConfig.getBufferSize());
+        long commitIntervalMillis = dbConfig.getBufferCommitIntervalMillis();
+        if (commitIntervalMillis > 0) {
+            writeBufferedDataFuture = scheduler.scheduleWithFixedDelay(new Runnable() {
+                @Override
+                public void run() {
+                    DynamoDBPersistenceService.this.flushBufferedData();
+                }
+            }, 0, commitIntervalMillis, TimeUnit.MILLISECONDS);
         }
         isProperlyConfigured = true;
         logger.debug("dynamodb persistence service activated");
@@ -118,17 +204,21 @@ public class DynamoDBPersistenceService implements QueryablePersistenceService {
 
     public void deactivate() {
         logger.debug("dynamodb persistence service deactivated");
+        if (writeBufferedDataFuture != null) {
+            writeBufferedDataFuture.cancel(false);
+            writeBufferedDataFuture = null;
+        }
         resetClient();
     }
 
     /**
-     * Initializes DynamoDBClient (db field), if necessary, and checks the connection.
+     * Initializes DynamoDBClient (db field)
      *
      * If DynamoDBClient constructor throws an exception, error is logged and false is returned.
      *
-     * @return whether connection was successful.
+     * @return whether initialization was successful.
      */
-    private boolean maybeConnectAndCheckConnection() {
+    private boolean ensureClient() {
         if (db == null) {
             try {
                 db = new DynamoDBClient(dbConfig);
@@ -137,7 +227,12 @@ public class DynamoDBPersistenceService implements QueryablePersistenceService {
                 return false;
             }
         }
-        return db.checkConnection();
+        return true;
+    }
+
+    @Override
+    public DynamoDBItem<?> persistenceItemFromState(String name, State state, Date time) {
+        return AbstractDynamoDBItem.fromState(name, state, time);
     }
 
     /**
@@ -242,54 +337,112 @@ public class DynamoDBPersistenceService implements QueryablePersistenceService {
     }
 
     @Override
+    protected boolean isReadyToStore() {
+        return isProperlyConfigured && ensureClient();
+    }
+
+    @Override
     public String getName() {
         return "dynamodb";
     }
 
     @Override
-    public void store(Item item) {
-        store(item, null);
+    protected void flushBufferedData() {
+        if (buffer.isEmpty()) {
+            return;
+        }
+        logger.debug("Writing buffered data. Buffer size: {}", buffer.size());
+
+        for (;;) {
+            Map<String, Deque<DynamoDBItem<?>>> itemsByTable = readBuffer();
+            // Write batch of data, one table at a time
+            for (Entry<String, Deque<DynamoDBItem<?>>> entry : itemsByTable.entrySet()) {
+                String tableName = entry.getKey();
+                Deque<DynamoDBItem<?>> batch = entry.getValue();
+                if (!batch.isEmpty()) {
+                    flushBatch(getDBMapper(tableName), batch);
+                }
+            }
+            if (buffer.isEmpty()) {
+                break;
+            }
+        }
+    }
+
+    private Map<String, Deque<DynamoDBItem<?>>> readBuffer() {
+        Map<String, Deque<DynamoDBItem<?>>> batchesByTable = new HashMap<String, Deque<DynamoDBItem<?>>>(2);
+        // Get batch of data
+        while (!buffer.isEmpty()) {
+            DynamoDBItem<?> dynamoItem = buffer.poll();
+            if (dynamoItem == null) {
+                break;
+            }
+            String tableName = tableNameResolver.fromItem(dynamoItem);
+            Deque<DynamoDBItem<?>> batch = batchesByTable.computeIfAbsent(tableName,
+                    new Function<String, Deque<DynamoDBItem<?>>>() {
+                        @Override
+                        public Deque<DynamoDBItem<?>> apply(String t) {
+                            return new ArrayDeque<DynamoDBItem<?>>();
+                        }
+                    });
+            batch.add(dynamoItem);
+        }
+        return batchesByTable;
     }
 
     /**
-     * {@inheritDoc}
+     * Flush batch of data to DynamoDB
+     *
+     * @param mapper mapper associated with the batch
+     * @param batch batch of data to write to DynamoDB
      */
-    @Override
-    public void store(Item item, String alias) {
-        if (item.getState() instanceof UnDefType) {
-            logger.debug("Undefined item state received. Not storing item.");
-            return;
+    private void flushBatch(DynamoDBMapper mapper, Deque<DynamoDBItem<?>> batch) {
+        long currentTimeMillis = System.currentTimeMillis();
+        List<FailedBatch> failed = mapper.batchSave(batch);
+        for (FailedBatch failedBatch : failed) {
+            if (failedBatch.getException() instanceof ResourceNotFoundException) {
+                // Table did not exist. Try writing everything again.
+                retryFlushAfterCreatingTable(mapper, batch, failedBatch);
+                break;
+            } else {
+                logger.debug("Batch failed with {}. Retrying next with exponential back-off",
+                        failedBatch.getException().getMessage());
+                new ExponentialBackoffRetry(failedBatch.getUnprocessedItems()).run();
+            }
         }
-        if (!isProperlyConfigured) {
-            logger.warn("Configuration for dynamodb not yet loaded or broken. Not storing item.");
-            return;
+        if (failed.isEmpty()) {
+            logger.debug("flushBatch ended with {} items in {} ms: {}", batch.size(),
+                    System.currentTimeMillis() - currentTimeMillis, batch);
+        } else {
+            logger.warn(
+                    "flushBatch ended with {} items in {} ms: {}. There were some failed batches that were retried -- check logs for ERRORs to see if writes were successful",
+                    batch.size(), System.currentTimeMillis() - currentTimeMillis, batch);
         }
-        if (!maybeConnectAndCheckConnection()) {
-            logger.warn("DynamoDB not connected. Not storing item.");
-            return;
-        }
-        String realName = item.getName();
-        String name = (alias != null) ? alias : realName;
-        Date time = new Date(System.currentTimeMillis());
+    }
 
-        State state = item.getState();
-        logger.trace("Tried to get item from item class {}, state is {}", item.getClass(), state.toString());
-        DynamoDBItem<?> dynamoItem = AbstractDynamoDBItem.fromState(name, state, time);
-        DynamoDBMapper mapper = getDBMapper(tableNameResolver.fromItem(dynamoItem));
-
-        if (!createTable(mapper, dynamoItem.getClass())) {
-            logger.warn("Table creation failed. Not storing item");
-            return;
+    /**
+     * Retry flushing data after creating table associated with mapper
+     *
+     * @param mapper mapper associated with the batch
+     * @param batch original batch of data. Used for logging and to determine table name
+     * @param failedBatch failed batch that should be retried
+     */
+    private void retryFlushAfterCreatingTable(DynamoDBMapper mapper, Deque<DynamoDBItem<?>> batch,
+            FailedBatch failedBatch) {
+        logger.debug("Table was not found. Trying to create table and try saving again");
+        if (createTable(mapper, batch.peek().getClass())) {
+            logger.debug("Table creation successful, trying to save again");
+            if (!failedBatch.getUnprocessedItems().isEmpty()) {
+                ExponentialBackoffRetry retry = new ExponentialBackoffRetry(failedBatch.getUnprocessedItems());
+                retry.run();
+                if (retry.getUnprocessedItems().isEmpty()) {
+                    logger.debug("Successfully saved items after table creation");
+                }
+            }
+        } else {
+            logger.warn("Table creation failed. Not storing some parts of batch: {}. Unprocessed items: {}", batch,
+                    failedBatch.getUnprocessedItems());
         }
-
-        try {
-            logger.debug("storing {} in dynamo. Serialized value {}. Original Item: {}", name, state, item);
-            mapper.save(dynamoItem);
-            logger.debug("Sucessfully stored item {}", item);
-        } catch (AmazonClientException e) {
-            logger.error("Error storing object to dynamo: {}", e.getMessage());
-        }
-
     }
 
     /**
@@ -302,7 +455,7 @@ public class DynamoDBPersistenceService implements QueryablePersistenceService {
             logger.warn("Configuration for dynamodb not yet loaded or broken. Not storing item.");
             return Collections.emptyList();
         }
-        if (!maybeConnectAndCheckConnection()) {
+        if (!ensureClient()) {
             logger.warn("DynamoDB not connected. Not storing item.");
             return Collections.emptyList();
         }
@@ -322,7 +475,8 @@ public class DynamoDBPersistenceService implements QueryablePersistenceService {
 
         List<HistoricItem> historicItems = new ArrayList<HistoricItem>();
 
-        DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression = createQueryExpression(dtoClass, filter);
+        DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression = DynamoDBQueryUtils.createQueryExpression(dtoClass,
+                filter);
         @SuppressWarnings("rawtypes")
         final PaginatedQueryList<? extends DynamoDBItem> paginatedList;
         try {
@@ -354,121 +508,6 @@ public class DynamoDBPersistenceService implements QueryablePersistenceService {
     }
 
     /**
-     * Construct dynamodb query from filter
-     *
-     * @param filter
-     * @return DynamoDBQueryExpression corresponding to the given FilterCriteria
-     */
-    private DynamoDBQueryExpression<DynamoDBItem<?>> createQueryExpression(Class<? extends DynamoDBItem<?>> dtoClass,
-            FilterCriteria filter) {
-        DynamoDBItem<?> item = getDynamoDBHashKey(dtoClass, filter.getItemName());
-        final DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression = new DynamoDBQueryExpression<DynamoDBItem<?>>()
-                .withHashKeyValues(item).withScanIndexForward(filter.getOrdering() == Ordering.ASCENDING)
-                .withLimit(filter.getPageSize());
-        Condition timeFilter = maybeAddTimeFilter(queryExpression, filter);
-        maybeAddStateFilter(filter, queryExpression);
-        logger.debug("Querying: {} with {}", filter.getItemName(), timeFilter);
-        return queryExpression;
-    }
-
-    private DynamoDBItem<?> getDynamoDBHashKey(Class<? extends DynamoDBItem<?>> dtoClass, String itemName) {
-        DynamoDBItem<?> item;
-        try {
-            item = dtoClass.newInstance();
-        } catch (InstantiationException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-        item.setName(itemName);
-        return item;
-    }
-
-    private void maybeAddStateFilter(FilterCriteria filter,
-            final DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression) {
-        if (filter.getOperator() != null && filter.getState() != null) {
-            // Convert filter's state to DynamoDBItem in order get suitable string representation for the state
-            final DynamoDBItem<?> filterState = AbstractDynamoDBItem.fromState(filter.getItemName(), filter.getState(),
-                    new Date());
-            queryExpression.setFilterExpression(String.format("%s %s :opstate", DynamoDBItem.ATTRIBUTE_NAME_ITEMSTATE,
-                    operatorAsString(filter.getOperator())));
-
-            filterState.accept(new DynamoDBItemVisitor() {
-
-                @Override
-                public void visit(DynamoDBStringItem dynamoStringItem) {
-                    queryExpression.setExpressionAttributeValues(
-                            ImmutableMap.of(":opstate", new AttributeValue().withS(dynamoStringItem.getState())));
-                }
-
-                @Override
-                public void visit(DynamoDBBigDecimalItem dynamoBigDecimalItem) {
-                    queryExpression.setExpressionAttributeValues(ImmutableMap.of(":opstate",
-                            new AttributeValue().withN(dynamoBigDecimalItem.getState().toPlainString())));
-                }
-            });
-
-        }
-    }
-
-    private Condition maybeAddTimeFilter(final DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression,
-            final FilterCriteria filter) {
-        final Condition timeCondition = constructTimeCondition(filter);
-        if (timeCondition != null) {
-            queryExpression.setRangeKeyConditions(
-                    Collections.singletonMap(DynamoDBItem.ATTRIBUTE_NAME_TIMEUTC, timeCondition));
-        }
-        return timeCondition;
-    }
-
-    private Condition constructTimeCondition(FilterCriteria filter) {
-        boolean hasBegin = filter.getBeginDate() != null;
-        boolean hasEnd = filter.getEndDate() != null;
-
-        final Condition timeCondition;
-        if (!hasBegin && !hasEnd) {
-            timeCondition = null;
-        } else if (!hasBegin && hasEnd) {
-            timeCondition = new Condition().withComparisonOperator(ComparisonOperator.LE).withAttributeValueList(
-                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getEndDate())));
-        } else if (hasBegin && !hasEnd) {
-            timeCondition = new Condition().withComparisonOperator(ComparisonOperator.GE).withAttributeValueList(
-                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getBeginDate())));
-        } else {
-            timeCondition = new Condition().withComparisonOperator(ComparisonOperator.BETWEEN).withAttributeValueList(
-                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getBeginDate())),
-                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getEndDate())));
-        }
-        return timeCondition;
-    }
-
-    /**
-     * Convert op to string suitable for dynamodb filter expression
-     *
-     * @param op
-     * @return string representation corresponding to the given the Operator
-     */
-    private static String operatorAsString(Operator op) {
-        switch (op) {
-            case EQ:
-                return "=";
-            case NEQ:
-                return "<>";
-            case LT:
-                return "<";
-            case LTE:
-                return "<=";
-            case GT:
-                return ">";
-            case GTE:
-                return ">=";
-
-            default:
-                throw new IllegalStateException("Unknown operator " + op);
-        }
-    }
-
-    /**
      * Retrieves the item for the given name from the item registry
      *
      * @param itemName
@@ -484,6 +523,38 @@ public class DynamoDBPersistenceService implements QueryablePersistenceService {
             logger.error("Unable to get item {} from registry", itemName);
         }
         return item;
+    }
+
+    /**
+     * This is a normal thread factory, which adds a named prefix to all created
+     * threads.
+     *
+     * Adapted from RRD4jService
+     */
+    private static class NamedThreadFactory implements ThreadFactory {
+
+        protected final ThreadGroup group;
+        protected final AtomicInteger threadNumber = new AtomicInteger(1);
+        protected final String namePrefix;
+
+        public NamedThreadFactory() {
+            this.namePrefix = DYNAMODB_THREADPOOL_NAME;
+            SecurityManager s = System.getSecurityManager();
+            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
+            if (!t.isDaemon()) {
+                t.setDaemon(true);
+            }
+            if (t.getPriority() != Thread.NORM_PRIORITY) {
+                t.setPriority(Thread.NORM_PRIORITY);
+            }
+
+            return t;
+        }
     }
 
 }

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBQueryUtils.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBQueryUtils.java
@@ -1,0 +1,130 @@
+package org.openhab.persistence.dynamodb.internal;
+
+import java.util.Collections;
+import java.util.Date;
+
+import org.openhab.core.persistence.FilterCriteria;
+import org.openhab.core.persistence.FilterCriteria.Operator;
+import org.openhab.core.persistence.FilterCriteria.Ordering;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.google.common.collect.ImmutableMap;
+
+public class DynamoDBQueryUtils {
+    /**
+     * Construct dynamodb query from filter
+     *
+     * @param filter
+     * @return DynamoDBQueryExpression corresponding to the given FilterCriteria
+     */
+    public static DynamoDBQueryExpression<DynamoDBItem<?>> createQueryExpression(
+            Class<? extends DynamoDBItem<?>> dtoClass, FilterCriteria filter) {
+        DynamoDBItem<?> item = getDynamoDBHashKey(dtoClass, filter.getItemName());
+        final DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression = new DynamoDBQueryExpression<DynamoDBItem<?>>()
+                .withHashKeyValues(item).withScanIndexForward(filter.getOrdering() == Ordering.ASCENDING)
+                .withLimit(filter.getPageSize());
+        maybeAddTimeFilter(queryExpression, filter);
+        maybeAddStateFilter(filter, queryExpression);
+        return queryExpression;
+    }
+
+    private static DynamoDBItem<?> getDynamoDBHashKey(Class<? extends DynamoDBItem<?>> dtoClass, String itemName) {
+        DynamoDBItem<?> item;
+        try {
+            item = dtoClass.newInstance();
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        item.setName(itemName);
+        return item;
+    }
+
+    private static void maybeAddStateFilter(FilterCriteria filter,
+            final DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression) {
+        if (filter.getOperator() != null && filter.getState() != null) {
+            // Convert filter's state to DynamoDBItem in order get suitable string representation for the state
+            final DynamoDBItem<?> filterState = AbstractDynamoDBItem.fromState(filter.getItemName(), filter.getState(),
+                    new Date());
+            queryExpression.setFilterExpression(String.format("%s %s :opstate", DynamoDBItem.ATTRIBUTE_NAME_ITEMSTATE,
+                    operatorAsString(filter.getOperator())));
+
+            filterState.accept(new DynamoDBItemVisitor() {
+
+                @Override
+                public void visit(DynamoDBStringItem dynamoStringItem) {
+                    queryExpression.setExpressionAttributeValues(
+                            ImmutableMap.of(":opstate", new AttributeValue().withS(dynamoStringItem.getState())));
+                }
+
+                @Override
+                public void visit(DynamoDBBigDecimalItem dynamoBigDecimalItem) {
+                    queryExpression.setExpressionAttributeValues(ImmutableMap.of(":opstate",
+                            new AttributeValue().withN(dynamoBigDecimalItem.getState().toPlainString())));
+                }
+            });
+
+        }
+    }
+
+    private static Condition maybeAddTimeFilter(final DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression,
+            final FilterCriteria filter) {
+        final Condition timeCondition = constructTimeCondition(filter);
+        if (timeCondition != null) {
+            queryExpression.setRangeKeyConditions(
+                    Collections.singletonMap(DynamoDBItem.ATTRIBUTE_NAME_TIMEUTC, timeCondition));
+        }
+        return timeCondition;
+    }
+
+    private static Condition constructTimeCondition(FilterCriteria filter) {
+        boolean hasBegin = filter.getBeginDate() != null;
+        boolean hasEnd = filter.getEndDate() != null;
+
+        final Condition timeCondition;
+        if (!hasBegin && !hasEnd) {
+            timeCondition = null;
+        } else if (!hasBegin && hasEnd) {
+            timeCondition = new Condition().withComparisonOperator(ComparisonOperator.LE).withAttributeValueList(
+                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getEndDate())));
+        } else if (hasBegin && !hasEnd) {
+            timeCondition = new Condition().withComparisonOperator(ComparisonOperator.GE).withAttributeValueList(
+                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getBeginDate())));
+        } else {
+            timeCondition = new Condition().withComparisonOperator(ComparisonOperator.BETWEEN).withAttributeValueList(
+                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getBeginDate())),
+                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getEndDate())));
+        }
+        return timeCondition;
+    }
+
+    /**
+     * Convert op to string suitable for dynamodb filter expression
+     *
+     * @param op
+     * @return string representation corresponding to the given the Operator
+     */
+    private static String operatorAsString(Operator op) {
+        switch (op) {
+            case EQ:
+                return "=";
+            case NEQ:
+                return "<>";
+            case LT:
+                return "<";
+            case LTE:
+                return "<=";
+            case GT:
+                return ">";
+            case GTE:
+                return ">=";
+
+            default:
+                throw new IllegalStateException("Unknown operator " + op);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces several performance optimizations to DynamoDB Persistence Service:
- buffering data in the PersistenceService, and writing it in batches on background.
  We get performance gains by writing data in batches but also reduce
  `items` `QueueingThreadPoolExecutor.taskQueue` pressure in `GenericItem.notifyListeners`.
- previously several checks were done on each store, causing
  significant overhead on `store` and `query` operations: 1) connection check
  (listing tables), 2) checking table existence. These are now removed,
  table is created on error (`ResourceNotFoundException`).

In addition, I have implemented exponential back-off retry for writes.

I've been verified the changes in my local setup. Before I could see that `QueueingThreadPoolExecutor.taskQueue` size growed (temporarily, but still) up to 500-1500 when many items were persisted at the same time. Dealing with the queue took some noticeable time. With the improvements, the size remains close to zero all the time.

Signed-off-by: Sami Salonen <ssalonen@gmail.com>