### PR TITLE
[TCP1] Unescape UDP preAmble and postAmple like for TCP

### DIFF
--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.openhab.binding.tcp.AbstractDatagramChannelBinding;
 import org.openhab.binding.tcp.Direction;
 import org.openhab.binding.tcp.internal.TCPActivator;
@@ -40,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * text based status messages.
  *
  * @author Karel Goderis
- * @since 1.1.0
+ * @author Helmut Lehmeyer
  */
 public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvider> implements ManagedService {
 
@@ -117,8 +118,8 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
                 if (newState != null) {
                     eventPublisher.postUpdate(itemName, newState);
                 } else {
-                    logger.warn("Cannot parse transformed input {} to match command {} on item {}",
-                            transformedResponse, command, itemName);
+                    logger.warn("Cannot parse transformed input {} to match command {} on item {}", transformedResponse,
+                            command, itemName);
                 }
 
                 return false;
@@ -202,22 +203,14 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
 
         String preambleString = Objects.toString(config.get("preamble"), null);
         if (isNotBlank(preambleString)) {
-            try {
-                preAmble = preambleString.replaceAll("\\\\", "\\");
-            } catch (Exception e) {
-                preAmble = preambleString;
-            }
+            preAmble = StringEscapeUtils.unescapeJava(preambleString);
         } else {
             logger.info("The preamble for all write operations will be set to the default value of {}", preAmble);
         }
 
         String postambleString = Objects.toString(config.get("postamble"), null);
         if (isNotBlank(postambleString)) {
-            try {
-                postAmble = postambleString.replaceAll("\\\\", "\\");
-            } catch (Exception e) {
-                postAmble = postambleString;
-            }
+            postAmble = StringEscapeUtils.unescapeJava(postambleString);
         } else {
             logger.info("The postamble for all write operations will be set to the default value of {}", postAmble);
         }


### PR DESCRIPTION
Transfer the functionality of [TCPBinding.java](https://github.com/lewie/openhab/blob/master/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java#L210) also to UDPBinding.java 

Using UDP, postamble=\r was sent as UTF-8 instead as ASCII:

> Receved: str\\u000d	-> HEX:  73 74 72 5C 75 30 30 30 64

Now, it will be sent as ASCII:

> Receved: str\r	 	 	 -> HEX:  73 74 72 0D

Signed-off-by: lewie <helmut.lehmeyer@gmail.com>