### PR TITLE
Enforce Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ dist: xenial
 
 language: java
 
-jdk:
-  - openjdk8
-  - openjdk11
+jdk: openjdk8
 
 cache:
   directories:
@@ -16,9 +14,6 @@ before_install:
   - echo "MAVEN_OPTS='-Xms1g -Xmx2g'" > ~/.mavenrc
 install:
   - |
-    function extra_maven_opts() {
-        if [ "$TRAVIS_JDK_VERSION" != "openjdk8" ]; then echo "-Denforcer.skip=true"; fi;
-    }
     function prevent_timeout() {
         local i=0
         while [ -e /proc/$1 ]; do
@@ -46,9 +41,5 @@ after_success:
   - print_reactor_summary .build.log
 after_failure:
   - tail -n 2000 .build.log
-env: # required for allowing failures
-matrix:
-  allow_failures:
-    - jdk: openjdk11
 script:
-  - mvnp clean verify -B $(extra_maven_opts)
+  - mvnp clean verify -B

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1273,7 +1273,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>distro-assembly</id>

--- a/distribution/src/assemble/addons.xml
+++ b/distribution/src/assemble/addons.xml
@@ -9,7 +9,7 @@
 
   <files>
     <file>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>.</outputDirectory>
       <source>src/assemble/resources/README_addons.TXT</source>
       <destName>README.TXT</destName>
     </file>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,30 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.8.0-40,1.9)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
   </build>
 
 


### PR DESCRIPTION
The build fails when using newer Java versions and the root cause is not very obvious.

The maven-assembly-plugin has been updated from 2.2 (2011) to resolve an NPE when used with newer versions of the enforcer:

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.2:single (distro-assembly) on project openhab: Execution distro-assembly of goal org.apache.maven.plugins:maven-assembly-plugin:2.2:single failed.: NullPointerException -> [Help 1]`

The `outputDirectory` change is to resolve the following warnings being logged by the newer assembly plugin:

`[WARNING] The assembly descriptor contains a *nix-specific root-relative reference (starting with slash). This is not portable and might fail on Windows: /`

Signed-off-by: Wouter Born <github@maindrain.net>