### PR TITLE
Safer check in case meter_reset null

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMeterConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMeterConverter.java
@@ -97,7 +97,7 @@ public class ZWaveMeterConverter extends ZWaveCommandClassConverter<ZWaveMeterCo
 
         // we ignore any meter reports for item bindings configured with 'meter_reset=true'
         // since we don't want to be updating the 'reset' switch
-        if ("true".equalsIgnoreCase(arguments.get("meter_reset"))) {
+        if (Boolean.parseBoolean(arguments.get("meter_reset"))) {
             return;
         }
 


### PR DESCRIPTION
Possible null when using `"true".equalsIgnoreCase(arguments.get("meter_reset"))`.
In case it could be null, use `Boolean.parseBoolean(arguments.get("meter_reset"))`