### PR TITLE
Add comment to install transformation service

### DIFF
--- a/bundles/binding/org.openhab.binding.http/README.md
+++ b/bundles/binding/org.openhab.binding.http/README.md
@@ -138,3 +138,9 @@ Number Weather_OutTemp "Value: [%.1f °C]" { http="<[http://weewx/now.json:60000
 ```
 
 [jsonpath.com](http://jsonpath.com/) is a handy tool to create the JSONPATH transformation.
+
+Make sure the transformation used is installed, either via PaperUI (Addons -> Transformations) or by adding an entry to the `addons.cfg` file in `$OPENHAB_CONF/services`, like this:
+
+```
+transformation=jsonpath,javascript,...
+```


### PR DESCRIPTION
It is not always obvious, especially for new users of openHAB, that the transformation services mentioned in the http binding examples must be installed separately.
Added an explanation to the examples for `javascript` and `jsonpath` transformations.

Signed-off-by: Ron Moerman <ron@crazyelectron.io>