### PR TITLE
Add inactive badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## openHAB 1 Add-ons
 
+[![Project Status: Inactive – The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](https://www.repostatus.org/badges/latest/inactive.svg)](https://www.repostatus.org/#inactive)
+
 This repository contains add-ons that are using openHAB 1.x APIs.
 Earlier branches of this repo also contain the 1.x runtime and designer, which are no longer maintained.
 


### PR DESCRIPTION
Maybe it would be good idea to have badges showing the maintainance status of our repositories at a glance. https://www.repostatus.org/ offers such badges. If you think this is a good idea, I'd create PRs for all repos.

Signed-off-by: Patrick Fink <mail@pfink.de>