### PR TITLE
Enable expiration of data in DynamoDB

### DIFF
--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfigTest.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfigTest.java
@@ -63,6 +63,8 @@ public class DynamoDBConfigTest {
         assertEquals(1, fromConfig.getWriteCapacityUnits());
         assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
         assertEquals(1000, fromConfig.getBufferSize());
+        assertEquals(false, fromConfig.isAutoExpirationEnabled());
+        assertEquals(90, fromConfig.getAutoExpirationDays());
     }
 
     @Test
@@ -80,6 +82,8 @@ public class DynamoDBConfigTest {
         assertEquals(1, fromConfig.getWriteCapacityUnits());
         assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
         assertEquals(1000, fromConfig.getBufferSize());
+        assertEquals(false, fromConfig.isAutoExpirationEnabled());
+        assertEquals(90, fromConfig.getAutoExpirationDays());
     }
 
     @Test
@@ -125,6 +129,8 @@ public class DynamoDBConfigTest {
         assertEquals(1, fromConfig.getWriteCapacityUnits());
         assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
         assertEquals(1000, fromConfig.getBufferSize());
+        assertEquals(false, fromConfig.isAutoExpirationEnabled());
+        assertEquals(90, fromConfig.getAutoExpirationDays());
     }
 
     @Test
@@ -140,6 +146,8 @@ public class DynamoDBConfigTest {
         assertEquals(1, fromConfig.getWriteCapacityUnits());
         assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
         assertEquals(1000, fromConfig.getBufferSize());
+        assertEquals(false, fromConfig.isAutoExpirationEnabled());
+        assertEquals(90, fromConfig.getAutoExpirationDays());
     }
 
     @Test
@@ -155,6 +163,8 @@ public class DynamoDBConfigTest {
         assertEquals(1, fromConfig.getWriteCapacityUnits());
         assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
         assertEquals(1000, fromConfig.getBufferSize());
+        assertEquals(false, fromConfig.isAutoExpirationEnabled());
+        assertEquals(90, fromConfig.getAutoExpirationDays());
     }
 
     @Test
@@ -170,6 +180,8 @@ public class DynamoDBConfigTest {
         assertEquals(5, fromConfig.getWriteCapacityUnits());
         assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
         assertEquals(1000, fromConfig.getBufferSize());
+        assertEquals(false, fromConfig.isAutoExpirationEnabled());
+        assertEquals(90, fromConfig.getAutoExpirationDays());
     }
 
     @Test
@@ -185,6 +197,8 @@ public class DynamoDBConfigTest {
         assertEquals(5, fromConfig.getWriteCapacityUnits());
         assertEquals(1000L, fromConfig.getBufferCommitIntervalMillis());
         assertEquals(1000, fromConfig.getBufferSize());
+        assertEquals(false, fromConfig.isAutoExpirationEnabled());
+        assertEquals(90, fromConfig.getAutoExpirationDays());
     }
 
     @Test
@@ -202,5 +216,45 @@ public class DynamoDBConfigTest {
         assertEquals(5, fromConfig.getWriteCapacityUnits());
         assertEquals(501L, fromConfig.getBufferCommitIntervalMillis());
         assertEquals(112, fromConfig.getBufferSize());
+        assertEquals(false, fromConfig.isAutoExpirationEnabled());
+        assertEquals(90, fromConfig.getAutoExpirationDays());
+    }
+
+    @Test
+    public void testRegionWithAccessKeysWithPrefixWithReadWriteCapacityUnitsWithBufferSettingsWithExpirationEnabled() throws Exception {
+        DynamoDBConfig fromConfig = DynamoDBConfig.fromConfig(
+                ImmutableMap.<String, Object> builder().put("region", "eu-west-1").put("accessKey", "access1")
+                        .put("secretKey", "secret1").put("readCapacityUnits", "3").put("writeCapacityUnits", "5")
+                        .put("bufferCommitIntervalMillis", "501").put("bufferSize", "112").put("autoExpirationEnabled","true").build());
+        assertEquals(Regions.EU_WEST_1, fromConfig.getRegion());
+        assertEquals("access1", fromConfig.getCredentials().getAWSAccessKeyId());
+        assertEquals("secret1", fromConfig.getCredentials().getAWSSecretKey());
+        assertEquals("openhab-", fromConfig.getTablePrefix());
+        assertEquals(true, fromConfig.isCreateTable());
+        assertEquals(3, fromConfig.getReadCapacityUnits());
+        assertEquals(5, fromConfig.getWriteCapacityUnits());
+        assertEquals(501L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(112, fromConfig.getBufferSize());
+        assertEquals(true, fromConfig.isAutoExpirationEnabled());
+        assertEquals(90, fromConfig.getAutoExpirationDays());
+    }
+
+    @Test
+    public void testRegionWithAccessKeysWithPrefixWithReadWriteCapacityUnitsWithBufferSettingsWithExpirationEnabledWithCustomExpiration() throws Exception {
+        DynamoDBConfig fromConfig = DynamoDBConfig.fromConfig(
+                ImmutableMap.<String, Object> builder().put("region", "eu-west-1").put("accessKey", "access1")
+                        .put("secretKey", "secret1").put("readCapacityUnits", "3").put("writeCapacityUnits", "5")
+                        .put("bufferCommitIntervalMillis", "501").put("bufferSize", "112").put("autoExpirationEnabled","true").put("autoExpirationDays","30").build());
+        assertEquals(Regions.EU_WEST_1, fromConfig.getRegion());
+        assertEquals("access1", fromConfig.getCredentials().getAWSAccessKeyId());
+        assertEquals("secret1", fromConfig.getCredentials().getAWSSecretKey());
+        assertEquals("openhab-", fromConfig.getTablePrefix());
+        assertEquals(true, fromConfig.isCreateTable());
+        assertEquals(3, fromConfig.getReadCapacityUnits());
+        assertEquals(5, fromConfig.getWriteCapacityUnits());
+        assertEquals(501L, fromConfig.getBufferCommitIntervalMillis());
+        assertEquals(112, fromConfig.getBufferSize());
+        assertEquals(true, fromConfig.isAutoExpirationEnabled());
+        assertEquals(30, fromConfig.getAutoExpirationDays());
     }
 }

--- a/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/ExpiringStringItemIntegrationTest.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb.test/src/test/java/org/openhab/persistence/dynamodb/internal/ExpiringStringItemIntegrationTest.java
@@ -1,0 +1,60 @@
+package org.openhab.persistence.dynamodb.internal;
+
+import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec;
+import com.amazonaws.services.dynamodbv2.model.DescribeTimeToLiveRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeTimeToLiveResult;
+import com.amazonaws.services.dynamodbv2.model.TimeToLiveStatus;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ExpiringStringItemIntegrationTest extends StringItemIntegrationTest {
+
+    @BeforeClass
+    public static void initServiceWithExpirationEnabled() throws InterruptedException {
+        // this is a bit slow
+        // junit runs inherited (parent) class @BeforeClass methods first.
+        // this basically, for this class, results in us doing everything again.
+        // seems fine since it's an integration test, but could probably be refactored eventually
+        // some ideas: use a @Before - but store table creation in a static var.
+        // the impact is we must call each paren't method's @BeforeClass manually here.
+        // this is all in an effort to feed a different serviceConfig to the initService
+        Map<String,Object> expiringConfig = getExpiringServiceConfiguration();
+        initServiceWithConfig(expiringConfig);
+        checkService();
+        storeData();
+    }
+
+    public static Map<String, Object> getExpiringServiceConfiguration(){
+        Map<String, Object> baseConfiguration = BaseIntegrationTest.getDefaultServiceConfiguration();
+        baseConfiguration.put("autoExpirationEnabled", "true");
+        baseConfiguration.put("autoExpirationDays", "1");
+        return baseConfiguration;
+    }
+
+
+    @Test
+    public void testTableHasExpirationEnabled(){
+        for (String table: tableNames()){
+            if (table.contains("string")) {
+                DescribeTimeToLiveResult describeTimeToLiveResult = service.getDb().getDynamoClient().describeTimeToLive(new DescribeTimeToLiveRequest().withTableName(table));
+                assertNotNull(describeTimeToLiveResult.getTimeToLiveDescription());
+                assertEquals(TimeToLiveStatus.ENABLED.toString(), describeTimeToLiveResult.getTimeToLiveDescription().getTimeToLiveStatus());
+                System.out.println("checking " + table);
+                service.getDb().getDynamoDB().getTable(table).scan(new ScanSpec().withConsistentRead(true)).pages().forEach(page -> {
+                    assertNotNull(page);
+                    page.forEach(item -> {
+                        assertNotNull(item);
+                        System.out.println(item.toJSON());
+                        assertTrue("Expected the item fetched from the table to have an expiration time", item.isPresent(DynamoDBItem.ATTRIBUTE_NAME_EXPIRATION));
+                    });
+                });
+            }
+        }
+    }
+}

--- a/bundles/persistence/org.openhab.persistence.dynamodb/README.md
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/README.md
@@ -98,7 +98,8 @@ In addition to the configuration properties above, the following are also availa
 | tablePrefix                | `openhab-` |    No    | table prefix used in the name of created tables                                                    |
 | bufferCommitIntervalMillis | 1000       |    No    | Interval to commit (write) buffered data. In milliseconds.                                         |
 | bufferSize                 | 1000       |    No    | Internal buffer size which is used to batch writes to DynamoDB every `bufferCommitIntervalMillis`. |
-
+| autoExpirationEnabled      | false      |    No    | If historical events should be removed using DyanmoDB's TTL feature. This avoids infinite growth.  |
+| autoExpirationDays         | 90         |    No    | If autoExpirationEnabled is true - how long should historical events be kept for, in days.         |
 Typically you should not need to modify parameters related to buffering. 
 
 Refer to Amazon documentation on [provisioned throughput](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html) for details on read/write capacity.
@@ -112,6 +113,8 @@ All item- and event-related configuration is done in the file `persistence/dynam
 When an item is persisted via this service, a table is created (if necessary). Currently, the service will create at most two tables for different item types. The tables will be named `<tablePrefix><item-type>`, where the `<item-type>` is either `bigdecimal` (numeric items) or `string` (string and complex items).
 
 Each table will have three columns: `itemname` (item name), `timeutc` (in ISO 8601 format with millisecond accuracy), and `itemstate` (either a number or string representing item state).
+
+If `autoExpiration` is enabled, the tables will have the TTL Deletion feature turned on and an addtitional column called `expiration`. (numeric type) 
 
 ## Buffering
 

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItem.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItem.java
@@ -16,7 +16,6 @@ import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -217,12 +216,12 @@ public abstract class AbstractDynamoDBItem<T> implements DynamoDBItem<T> {
 
     @Override
     @DynamoDBAttribute(attributeName = ATTRIBUTE_NAME_EXPIRATION)
-    public Long getExpiration() {
+    public Long getExpirationDateEpochSeconds() {
         return this.expirationDateEpochSeconds;
     }
 
     @Override
-    public void setExpiration(long expirationDate) {
-        this.expirationDateEpochSeconds = expirationDate;
+    public void setExpirationDateEpochSeconds(long expirationDateEpochSeconds) {
+        this.expirationDateEpochSeconds = expirationDateEpochSeconds;
     }
 }

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItem.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItem.java
@@ -213,15 +213,4 @@ public abstract class AbstractDynamoDBItem<T> implements DynamoDBItem<T> {
     public String toString() {
         return DateFormat.getDateTimeInstance().format(time) + ": " + name + " -> " + state.toString();
     }
-
-    @Override
-    @DynamoDBAttribute(attributeName = ATTRIBUTE_NAME_EXPIRATION)
-    public Long getExpirationDateEpochSeconds() {
-        return this.expirationDateEpochSeconds;
-    }
-
-    @Override
-    public void setExpirationDateEpochSeconds(long expirationDateEpochSeconds) {
-        this.expirationDateEpochSeconds = expirationDateEpochSeconds;
-    }
 }

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItem.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItem.java
@@ -16,12 +16,14 @@ import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.ColorItem;
 import org.openhab.core.library.items.ContactItem;
@@ -95,6 +97,7 @@ public abstract class AbstractDynamoDBItem<T> implements DynamoDBItem<T> {
     protected String name;
     protected T state;
     protected Date time;
+    protected Long expirationDateEpochSeconds;
 
     public AbstractDynamoDBItem(String name, T state, Date time) {
         this.name = name;
@@ -212,4 +215,14 @@ public abstract class AbstractDynamoDBItem<T> implements DynamoDBItem<T> {
         return DateFormat.getDateTimeInstance().format(time) + ": " + name + " -> " + state.toString();
     }
 
+    @Override
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_NAME_EXPIRATION)
+    public Long getExpiration() {
+        return this.expirationDateEpochSeconds;
+    }
+
+    @Override
+    public void setExpiration(long expirationDate) {
+        this.expirationDateEpochSeconds = expirationDate;
+    }
 }

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBBigDecimalItem.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBBigDecimalItem.java
@@ -67,6 +67,12 @@ public class DynamoDBBigDecimalItem extends AbstractDynamoDBItem<BigDecimal> {
     }
 
     @Override
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_NAME_EXPIRATION)
+    public Long getExpirationDateEpochSeconds() {
+        return this.expirationDateEpochSeconds;
+    }
+
+    @Override
     public void setName(String name) {
         this.name = name;
     }
@@ -80,6 +86,9 @@ public class DynamoDBBigDecimalItem extends AbstractDynamoDBItem<BigDecimal> {
     public void setTime(Date time) {
         this.time = time;
     }
+
+    @Override
+    public void setExpirationDateEpochSeconds(long expirationDateEpochSeconds) { this.expirationDateEpochSeconds = expirationDateEpochSeconds; }
 
     @Override
     public void accept(org.openhab.persistence.dynamodb.internal.DynamoDBItemVisitor visitor) {

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBItem.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBItem.java
@@ -34,6 +34,8 @@ public interface DynamoDBItem<T> {
 
     static final String ATTRIBUTE_NAME_ITEMSTATE = "itemstate";
 
+    static final String ATTRIBUTE_NAME_EXPIRATION = "expiration";
+
     /**
      * Convert this AbstractDynamoItem as HistoricItem.
      *
@@ -47,6 +49,10 @@ public interface DynamoDBItem<T> {
     T getState();
 
     Date getTime();
+
+    Long getExpiration();
+
+    void setExpiration(long expirationTime);
 
     void setName(String name);
 

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBItem.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBItem.java
@@ -50,9 +50,9 @@ public interface DynamoDBItem<T> {
 
     Date getTime();
 
-    Long getExpiration();
+    Long getExpirationDateEpochSeconds();
 
-    void setExpiration(long expirationTime);
+    void setExpirationDateEpochSeconds(long expirationDateEpochSeconds);
 
     void setName(String name);
 

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBPersistenceService.java
@@ -374,7 +374,7 @@ public class DynamoDBPersistenceService extends AbstractBufferedPersistenceServi
                 if (dbConfig.isAutoExpirationEnabled()){
                     for (DynamoDBItem<?> batchItem: batch){
                         Instant expiration = batchItem.getTime().toInstant().plus(dbConfig.getAutoExpirationDays(), ChronoUnit.DAYS);
-                        batchItem.setExpiration(expiration.getEpochSecond());
+                        batchItem.setExpirationDateEpochSeconds(expiration.getEpochSecond());
                     }
                 }
                 if (!batch.isEmpty()) {

--- a/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBStringItem.java
+++ b/bundles/persistence/org.openhab.persistence.dynamodb/java/org/openhab/persistence/dynamodb/internal/DynamoDBStringItem.java
@@ -54,6 +54,12 @@ public class DynamoDBStringItem extends AbstractDynamoDBItem<String> {
     }
 
     @Override
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_NAME_EXPIRATION)
+    public Long getExpirationDateEpochSeconds() {
+        return this.expirationDateEpochSeconds;
+    }
+
+    @Override
     public void accept(org.openhab.persistence.dynamodb.internal.DynamoDBItemVisitor visitor) {
         visitor.visit(this);
     }
@@ -72,4 +78,7 @@ public class DynamoDBStringItem extends AbstractDynamoDBItem<String> {
     public void setTime(Date time) {
         this.time = time;
     }
+
+    @Override
+    public void setExpirationDateEpochSeconds(long expirationDateEpochSeconds) { this.expirationDateEpochSeconds = expirationDateEpochSeconds; }
 }

--- a/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
@@ -47,10 +47,10 @@
 # write capacity for the created tables
 #writeCapacityUnits=1
 
-# if auto expiration from ddb is enabled (ttl) [ defaults to false ]
+# if auto expiration from DynamoDB is enabled.
 #autoExpirationEnabled=false
 
-# if auto expiration is enabled, nubmer of days to keep data for before expiring
+# if auto expiration is enabled, number of days to keep data for before expiring
 #autoExpirationDays=90
 
 

--- a/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/dynamodb.cfg
@@ -47,5 +47,12 @@
 # write capacity for the created tables
 #writeCapacityUnits=1
 
+# if auto expiration from ddb is enabled (ttl) [ defaults to false ]
+#autoExpirationEnabled=false
+
+# if auto expiration is enabled, nubmer of days to keep data for before expiring
+#autoExpirationDays=90
+
+
 # table prefix used in the name of created tables
 #tablePrefix=openhab-


### PR DESCRIPTION
Howdy!
This is a work in progress for enabling expiration of historic data in the DDB Persistence side of OpenHab.  DDB has a built in [feature that expires items](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html) when a ttl is present. My thought process was to

1. Ensure we create tables with a TTL (if enabled)
1. For data that is inserted into DDB - add an `expiration` (epoch seconds) field to it with a 90 day (but configurable) expiration date from the time of data collection.

It's not ready to merge just yet - but I wanted to get feedback from folks in the know (first pull request 😬)

Let me know the obvious things I missed / things you want to see.

Thanks!