### PR TITLE
Update unleash plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,12 +182,12 @@
         <plugin>
           <groupId>com.itemis.maven.plugins</groupId>
           <artifactId>unleash-maven-plugin</artifactId>
-          <version>2.7.3</version>
+          <version>2.9.3</version>
           <dependencies>
             <dependency>
               <groupId>com.itemis.maven.plugins</groupId>
               <artifactId>unleash-scm-provider-git</artifactId>
-              <version>2.1.0</version>
+              <version>2.2.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Needed to fix error with current Git version:

 ```
[ERROR] Failed to execute goal com.itemis.maven.plugins:unleash-maven-plugin:2.7.3:perform-tycho (default-cli) on project pom-addons1: Execution default-cli of goal com.itemis.maven.plugins:unleash-maven-plugin:2.7.3:perform-tycho failed: Unable to add local changes to the index. At least one pattern is required.
```

Signed-off-by: Patrick Fink <mail@pfink.de>