### PR TITLE
update link for 2.x astro binding

### DIFF
--- a/bundles/binding/org.openhab.binding.astro/README.md
+++ b/bundles/binding/org.openhab.binding.astro/README.md
@@ -2,7 +2,7 @@
 
 The Astro binding is used for calculating many `DateTime` and positional values for sun and moon and for scheduling of events.
 
-There is also a binding specifically for openHAB 2 [here](https://www.openhab.org/addons/bindings/astro/).
+There is also a binding specifically for openHAB 2 [here](https://www.openhab.org/v2.4/addons/bindings/astro/).
 
 ### Binding Configuration
 


### PR DESCRIPTION
The link for the 2.x astro binding is broken.  This one works, but may be v2.4 specific.  I don't know of a better link.

Signed-off-by: John Schmitz <jswim400im@gmail.com> (github: jswim788)