### PR TITLE
[KNX.Test] workaround for timezone in KNXCoreTypeMapperTest

### DIFF
--- a/bundles/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/bundles/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -16,7 +16,9 @@ import static org.junit.Assert.*;
 
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.TimeZone;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -68,8 +70,17 @@ public class KNXCoreTypeMapperTest {
 
     private final KNXCoreTypeMapper knxCoreTypeMapper = new KNXCoreTypeMapper();
 
+    private TimeZone timeZoneBackup;
+
     @Before
     public void init() throws KNXFormatException {
+        timeZoneBackup = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+
+    @After
+    public void cleanup() {
+        TimeZone.setDefault(timeZoneBackup);
     }
 
     /**


### PR DESCRIPTION
This is workaround for failed test in timezone different then utc.
