### PR TITLE
Fix OpenWeather API key failure

### DIFF
--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
@@ -46,6 +46,6 @@ public class OpenWeatherMapProvider extends AbstractWeatherProvider {
      */
     @Override
     protected String getForecastUrl() {
-        return FORECAST;
+        return null;
     }
 }


### PR DESCRIPTION
Why:
* OpenWeather discontinued the the Free Plan and by this the old code generates an unconditonal error using API as FORECAST is always used / opened.

This change addresses the need by:
* returning null in the FORECAST call