### PR TITLE
[dynamodb] Fix test failure

### DIFF
--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
@@ -183,7 +183,7 @@ public class AbstractDynamoDBItemSerializationTest {
 
     @Test
     public void testDecimalTypeWithNumberItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new DecimalType(3.2), new BigDecimal("3.2"));
+        DynamoDBItem<?> dbitem = testStateGeneric(new DecimalType("3.2"), new BigDecimal("3.2"));
         testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType(3.2));
     }
 

--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
@@ -100,8 +100,8 @@ public class AbstractDynamoDBItemSerializationTest {
             BigDecimal expectedRounded = DynamoDBBigDecimalItem
                     .loseDigits(((DecimalType) expectedState).toBigDecimal());
             BigDecimal actual = ((DecimalType) historicItem.getState()).toBigDecimal();
-            assertTrue(String.format("Expected: %s actual: %s", expectedRounded, actual),
-                    expectedRounded.compareTo(actual) == 0);
+            assertTrue(String.format("Expected state %s (%s but with some digits lost) did not match actual state %s",
+                    expectedRounded, expectedState, actual), expectedRounded.compareTo(actual) == 0);
         } else if (expectedState instanceof CallType) {
             // CallType has buggy equals, let's compare strings instead
             assertEquals(expectedState.toString(), historicItem.getState().toString());

--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
@@ -61,19 +61,20 @@ public class AbstractDynamoDBItemSerializationTest {
      * @return dynamo db item
      * @throws IOException
      */
-    @SuppressWarnings("unchecked")
     public DynamoDBItem<?> testStateGeneric(State state, Object expectedState) throws IOException {
         DynamoDBItem<?> dbItem = AbstractDynamoDBItem.fromState("item1", state, date);
 
         assertEquals("item1", dbItem.getName());
         assertEquals(date, dbItem.getTime());
+        Object actualState = dbItem.getState();
         if (expectedState instanceof BigDecimal) {
-            BigDecimal expectedDigitsLost = DynamoDBBigDecimalItem.loseDigits(((BigDecimal) expectedState));
-            BigDecimal actual = ((DynamoDBItem<BigDecimal>) dbItem).getState();
-            assertTrue(String.format("Expected state %s (%s but with some digits lost) did not match actual state %s",
-                    expectedDigitsLost, expectedState, actual), expectedDigitsLost.compareTo(actual) == 0);
+            BigDecimal expectedRounded = DynamoDBBigDecimalItem.loseDigits(((BigDecimal) expectedState));
+            assertTrue(
+                    String.format("Expected state %s (%s but with some digits lost) did not match actual state %s",
+                            expectedRounded, expectedState, actualState),
+                    expectedRounded.compareTo((BigDecimal) actualState) == 0);
         } else {
-            assertEquals(expectedState, dbItem.getState());
+            assertEquals(expectedState, actualState);
         }
         return dbItem;
     }
@@ -96,8 +97,11 @@ public class AbstractDynamoDBItemSerializationTest {
         assertEquals(expectedState.getClass(), historicItem.getState().getClass());
         if (expectedState instanceof DecimalType) {
             // serialization loses accuracy, take this into consideration
-            assertTrue(DynamoDBBigDecimalItem.loseDigits(((DecimalType) expectedState).toBigDecimal())
-                    .compareTo(((DecimalType) historicItem.getState()).toBigDecimal()) == 0);
+            BigDecimal expectedRounded = DynamoDBBigDecimalItem
+                    .loseDigits(((DecimalType) expectedState).toBigDecimal());
+            BigDecimal actual = ((DecimalType) historicItem.getState()).toBigDecimal();
+            assertTrue(String.format("Expected: %s actual: %s", expectedRounded, actual),
+                    expectedRounded.compareTo(actual) == 0);
         } else if (expectedState instanceof CallType) {
             // CallType has buggy equals, let's compare strings instead
             assertEquals(expectedState.toString(), historicItem.getState().toString());

--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
@@ -188,7 +188,7 @@ public class AbstractDynamoDBItemSerializationTest {
     @Test
     public void testDecimalTypeWithNumberItem() throws IOException {
         DynamoDBItem<?> dbitem = testStateGeneric(new DecimalType("3.2"), new BigDecimal("3.2"));
-        testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType(3.2));
+        testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType("3.2"));
     }
 
     @Test


### PR DESCRIPTION
Attempt to fix https://ci.openhab.org/job/openHAB1-Addons/lastCompletedBuild/org.openhab.persistence$org.openhab.persistence.dynamodb.test/testReport/org.openhab.persistence.dynamodb.internal/AbstractDynamoDBItemSerializationTest/testDecimalTypeWithNumberItem/

cc @kaikreuzer 

Did not fail with all platforms (for example could reproduce locally).

```
org.openhab.persistence.dynamodb.internal.AbstractDynamoDBItemSerializationTest.testDecimalTypeWithNumberItem

Failing for the past 3 builds (Since Unstable#1698 )
Took 3 ms.

Error Message
Expected state 3.2 (3.2 but with some digits lost) did not match actual state 3.2000000000000001776356839400250464678

Stacktrace
java.lang.AssertionError: Expected state 3.2 (3.2 but with some digits lost) did not match actual state 3.2000000000000001776356839400250464678
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.openhab.persistence.dynamodb.internal.AbstractDynamoDBItemSerializationTest.testStateGeneric(AbstractDynamoDBItemSerializationTest.java:73)
	at org.openhab.persistence.dynamodb.internal.AbstractDynamoDBItemSerializationTest.testDecimalTypeWithNumberItem(AbstractDynamoDBItemSerializationTest.java:186)
```

Signed-off-by: Sami Salonen <ssalonen@gmail.com>