### PR TITLE
Fixed restriction on special characters in URLs

### DIFF
--- a/bundles/binding/org.openhab.binding.caldav-personal/README.md
+++ b/bundles/binding/org.openhab.binding.caldav-personal/README.md
@@ -19,7 +19,7 @@ openhab.cfg
 * `caldavio:timeZone=<Timezone>`
 
 **Restrictions**
-* The calendar-id must be just upper- and lowercase characters. (e. g. private or work, something like 1 or private-home is not allowed)
+* The calendar-id must either be only upper- and lowercase characters (e. g. private or work), or special characters must be escaped, ref. https://www.w3schools.com/tags/ref_urlencode.asp (e.g. 'calendar1' -> 'calendar%31' or 'private-home' -> 'private%2Dhome')
 * disableCertificateVerification can just be set to true (default is false) if ssl is used.
 * timeZone must just be used if the local timezone of the pc is not the correct one. E. g. if you are living in Berlin and your calendar timezone is Berlin and your local pc timezone is Berlin you must not define this setting
 * '' for item configurations are optional (eventNr:1 and eventNr:'1' is the same). I prefer to use ''


### PR DESCRIPTION
Escaping special characters in URLs allows usage of calendar-ids with special characters, e.g. private-home --> private%2Dhome