### PR TITLE
[caldav-personal] Filters now allow any character, but require single quotes

### DIFF
--- a/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavBindingProviderImpl.java
+++ b/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavBindingProviderImpl.java
@@ -51,9 +51,9 @@ public class CalDavBindingProviderImpl extends AbstractGenericBindingProvider im
     private static final String REGEX_TYPE = "type:'?([A-Za-z]+)'?";
     private static final String REGEX_EVENT_NR = "eventNr:'?([0-9]+)'?";
     private static final String REGEX_VALUE = "value:'?([A-Za-z]+)'?";
-    private static final String REGEX_FILTER_NAME = "filter-name:'?([A-Za-z\\.\\*\\+\\- \\|]+)'?";
-    private static final String REGEX_FILTER_CATEGORY = "filter-category:'?([A-Za-z-_]+(, ?[A-Za-z-_]+)*)'?";
-    private static final String REGEX_FILTER_CATEGORY_ANY = "filter-category-any:'?([A-Za-z-_]+(, ?[A-Za-z-_]+)*)'?";
+    private static final String REGEX_FILTER_NAME = "filter-name:'([^']+)'";
+    private static final String REGEX_FILTER_CATEGORY = "filter-category:'([^']+)'";
+    private static final String REGEX_FILTER_CATEGORY_ANY = "filter-category-any:'([^']+)'";
 
     private boolean categoriesFiltersAny = false;
 


### PR DESCRIPTION
This change makes single quotes around the filters a requirement, which is what [the documentation already shows](https://www.openhab.org/addons/bindings/caldav-personal1/#filtering). Single quotes inside the filter will stop the matching, so they should be replaced with a period (.) in the Item definition. The benefit of this change is that the characters in the filters no longer have any other limitation. Previously, they were limited, [as discussed in the forum](https://community.openhab.org/t/caldav-personal-regular-expression/84751/13?u=5iver). 

PRs for the documentation are in #5936 and #5937.

Signed-off-by: Scott Rushworth <openhab@5iver.com>