### PR TITLE
The xbee license is actual a GPL not LGPL

### DIFF
--- a/bundles/binding/org.openhab.binding.diyonxbee/NOTICE
+++ b/bundles/binding/org.openhab.binding.diyonxbee/NOTICE
@@ -25,6 +25,6 @@ rxtx
 * Source:  http://rxtx.qbang.org
 
 xbee-api
-* License: LGPL v3.0 License
+* License: GPL v3.0 License
 * Project: https://github.com/andrewrapp/xbee-api
 * Source:  https://github.com/andrewrapp/xbee-api


### PR DESCRIPTION
See https://github.com/andrewrapp/xbee-api/blob/master/COPYING