### PR TITLE
Fix CUL 2s blocking problem after sending FS20 message

### DIFF
--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
@@ -204,8 +204,12 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
     @Override
     public void send(String command) {
         if (isMessageAllowed(command)) {
-            sendQueue.offer(command);
-            requestCreditReport();
+            if (sendQueue.offer(command)) {
+                requestCreditReport();
+            } else {
+                log.warn("Send buffer overrun. Doing reset");
+                sendQueue.clear();
+            }
         }
     }
 

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
@@ -104,7 +104,7 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
 
         @Override
         public synchronized void error(Exception e) {
-            logger.trace("CUL error received: {}", e);
+            logger.debug("CUL error received: {}", e);
             notify();
         }
     }
@@ -297,7 +297,7 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
      */
     private void requestCreditReport() {
         /* this requests a report which provides credit10ms */
-        log.debug("Requesting credit report");
+        log.trace("Requesting credit report");
         try {
             sendWithoutCheck("X\r\n");
         } catch (CULCommunicationException e) {

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
@@ -83,6 +83,7 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
                     logger.warn("Error while writing command to CUL", e);
                 }
             }
+            logger.warn("Sending thread interrupted");
         }
 
         private synchronized void waitOnCulResponse() {

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
@@ -78,7 +78,9 @@ public abstract class AbstractCULHandler<T extends CULConfig> implements CULHand
                     if (async_cmds.contains(command.subSequence(0, 1))) {
                         continue;
                     }
+                    long start_ms = System.nanoTime();
                     waitOnCulResponse();
+                    logger.trace("Response took {} ms", (System.nanoTime() - start_ms) / 1000000);
                 } catch (CULCommunicationException e) {
                     logger.warn("Error while writing command to CUL", e);
                 }


### PR DESCRIPTION
Currently the CUL sending thread will produce a timeout of 2s if a command is sent that will not provide a response. This is the case when sending a FS20 message ("F" prefix). The major purpose of this PR is to provide a generic solution for such commands and only fix the problem for the FS20 protocol as there is no other equipment for testing available.

Additional Minor changes and refactorings:
 - Use a queue that is blocking instead of polling in a busy loop
 - Use monitors / synchronized methods to wait for a response instead of using a boolean local member
