### PR TITLE
Adding a debug level with exception stracktrace

### DIFF
--- a/bundles/binding/org.openhab.binding.bticino/src/main/java/com/myhome/fcrisciani/connector/MyHomeJavaConnector.java
+++ b/bundles/binding/org.openhab.binding.bticino/src/main/java/com/myhome/fcrisciani/connector/MyHomeJavaConnector.java
@@ -349,6 +349,7 @@ public class MyHomeJavaConnector {
                 retry++;
                 Thread.sleep(1000);
                 logger.warn("Monitor connection problem. Attempting retry {}.", retry);
+                logger.debug("Monitor connection problem. Exception details",e);
                 try {
                     startMonitoring();
                 } catch (IOException e1) {


### PR DESCRIPTION
I've currently this : 

:28:34.894 [WARN ] [isciani.connector.MyHomeJavaConnector] - Monitor connection problem. Attempting retry 6.
18:29:46.170 [WARN ] [isciani.connector.MyHomeJavaConnector] - Monitor connection problem. Attempting retry 1.
18:30:32.228 [WARN ] [isciani.connector.MyHomeJavaConnector] - Monitor connection problem. Attempting retry 2.
18:32:03.577 [WARN ] [isciani.connector.MyHomeJavaConnector] - Monitor connection problem. Attempting retry 1.
18:32:49.635 [WARN ] [isciani.connector.MyHomeJavaConnector] - Monitor connection problem. Attempting retry 2.


Which doesn't seems debuggable with the current code, since the stacktrace is never logged.

I can connect to my F454 server using the MyHome configuration tool using the same IP, Port, Password that I've set in the bticino.cfg and yet, the error keep looping