### PR TITLE
[Garadget] Fix NullPointerException.

### DIFF
--- a/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/Connection.java
+++ b/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/Connection.java
@@ -115,6 +115,10 @@ public class Connection {
                         logger.warn("Unable to parse token response.", e);
                     }
                 }
+                else {
+                    logger.warn("Login failure. Status code = {}", statusCode);
+                    logger.trace("Failure response: {}", responseBody);
+                }
             }
         });
     }
@@ -222,13 +226,25 @@ public class Connection {
                 break;
             case "deleteToken":
                 httpMethod = HTTP_DELETE;
+                if (tokens == null) {
+                    logger.debug("Unable to execute deleteToken command; no tokens exist");
+                    return;
+                }
                 url = String.format(ACCESS_TOKENS_URL, tokens.accessToken);
                 break;
             case "getDevices":
                 httpMethod = HTTP_GET;
+                if (tokens == null) {
+                    logger.debug("Unable to execute getDevices command; no tokens exist");
+                    return;
+                }
                 url = String.format(GET_DEVICES_URL, tokens.accessToken);
                 break;
             default:
+                if (tokens == null) {
+                    logger.debug("Unable to execute {} command; no tokens exist", funcName);
+                    return;
+                }
                 url = String.format(DEVICE_FUNC_URL, device.getId(), funcName, tokens.accessToken);
                 if (command == null) {
                     // retrieve a variable

--- a/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/GaradgetBinding.java
+++ b/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/GaradgetBinding.java
@@ -130,6 +130,9 @@ public class GaradgetBinding extends AbstractActiveBinding<GaradgetBindingProvid
         if (isNotBlank(username) && isNotBlank(password)) {
             connection = new Connection(username, password, timeout);
             connection.login();
+        }
+
+        if (connection.isLoggedIn()) {
             // Poll at the earliest opportunity
             schedulePoll(0);
             setProperlyConfigured(true);


### PR DESCRIPTION
Don't start the polling loop if login fails.
Add a message for login failure.
Also prevent obvious opportunities for null pointer exceptions.

Fixes #5924 