### PR TITLE
Novelan heatpump: Add output signals and additional state variables as items, add missing heatpump states

### DIFF
--- a/bundles/binding/org.openhab.binding.novelanheatpump/README.md
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/README.md
@@ -47,7 +47,10 @@ where `<eventType>` is one of the following values:
 | `temperature_servicewater` | Number | the temperature of the servicewater |
 | `state` | String | contains the time of the state and the state; Possible states are error, running, stopped, defrosting |
 | `simple_state` | String | contains only the short statename; Possible states are error, running, stopped, defrosting |
+| `simple_state_num` | Number | same information as `simple_state`, but as a numeric value |
 | `extended_state` | String | contains the time of the state and the state; Possible states are error, heating, standby, switch-on delay, switching cycle | blocked, provider lock time, service water, screed heat up, defrosting, pump flow, desinfection, cooling, pool water, heating ext., service water ext., | flow monitoring, ZWE operation |
+| `switchoff_reason_0` | Number | contains the last shutdown reason |
+| `switchoff_code_0` | Number | contains the last heatpump error code |
 | `temperature_solar_collector` | Number | the temperature of the sensor in the solar collector |
 | `temperature_hot_gas` | Number | 
 | `temperature_probe_in` | Number | temperature flowing to probe head |
@@ -84,7 +87,34 @@ where `<eventType>` is one of the following values:
 | `cooling_inlet_temperature` | Number | cooling inlet temeprature |
 | `cooling_start_hours` | Number | cooling start after hours |
 | `cooling_stop_hours` | Number | cooling stop after hours |
-
+| `output_av` | Switch | Output: defrosting (= Abtauventil) |
+| `output_bup` | Switch | Output: water pump (= Brauchwasserpumpe) |
+| `output_hup` | Switch | Output: heat pump (= Heizungsumwälzpumpe) |
+| `output_mz1` | Switch | |
+| `output_ven` | Switch | Output: ventilation |
+| `output_vbo` | Switch | |
+| `output_vd1` | Switch | Output: compressor 1 |
+| `output_vd2` | Switch | Output: compressor 2 |
+| `output_zip` | Switch | Output: water circulation pump |
+| `output_zup` | Switch | Output: additional water pump |
+| `output_zw1` | Switch | Output: additional heater 1 |
+| `output_zw2sst` | Switch | Output: additional heater 2 |
+| `output_zw3sst` | Switch | Output: additional heater 3 |
+| `output_fp2` | Switch | |
+| `output_slp` | Switch | |
+| `output_sup` | Switch | |
+| `output_ma2` | Switch | |
+| `output_mz2` | Switch | |
+| `output_ma3` | Switch | |
+| `output_mz3` | Switch | |
+| `output_fp3` | Switch | |
+| `output_vsk` | Switch | |
+| `output_frh` | Switch | |
+| `output_vdh` | Switch | Output: compressor heating |
+| `output_av2` | Switch | Output: defrosting 2 (= Abtauventil 2) |
+| `output_vbo2` | Switch | |
+| `output_vd12` | Switch | Output: compressor 1/2 |
+| `output_vdh2` | Switch | Output: compressor heating 2 |
 
 ## Examples
 
@@ -138,6 +168,9 @@ Number HeatPump_Cooling_Release "Freigabe [%.1f °C]" (gHeatpump) { novelanheatp
 Number HeatPump_Cooling_Inlet "Vorlauf Soll [%.1f °C]" (gHeatpump) { novelanheatpump="cooling_inlet_temperature" }
 Number HeatPump_Cooling_Start "AT Überschreitung[%.1f hrs]" (gHeatpump) { novelanheatpump="cooling_start_hours" }
 Number HeatPump_Cooling_Stop "AT Unterschreitung[%.1f hrs]" (gHeatpump) { novelanheatpump="cooling_stop_hours" }
+
+Switch HeatPump_HUP  "Heizungsumwälzpumpe [%s]"   <switch>   (gHeatpump)   { novelanheatpump="output_hup" }
+
 ```
 
 ### Sitemap (fragment)

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
@@ -15,7 +15,7 @@ package org.openhab.binding.novelanheatpump;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.StringItem;
-import org.openhab.core.library.items.ContactItem;
+import org.openhab.core.library.items.SwitchItem;
 
 /**
  * Represents all valid commands which could be processed by this binding
@@ -383,203 +383,203 @@ public enum HeatpumpCommandType {
     TYPE_OUTPUT_AV {
         {
             command = "output_av";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german BUP (Brauchwasserpumpe/Umstellventil)
     TYPE_OUTPUT_BUP {
         {
             command = "output_bup";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german HUP (Heizungsumwälzpumpe)
     TYPE_OUTPUT_HUP {
         {
             command = "output_hup";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german MA1 (Mischkreis 1 auf)
     TYPE_OUTPUT_MA1 {
         {
             command = "output_ma1";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german MZ1 (Mischkreis 1 zu)
     TYPE_OUTPUT_MZ1 {
         {
             command = "output_mz1";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german VEN (Ventilation/Lüftung)
     TYPE_OUTPUT_VEN {
         {
             command = "output_ven";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german VBO (Solepumpe/Ventilator)
     TYPE_OUTPUT_VBO {
         {
             command = "output_vbo";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german VD1 (Verdichter 1)
     TYPE_OUTPUT_VD1 {
         {
             command = "output_vd1";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german VD2 (Verdichter 2)
     TYPE_OUTPUT_VD2 {
         {
             command = "output_vd2";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german ZIP (Zirkulationspumpe)
     TYPE_OUTPUT_ZIP {
         {
             command = "output_zip";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german ZUP (Zusatzumwälzpumpe)
     TYPE_OUTPUT_ZUP {
         {
             command = "output_zup";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german ZW1 (Steuersignal Zusatzheizung v. Heizung)
     TYPE_OUTPUT_ZW1 {
         {
             command = "output_zw1";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german ZW2 (Steuersignal Zusatzheizung/Störsignal)
     TYPE_OUTPUT_ZW2SST {
         {
             command = "output_zw2sst";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german ZW3 (Zusatzheizung 3)
     TYPE_OUTPUT_ZW3SST {
         {
             command = "output_zw3sst";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german FP2 (Pumpe Mischkreis 2)
     TYPE_OUTPUT_FP2 {
         {
             command = "output_fp2";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german SLP (Solarladepumpe)
     TYPE_OUTPUT_SLP {
         {
             command = "output_slp";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german SUP (Schwimmbadpumpe)
     TYPE_OUTPUT_SUP {
         {
             command = "output_sup";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german MA2 (Mischkreis 2 auf)
     TYPE_OUTPUT_MA2 {
         {
             command = "output_ma2";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german MZ2 (Mischkreis 2 zu)
     TYPE_OUTPUT_MZ2 {
         {
             command = "output_mz2";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german MA3 (Mischkreis 3 auf)
     TYPE_OUTPUT_MA3 {
         {
             command = "output_ma3";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german MZ3 (Mischkreis 3 zu)
     TYPE_OUTPUT_MZ3 {
         {
             command = "output_mz3";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german FP3 (Pumpe Mischkreis 3)
     TYPE_OUTPUT_FP3 {
         {
             command = "output_fp3";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german VSK
     TYPE_OUTPUT_VSK {
         {
             command = "output_vsk";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german FRH
     TYPE_OUTPUT_FRH {
         {
             command = "output_frh";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german VDH (Verdichterheizung)
     TYPE_OUTPUT_VDH {
         {
             command = "output_vdh";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german AV2 (Abtauventil 2)
     TYPE_OUTPUT_AV2 {
         {
             command = "output_av2";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german VBO2 (Solepumpe/Ventilator)
     TYPE_OUTPUT_VBO2 {
         {
             command = "output_vbo2";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german VD12 (Verdichter 1/2)
     TYPE_OUTPUT_VD12 {
         {
             command = "output_vd12";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     },
     // in german VDH2 (Verdichterheizung 2)
     TYPE_OUTPUT_VDH2 {
         {
             command = "output_vdh2";
-            itemClass = ContactItem.class;
+            itemClass = SwitchItem.class;
         }
     };
 

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
@@ -95,6 +95,20 @@ public enum HeatpumpCommandType {
         }
     },
 
+    TYPE_HEATPUMP_SIMPLE_STATE_NUM {
+        {
+            command = "simple_state_num";
+            itemClass = NumberItem.class;
+        }
+    },
+
+    TYPE_HEATPUMP_SWITCHOFF_REASON_0 {
+        {
+            command = "switchoff_reason_0";
+            itemClass = NumberItem.class;
+        }
+    },
+
     TYPE_HEATPUMP_EXTENDED_STATE {
         {
             command = "extended_state";

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
@@ -15,6 +15,7 @@ package org.openhab.binding.novelanheatpump;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.items.ContactItem;
 
 /**
  * Represents all valid commands which could be processed by this binding
@@ -371,11 +372,207 @@ public enum HeatpumpCommandType {
             itemClass = NumberItem.class;
         }
     },
-    // in german AT-Unterschreitung
-    TYPE_COOLING_STOP_AFTER_HOURS {
+    // in german AV (Abtauventil)
+    TYPE_OUTPUT_AV {
         {
-            command = "cooling_stop_hours";
-            itemClass = NumberItem.class;
+            command = "output_av";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german BUP (Brauchwasserpumpe/Umstellventil)
+    TYPE_OUTPUT_BUP {
+        {
+            command = "output_bup";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german HUP (Heizungsumwälzpumpe)
+    TYPE_OUTPUT_HUP {
+        {
+            command = "output_hup";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german MA1 (Mischkreis 1 auf)
+    TYPE_OUTPUT_MA1 {
+        {
+            command = "output_ma1";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german MZ1 (Mischkreis 1 zu)
+    TYPE_OUTPUT_MZ1 {
+        {
+            command = "output_mz1";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german VEN (Ventilation/Lüftung)
+    TYPE_OUTPUT_VEN {
+        {
+            command = "output_ven";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german VBO (Solepumpe/Ventilator)
+    TYPE_OUTPUT_VBO {
+        {
+            command = "output_vbo";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german VD1 (Verdichter 1)
+    TYPE_OUTPUT_VD1 {
+        {
+            command = "output_vd1";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german VD2 (Verdichter 2)
+    TYPE_OUTPUT_VD2 {
+        {
+            command = "output_vd2";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german ZIP (Zirkulationspumpe)
+    TYPE_OUTPUT_ZIP {
+        {
+            command = "output_zip";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german ZUP (Zusatzumwälzpumpe)
+    TYPE_OUTPUT_ZUP {
+        {
+            command = "output_zup";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german ZW1 (Steuersignal Zusatzheizung v. Heizung)
+    TYPE_OUTPUT_ZW1 {
+        {
+            command = "output_zw1";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german ZW2 (Steuersignal Zusatzheizung/Störsignal)
+    TYPE_OUTPUT_ZW2SST {
+        {
+            command = "output_zw2sst";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german ZW3 (Zusatzheizung 3)
+    TYPE_OUTPUT_ZW3SST {
+        {
+            command = "output_zw3sst";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german FP2 (Pumpe Mischkreis 2)
+    TYPE_OUTPUT_FP2 {
+        {
+            command = "output_fp2";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german SLP (Solarladepumpe)
+    TYPE_OUTPUT_SLP {
+        {
+            command = "output_slp";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german SUP (Schwimmbadpumpe)
+    TYPE_OUTPUT_SUP {
+        {
+            command = "output_sup";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german MA2 (Mischkreis 2 auf)
+    TYPE_OUTPUT_MA2 {
+        {
+            command = "output_ma2";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german MZ2 (Mischkreis 2 zu)
+    TYPE_OUTPUT_MZ2 {
+        {
+            command = "output_mz2";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german MA3 (Mischkreis 3 auf)
+    TYPE_OUTPUT_MA3 {
+        {
+            command = "output_ma3";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german MZ3 (Mischkreis 3 zu)
+    TYPE_OUTPUT_MZ3 {
+        {
+            command = "output_mz3";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german FP3 (Pumpe Mischkreis 3)
+    TYPE_OUTPUT_FP3 {
+        {
+            command = "output_fp3";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german VSK
+    TYPE_OUTPUT_VSK {
+        {
+            command = "output_vsk";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german FRH
+    TYPE_OUTPUT_FRH {
+        {
+            command = "output_frh";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german VDH (Verdichterheizung)
+    TYPE_OUTPUT_VDH {
+        {
+            command = "output_vdh";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german AV2 (Abtauventil 2)
+    TYPE_OUTPUT_AV2 {
+        {
+            command = "output_av2";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german VBO2 (Solepumpe/Ventilator)
+    TYPE_OUTPUT_VBO2 {
+        {
+            command = "output_vbo2";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german VD12 (Verdichter 1/2)
+    TYPE_OUTPUT_VD12 {
+        {
+            command = "output_vd12";
+            itemClass = ContactItem.class;
+        }
+    },
+    // in german VDH2 (Verdichterheizung 2)
+    TYPE_OUTPUT_VDH2 {
+        {
+            command = "output_vdh2";
+            itemClass = ContactItem.class;
         }
     };
 

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
@@ -372,6 +372,13 @@ public enum HeatpumpCommandType {
             itemClass = NumberItem.class;
         }
     },
+    // in german AT-Unterschreitung
+    TYPE_COOLING_STOP_AFTER_HOURS {
+        {
+            command = "cooling_stop_hours";
+            itemClass = NumberItem.class;
+        }
+    },
     // in german AV (Abtauventil)
     TYPE_OUTPUT_AV {
         {

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
@@ -109,6 +109,13 @@ public enum HeatpumpCommandType {
         }
     },
 
+    TYPE_HEATPUMP_SWITCHOFF_CODE_0 {
+        {
+            command = "switchoff_code_0";
+            itemClass = NumberItem.class;
+        }
+    },
+
     TYPE_HEATPUMP_EXTENDED_STATE {
         {
             command = "extended_state";

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/Messages.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/Messages.java
@@ -41,7 +41,8 @@ public class Messages extends NLS {
     public static String HeatPumpBinding_FLOW_MONITORING;
     public static String HeatPumpBinding_ZWE_OPERATION;
     public static String HeatPumpBinding_SERVICE_WATER_ADDITIONAL_HEATING;
-
+    public static String HeatPumpBinding_COMPRESSOR_HEATING;
+    
     static {
         // initialize resource bundle
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/messages.properties
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/messages.properties
@@ -20,3 +20,4 @@ HeatPumpBinding_SERVICE_WATER_EXT=service water ext.
 HeatPumpBinding_FLOW_MONITORING=flow monitoring
 HeatPumpBinding_ZWE_OPERATION=ZWE operation
 HeatPumpBinding_SERVICE_WATER_ADDITIONAL_HEATING=service water add. heating
+HeatPumpBinding_COMPRESSOR_HEATING=compressor heating up

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/messages_de.properties
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/messages_de.properties
@@ -20,3 +20,4 @@ HeatPumpBinding_SERVICE_WATER_EXT=Brauchwasser Ext.
 HeatPumpBinding_FLOW_MONITORING=Durchflussueberwachung
 HeatPumpBinding_ZWE_OPERATION=ZWE Betrieb
 HeatPumpBinding_SERVICE_WATER_ADDITIONAL_HEATING=Warmw. Nachheizung
+HeatPumpBinding_COMPRESSOR_HEATING=Verdichter heizt auf

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -30,6 +30,7 @@ import org.openhab.binding.novelanheatpump.internal.HeatPumpGenericBindingProvid
 import org.openhab.core.binding.AbstractActiveBinding;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.Command;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
@@ -237,6 +238,64 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
                     HeatpumpCommandType.TYPE_COOLING_START_AFTER_HOURS);
             handleEventType(new DecimalType(heatpumpParams[PARAM_COOLING_STOP] / 10.),
                     HeatpumpCommandType.TYPE_COOLING_STOP_AFTER_HOURS);
+
+            // read all boolean output signals
+            handleEventType((heatpumpValues[37] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_AV);
+            handleEventType((heatpumpValues[38] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_BUP);
+            handleEventType((heatpumpValues[39] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_HUP);
+            handleEventType((heatpumpValues[40] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_MA1);
+            handleEventType((heatpumpValues[41] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_MZ1);
+            handleEventType((heatpumpValues[42] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_VEN);
+            handleEventType((heatpumpValues[43] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_VBO);
+            handleEventType((heatpumpValues[44] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_VD1);
+            handleEventType((heatpumpValues[45] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_VD2);
+            handleEventType((heatpumpValues[46] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_ZIP);
+            handleEventType((heatpumpValues[47] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_ZUP);
+            handleEventType((heatpumpValues[48] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_ZW1);
+            handleEventType((heatpumpValues[49] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_ZW2SST);
+            handleEventType((heatpumpValues[50] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_ZW3SST);
+            handleEventType((heatpumpValues[51] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_FP2);
+            handleEventType((heatpumpValues[52] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_SLP);
+            handleEventType((heatpumpValues[53] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_SUP);
+            handleEventType((heatpumpValues[54] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_MZ2);
+            handleEventType((heatpumpValues[55] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_MA2);
+            handleEventType((heatpumpValues[138] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_MZ3);
+            handleEventType((heatpumpValues[139] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_MA3);
+            handleEventType((heatpumpValues[140] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_FP3);
+            handleEventType((heatpumpValues[166] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_VSK);
+            handleEventType((heatpumpValues[167] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_FRH);
+            handleEventType((heatpumpValues[213] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_AV2);
+            handleEventType((heatpumpValues[214] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_VBO2);
+            handleEventType((heatpumpValues[215] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_VD12);
+            handleEventType((heatpumpValues[216] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                    HeatpumpCommandType.TYPE_OUTPUT_VDH2);
 
         } catch (UnknownHostException e) {
             logger.warn("the given hostname '{}' of the Novelan heatpump is unknown", ip);

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -213,6 +213,10 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
             handleEventType(new StringType(heatpumpState), HeatpumpCommandType.TYPE_HEATPUMP_STATE);
             String heatpumpSimpleState = getStateString(heatpumpValues);
             handleEventType(new StringType(heatpumpSimpleState), HeatpumpCommandType.TYPE_HEATPUMP_SIMPLE_STATE);
+            handleEventType(new DecimalType(heatpumpValues[117]), HeatpumpCommandType.TYPE_HEATPUMP_SIMPLE_STATE_NUM);
+
+            handleEventType(new DecimalType(heatpumpValues[106]), HeatpumpCommandType.TYPE_HEATPUMP_SWITCHOFF_REASON_0);
+
             String heatpumpExtendedState = getExtendeStateString(heatpumpValues) + ": " //$NON-NLS-1$
                     + formatHours(heatpumpValues[120]);
             handleEventType(new StringType(heatpumpExtendedState), HeatpumpCommandType.TYPE_HEATPUMP_EXTENDED_STATE);

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -150,6 +150,15 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
             // all temperatures are 0.2 degree Celsius exact
             // but use int to save values
             // example 124 is 12.4 degree Celsius
+
+            // workaround for thermal energies
+            // the thermal energies can be unreasonably high in some cases, probably due to a sign bug in the firmware
+            // trying to correct this issue here
+            if (heatpumpValues[151] >= 214748364) heatpumpValues[151] -= 214748364;
+            if (heatpumpValues[152] >= 214748364) heatpumpValues[152] -= 214748364;
+            if (heatpumpValues[153] >= 214748364) heatpumpValues[153] -= 214748364;
+            if (heatpumpValues[154] >= 214748364) heatpumpValues[154] -= 214748364;
+
             handleEventType(new DecimalType((double) heatpumpValues[10] / 10),
                     HeatpumpCommandType.TYPE_TEMPERATURE_SUPPLAY);
             handleEventType(new DecimalType((double) heatpumpValues[11] / 10),

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -217,6 +217,8 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
 
             handleEventType(new DecimalType(heatpumpValues[106]), HeatpumpCommandType.TYPE_HEATPUMP_SWITCHOFF_REASON_0);
 
+            handleEventType(new DecimalType(heatpumpValues[100]), HeatpumpCommandType.TYPE_HEATPUMP_SWITCHOFF_CODE_0);
+
             String heatpumpExtendedState = getExtendeStateString(heatpumpValues) + ": " //$NON-NLS-1$
                     + formatHours(heatpumpValues[120]);
             handleEventType(new StringType(heatpumpExtendedState), HeatpumpCommandType.TYPE_HEATPUMP_EXTENDED_STATE);

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -416,6 +416,9 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
             case 17:
                 returnValue = Messages.HeatPumpBinding_ZWE_OPERATION;
                 break;
+            case 18:
+                returnValue = Messages.HeatPumpBinding_COMPRESSOR_HEATING;
+                break;
             case 19:
                 returnValue = Messages.HeatPumpBinding_SERVICE_WATER_ADDITIONAL_HEATING;
                 break;

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -288,14 +288,18 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
                     HeatpumpCommandType.TYPE_OUTPUT_VSK);
             handleEventType((heatpumpValues[167] == 0) ? OnOffType.OFF : OnOffType.ON, 
                     HeatpumpCommandType.TYPE_OUTPUT_FRH);
-            handleEventType((heatpumpValues[213] == 0) ? OnOffType.OFF : OnOffType.ON, 
-                    HeatpumpCommandType.TYPE_OUTPUT_AV2);
-            handleEventType((heatpumpValues[214] == 0) ? OnOffType.OFF : OnOffType.ON, 
-                    HeatpumpCommandType.TYPE_OUTPUT_VBO2);
-            handleEventType((heatpumpValues[215] == 0) ? OnOffType.OFF : OnOffType.ON, 
-                    HeatpumpCommandType.TYPE_OUTPUT_VD12);
-            handleEventType((heatpumpValues[216] == 0) ? OnOffType.OFF : OnOffType.ON, 
-                    HeatpumpCommandType.TYPE_OUTPUT_VDH2);
+
+            if (heatpumpValues.length > 213)
+            {
+                handleEventType((heatpumpValues[213] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                        HeatpumpCommandType.TYPE_OUTPUT_AV2);
+                handleEventType((heatpumpValues[214] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                        HeatpumpCommandType.TYPE_OUTPUT_VBO2);
+                handleEventType((heatpumpValues[215] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                        HeatpumpCommandType.TYPE_OUTPUT_VD12);
+                handleEventType((heatpumpValues[216] == 0) ? OnOffType.OFF : OnOffType.ON, 
+                        HeatpumpCommandType.TYPE_OUTPUT_VDH2);
+            }
 
         } catch (UnknownHostException e) {
             logger.warn("the given hostname '{}' of the Novelan heatpump is unknown", ip);

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -452,8 +452,17 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
             case 2:
                 returnValue = Messages.HeatPumpBinding_APPEAR;
                 break;
+            case 4:
+                returnValue = Messages.HeatPumpBinding_ERROR;
+                break;
             case 5:
                 returnValue = Messages.HeatPumpBinding_DEFROSTING;
+                break;
+            case 7:
+                returnValue = Messages.HeatPumpBinding_COMPRESSOR_HEATING;
+                break;
+            case 8:
+                returnValue = Messages.HeatPumpBinding_PUMP_FLOW;
                 break;
             default:
                 logger.info(

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpGenericBindingProvider.java
@@ -22,7 +22,7 @@ import org.openhab.core.binding.BindingConfig;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.StringItem;
-import org.openhab.core.library.items.ContactItem;
+import org.openhab.core.library.items.SwitchItem;
 import org.openhab.model.item.binding.AbstractGenericBindingProvider;
 import org.openhab.model.item.binding.BindingConfigParseException;
 import org.slf4j.Logger;
@@ -74,10 +74,10 @@ public class HeatPumpGenericBindingProvider extends AbstractGenericBindingProvid
      */
     @Override
     public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
-        if (!(item instanceof NumberItem || item instanceof StringItem || item instanceof ContactItem)) {
+        if (!(item instanceof NumberItem || item instanceof StringItem || item instanceof SwitchItem)) {
             throw new BindingConfigParseException(
                     "item '" + item.getName() + "' is of type '" + item.getClass().getSimpleName()
-                            + "', only Number-, String- and ContactItems are allowed - please check your *.items configuration");
+                            + "', only Number-, String- and SwitchItems are allowed - please check your *.items configuration");
         }
     }
 

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpGenericBindingProvider.java
@@ -22,6 +22,7 @@ import org.openhab.core.binding.BindingConfig;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.items.ContactItem;
 import org.openhab.model.item.binding.AbstractGenericBindingProvider;
 import org.openhab.model.item.binding.BindingConfigParseException;
 import org.slf4j.Logger;
@@ -73,10 +74,10 @@ public class HeatPumpGenericBindingProvider extends AbstractGenericBindingProvid
      */
     @Override
     public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
-        if (!(item instanceof NumberItem || item instanceof StringItem)) {
+        if (!(item instanceof NumberItem || item instanceof StringItem || item instanceof ContactItem)) {
             throw new BindingConfigParseException(
                     "item '" + item.getName() + "' is of type '" + item.getClass().getSimpleName()
-                            + "', only Number- and StringItems are allowed - please check your *.items configuration");
+                            + "', only Number-, String- and ContactItems are allowed - please check your *.items configuration");
         }
     }
 


### PR DESCRIPTION
All currently known output signals were added as Switch items (prefix `output_`), together with `simple_state_num`, `switchoff_reason_0` and `switchoff_code_0` to allow better rule-based error management.

Both extended and regular state strings now can translate more heatpump states.

I also added a workaround for the calculation of the thermal energies because (probably due to a sign bug in the firmware) the energies might be unreasonably large.