### PR TITLE
[weather] Fix OpenWeather API key failure by removing FORECAST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,14 @@ itemDump.txt
 # IntelliJ files
 **/.idea
 **/*.iml
+
+# ignore eclipse and vscode output
+.vscode/
+.classpath
+.project
+.settings
+.idea
+.metadata
+*.iml
+*.ipr
+

--- a/bundles/binding/org.openhab.binding.weather/README.md
+++ b/bundles/binding/org.openhab.binding.weather/README.md
@@ -44,6 +44,7 @@ The table below shows the apikey properties for the different weather providers;
 |---------------------------|-------------|
 | apikey.ForecastIo         | API key for [ForecastIo](http://forecast.io) |
 | apikey.OpenWeatherMap     | API key for [OpenWeatherMap](http://openweathermap.org) |
+| apikey2.OpenWeatherMap    | optional API key if [OpenWeatherMap forecasts](https://openweathermap.org/forecast5) paid / non-free, are to acquired|
 | apikey.WorldWeatherOnline | API key for [WorldWeatherOnline](http://worldweatheronline.com) |
 | apikey.Hamweather         | `client_id` for [Hamweather](http://hamweather.com) |
 | apikey2.Hamweather        | `client_secret` for [Hamweather](http://hamweather.com) |
@@ -53,6 +54,7 @@ The table below shows the apikey properties for the different weather providers;
 
 > [Hamweather](http://hamweather.com) is the only provider with multiple keys; both are required.
 
+> [OpenWeather](http://openweathermap.org) has a non-free FORECAST service, specify the key in `apikey2` that then will include this service in openHAB, value may be the same as the first apikey. In case apikey2 was accidentally specified or produces error-messages, one can nullify the use by: `apikey2.OpenWeatherMap=null`; or leave it out and restart openHAB.
 
 ### Location Configuration
 
@@ -284,7 +286,7 @@ Number   Temp_Max         "Temperature max [%.2f °C]"   {weather="locationId=ho
 Each provider sends different forecast days. 
 
 - ForecastIo: 8 days (0-7)
-- OpenWeatherMap: 5 days (0-4)
+- OpenWeatherMap: 5 days (0-4)  (Note: requires a paid key in weather configuration)
 - WorldWeatherOnline: 5 days (0-4)
 - Hamweather: 5 days (0-4)
 - Meteoblue: 10 days (0-9)

--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
@@ -46,6 +46,6 @@ public class OpenWeatherMapProvider extends AbstractWeatherProvider {
      */
     @Override
     protected String getForecastUrl() {
-        return FORECAST;
+        return null;
     }
 }

--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/OpenWeatherMapProvider.java
@@ -11,6 +11,10 @@ package org.openhab.binding.weather.internal.provider;
 import org.openhab.binding.weather.internal.model.ProviderName;
 import org.openhab.binding.weather.internal.parser.JsonWeatherParser;
 
+import org.openhab.binding.weather.internal.common.WeatherConfig;
+import org.openhab.binding.weather.internal.common.WeatherContext;
+import org.openhab.binding.weather.internal.common.ProviderConfig;
+
 /**
  * OpenWeatherMap weather provider.
  *
@@ -19,8 +23,11 @@ import org.openhab.binding.weather.internal.parser.JsonWeatherParser;
  */
 public class OpenWeatherMapProvider extends AbstractWeatherProvider {
     private static final String URL = "http://api.openweathermap.org/data/2.5/weather?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&mode=json&units=metric&APPID=[API_KEY]";
-    private static final String FORECAST = "http://api.openweathermap.org/data/2.5/forecast/daily?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&cnt=5&mode=json&units=metric&APPID=[API_KEY]";
-
+    // private static final String FORECAST = "http://api.openweathermap.org/data/2.5/forecast/daily?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&cnt=5&mode=json&units=metric&APPID=[API_KEY]";
+    private static final String FORECAST = "http://api.openweathermap.org/data/2.5/forecast/daily?lat=[LATITUDE]&lon=[LONGITUDE]&lang=[LANGUAGE]&cnt=5&mode=json&units=metric&APPID=[API_KEY_2]";
+    
+    private WeatherConfig config = WeatherContext.getInstance().getConfig();
+   
     public OpenWeatherMapProvider() {
         super(new JsonWeatherParser());
     }
@@ -46,6 +53,12 @@ public class OpenWeatherMapProvider extends AbstractWeatherProvider {
      */
     @Override
     protected String getForecastUrl() {
-        return FORECAST;
+        ProviderConfig providerConfig = config.getProviderConfig(getProviderName());
+        if (providerConfig.getApiKey2() != null && !providerConfig.getApiKey2().equals("null") ) {
+            return FORECAST;
+        } else {
+            return null;
+        }
+        
     }
 }


### PR DESCRIPTION
Yahoo stopped the functionality for openHAB, we switched to OpenWeather which generated an other issue.
Why:
* OpenWeather discontinued the 5-day FORECAST included in their Free Plan which now generate an API-key error message in the openhab.log as the Weather bundle, unconditionally calls for FORECAST in succession to the default (actual) Weatherstatus.

For OpenWeather information reasons,  pulling FORECAST from FreePlan, [read thread 17136552](https://openweathermap.desk.com/customer/portal/questions/17136552-api-not-allowing-daily-forecast)

This change addresses the need by:
* return null in the FORECAST @override call

Fixes #5837 