### PR TITLE
[rrd4j] improvements and extensions to documentation

### DIFF
--- a/bundles/persistence/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/README.md
@@ -55,8 +55,8 @@ The various datasource property values are explained in the table below.
 
 | Property            | Description |
 |---------------------|-------------|
-| `<dsName>`.def      | Definition of what kind of samples are taken and when. The format is `<dsType>,<heartBeat>,<minValue>,<maxValue>,<sampleInterval>` |
-| `<dsName>`.archives | List of archives to be created. Each archive defines which subset of data samples shall be archived, and for how long. Consists of one or more archive entries separated by a ":" character. The format is `<consolidationFunction>,<xff>,<samplesPerBox>,<boxCount>[:<consolidationFunction>,<xff>,<samplesPerBox>,<boxCount>]` |
+| `<dsName>`.def      | Definition of the range of sample values to be taken, and when. The format is `<dsType>,<heartBeat>,<minValue>,<maxValue>,<sampleInterval>` |
+| `<dsName>`.archives | List of archives to be created. Each archive defines which subset of data samples shall be archived, and for how long. Consists of one or more archive entries separated by a ":" character. The format for one archive entry is `<consolidationFunction>,<xff>,<samplesPerBox>,<boxCount>` |
 | `<dsName>`.items    | List of Items whose values shall be sampled and stored in the archive. The format is `Item1,Item2` _**Note: the same Item is not allowed to be listed in more than one datasource!**_ |
 
 For example..

--- a/bundles/persistence/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/README.md
@@ -113,8 +113,11 @@ So if you use (say) the `AVERAGE` function, and two samples of `20.0` and `21.0`
 It must be one of the following strings:
 
 - **AVERAGE** the average of all the samples is stored in the box
-- **MINIMUM** the highest sample is stored in the box
-- **MAXIMUM** the lowest sample is stored in the box
+- **MIN** the highest sample is stored in the box
+- **MAX** the lowest sample is stored in the box
+- **LAST** the last sample is stored in the box
+- **FIRST** the first sample is stored in the box
+- **TOTAL** the sum of all samples is stored in the box
 
 ### `<xff>` (..)
 

--- a/bundles/persistence/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/README.md
@@ -38,7 +38,7 @@ Two things must be done in order for an Item to get persisted:
 1. it must have a persistence strategy defined in the `rrd4j.persist` file.
 2. it must have a `datasource` defined as follows..
 
-# Datasources
+## Datasources
 
 The database comprises at least one datasource.
 The rrd4j service automatically creates one internal _**default**_ datasource for you.

--- a/bundles/persistence/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/README.md
@@ -127,14 +127,14 @@ Nobody seems to know what this parameter is, but its recommended value is 0.5 :)
 
 The number of consecutive data samples that will be consolidated to create a single entry ("storage box") in the database.
 If `<samplesPerBox>` is greater than 1 then the samples will be consolidated into the "storage box" by means of the `<consolidationFunction>` described above.
-The time span covered by a single "storage box" is therfore (`<sampleInterval>` x `<samplesPerBox>`) seconds.
+The time span covered by a single "storage box" is therefore (`<sampleInterval>` x `<samplesPerBox>`) seconds.
 
 It must be a positive integer value.
 
 ### `<boxCount>` (Box Count)
 
 The number of "storage boxes" in the archive.
-The time span covered by a full archive is therfore (`<sampleInterval>` x `<samplesPerBox>` x `<boxCount>`) seconds.
+The time span covered by a full archive is therefore (`<sampleInterval>` x `<samplesPerBox>` x `<boxCount>`) seconds.
 
 It must be a positive integer value.
 

--- a/bundles/persistence/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/README.md
@@ -120,11 +120,10 @@ It must be one of the following strings:
 - **TOTAL** the sum of all samples is stored in the box
 
 All archives of a datasource must use the same `<consolidationFunction>`.
-    
 
-### `<xff>` (..)
+### `<xff>` (X-files Factor)
 
-Defines the maximum allowed proportion of data samples that stored as NaN relative to the set number of `<samplesPerBox>`. In case this proportion is above the set value NaN will be persisted instead of the consolidated value. Using 0.5 would require at least 50 percent of the data samples to hold a value other then NaN.
+Defines the maximum allowed proportion of data samples that are stored as NaN ("Not a Number") relative to the set number of `<samplesPerBox>`. In case this proportion is above the set value, NaN will be persisted instead of the consolidated value. Using 0.5 would require at least 50 percent of the data samples to hold a value other than NaN.
 
 It must be a value between 0 and 1.
 
@@ -156,7 +155,7 @@ ctr24h.archives=AVERAGE,0.5,1,480:AVERAGE,0.5,10,144
 ctr24h.items=Item1,Item2
 ```
 
-The `ctr24.def` defines a datasource which is using a COUNTER, a `<hearBeat>` of 900 seconds, a `<minValue>` of 0, a `<maxValue>` of unlimited  and a `<sampleIntervall>` of 60 seconds.
+The `ctr24.def` defines a datasource which is using a COUNTER, a `<hearBeat>` of 900 seconds, a `<minValue>` of 0, a `<maxValue>` of unlimited  and a `<sampleInterval>` of 60 seconds.
 
 The first archive entry in the `ctr24.archives` parameter has `480` boxes each containing `1` sample (or to be exact the `AVERAGE` of `1` sample).
 So it covers `480 X 60` seconds of data (8 hours) at a granularity of one minute.

--- a/bundles/persistence/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/README.md
@@ -1,102 +1,193 @@
 # rrd4j Persistence
 
-The [rrd4j](https://github.com/rrd4j/rrd4j) Persistence service is based on a round-robin database.
+The [rrd4j](https://github.com/rrd4j/rrd4j) persistence service is based on a round-robin database.
 
-In contrast to a "normal" database such as db4o, a round-robin database does not grow in size - it has a fixed allocated size, which is used. 
+In contrast to a "normal" database such as db4o, a round-robin database does not grow in size - it has a fixed allocated size.
 This is accomplished by saving a fixed amount of datapoints and by doing data compression, which means that the older the data is, the less values are available. 
-The data is kept in several "archives", each holding the data for its set timeframe in the set granularity.
-The start point for all archives is the actually saved datapoint.
-So while you might have a value every minute for the last 8 hours, you might only have one every day for the last year.
+The data is kept in several "archives", each holding the data for its set timeframe at a defined level of granularity.
+The starting point for all archives is the actually saved data sample (Item value).
+So while you might store a sample value every minute for the last 8 hours, you might store the average per day for the last year.
 
-This service cannot be directly queried, because of the data compression. You could not provide precise answers for all questions. 
+This service cannot be directly queried, because of its data compression, which means that it cannot provide precise answers to all queries.
 
 NOTE: rrd4j is for storing numerical data only.
-Attempting to use rrd4j to store complex datatypes (e.g. for restore-on-startup) will not work.
+It cannot store complex data types.
 
-<!-- MarkdownTOC -->
+## Persistence Process
 
-- [Configuration](#configuration)
-    - [Datasource types](#datasource-types)
-    - [Heartbeat, MIN, MAX](#heartbeat-min-max)
-    - [Step\(s\)](#steps)
-    - [Example](#example)
-- [Troubleshooting](#troubleshooting)
+Round-robin databases (RRDs) have fixed length so called "archives" for storing values.
+Think of an archive as a "drawer" with a fixed number of "storage boxes" in it.
 
-<!-- /MarkdownTOC -->
+The persistence service reads data "samples" from the OpenHAB core at regular intervals, and these are then put into the storage boxes.
+Either a) the samples are stored singly directly into a box, or b) multiple samples are consolidated (using a consolidation function) into a box.
+
+The service starts by storing samples in the leftmost box in the drawer.
+Once the leftmost box is full, the service starts filling the next box to the right; and so on.
+Once the rightmost box in the drawer is full, the leftmost box is emptied, the content of all boxes is moved one box to the left, and new content is added to the rightmost box.
+
+So for example..
+
+- Samples are taken at intervals of (say) `60` seconds
+- They are consolidated by (say) the `AVERAGE` function, over (say) `10` samples, into boxes i.e. a box covers `10 X 60` seconds
+- The ful archive contains (say) `250` boxes i.e. the archive/drawer covers `60 X 10 X 250` seconds
 
 ## Configuration
 
-This service can be configured in the file `services/rrd4j.cfg`.
+Two things must be done in order for an Item to get persisted:
 
-| Property | Default | Required | Description |
-|----------|---------|:--------:|-------------|
-| `<dsname>`.def | |        | `<dstype>,<heartbeat>,[<min>\|U],[<max>\|U],<step>`. For example, `COUNTER,900,0,U,300` |
-| `<dsname>`.archives | |        | `<consolidationfunction>,<xff>,<steps>,<rows>`. For example, `AVERAGE,0.5,1,365:AVERAGE,0.5,7,300` |
-| `<dsname>`.items  |     |      | `<list of items for this dsname>`. For example, `Item1,Item2` |
+1. it must have a persistence strategy defined in the `rrd4j.persist` file.
+2. it must have a `datasource` defined as follows..
 
-where:
+# Datasources
 
-- Sections in `[square brackets]` are optional.
-- `<dsname>` is a name you choose for the datasource.
-- See [Datasource types](#datasource-types) for an explanation of `<dstype>`.
-- See [Heartbeat, MIN, MAX](#heartbeat-min-max) for an explanation of `<heartbeat>`, `<min>`, `<max>` and `U`.
-- See [Step\(s\)](#steps) for an explanation of `<step>`, `<consolidationfunction>`, `<xff>`, `<steps>`, and `<rows>`.
-- `<list of items for this dsname>` is explained in
+The database comprises at least one datasource.
+The rrd4j service automatically creates one internal _**default**_ datasource for you.
+Other datasources **may** be configured in addition, in the `services/rrd4j.cfg` file.
 
-Round-robin databases (RRDs) have fixed-length so-called "archives" for storing values. 
-One RRD can have (in general) several datasources and each datasource can have several archives. 
-openHAB only supports one datasource per RRD (i.e. per stored item), which is named DATASOURCE_STATE.
-Multiple configurations (with differing .items settings) can be used (see example below).
+By default, if `services/rrd4j.cfg` does not exist, or if an Item is not explicitly listed in a `<dsName>.items` property value in it, then the respective Item will be persisted according to the [default datasource settings](#default-datasource).
 
-### Datasource types
+By constrast if an Item **is** explicitly listed in a `<dsName>.items` property value, then it will be persisted according to those respective datasource settings.
 
-Depending on the data to be stored, several types for datasources exist:
+Each datasource is defined by three property values (`def`, `archives`, `items`).
+Whereby each `archives` property can comprise settings for one or more archives.
+
+The various datasource property values are explained in the table below.
+
+| Property            | Description |
+|---------------------|-------------|
+| `<dsName>`.def      | Definition of what kind of samples are taken and when. The format is `<dsType>,<heartBeat>,<minValue>,<maxValue>,<sampleInterval>` |
+| `<dsName>`.archives | List of archives to be created. Each archive defines which subset of data samples shall be archived, and for how long. Consists of one or more archive entries separated by a ":" character. The format is `<consolidationFunction>,<xff>,<samplesPerBox>,<boxCount>[:<consolidationFunction>,<xff>,<samplesPerBox>,<boxCount>]` |
+| `<dsName>`.items    | List of Items whose values shall be sampled and stored in the archive. The format is `Item1,Item2` _**Note: the same Item is not allowed to be listed in more than one datasource!**_ |
+
+For example..
+
+```
+ctr24h.def=COUNTER,900,0,U,60
+ctr24h.archives=AVERAGE,0.5,1,480:AVERAGE,0.5,10,144
+ctr24h.items=Item1,Item2
+```
+
+The description of the various datasource property elements is as follows:
+
+### `<dsName>` (Datasource Name)
+
+The name of the datasource.
+It must be an alphanumeric string.
+
+### `<dsType>` (Datasource Type)
+
+Defines the type of data to be stored.
+It must be one of the following string values:
 
 - **COUNTER** represents a ever-incrementing value (historically this was used for packet counters or traffic counters on network interfaces, a typical home-automation application would be your electricity meter). If you store the values of this counter in a simple database and make a chart of that, you'll most likely see a nearly flat line, because the increments per time are small compared to the absolute value (e.g. your electricity meter reads 60567 kWh, and you add 0.5 kWh per hour, than your chart over the whole day will show 60567 at the start and 60579 at the end of your chart. That is nearly invisible. RRD4J helps you out and will display the difference from one stored value to the other (depending on the selected size). Please note that the persistence extensions will return difference instead of the actual values if you use this type; this especially leads to wrong values if you try to restoreOnStartup!
 - **GAUGE** represents the reading of e.g. a temperature sensor. You'll see only small deviation over the day and your values will be within a small range, clearly visible within a chart.
 - **ABSOLUTE** is like a counter, but RRD4J assumes that the counter is reset when the value is read. So these are basically the delta values between the reads.
 - **DERIVE** is like a counter, but it can also decrease and therefore have a negative delta.
 
-### Heartbeat, MIN, MAX
+### `<heartBeat>` (Heart Beat)
 
-Each datasource also has a value for heartbeat, minimum and maximum. This heartbeat setting helps the database to detect "missing" values, i.e. if no new value is stored after "heartbeat" seconds, the value is considered missing when charting. Minimum and maximum define the range of acceptable values for that datasource.
+The heartbeat parameter helps the database to detect missing values.
+i.e. if no new value is stored after "heartBeat" seconds, the value is considered missing when charting.
 
-### Step(s)
+It must be a positive integer value.
 
-Step (set in `.def=<dstype>,<heartbeat>,[<min>|U],[<max>|U],<step>` with step in seconds)
+### `<minValue> / <maxValue>` (Minimum resp. Maximum Value)
 
-Sets the time interval (seconds) between consecutive readings.
+These parameters define the range of acceptable sample values for that datasource.
+They must be either:
 
-- Steps or Granularity (set in `.archives=<consolidationfunction>,<xff>,<steps>,<rows>`
+- A numeric value, or
+- The letter "U" (unlimited)
 
-Steps are the number of consecutive readings that are used the create a single entry into the database for this time interval.
-The time interval covered is calculated by (step x steps) seconds.
+### `<sampleInterval>` (Sample Interval)
 
-Now for the archives: As already said, each datasource can have several archives.
-Think of an archive as a drawer with a fixed number of boxes in it.
-Each (step x steps) seconds (the step is globally defined for the RRD, 60s in our example) the leftmost box is emptied, the content of all boxes is moved one box to the left and new content is added to the rightmost box.
-The "steps" value is defined per archive it is the third parameter in the archive definition.
-The number of boxes is defined as the fourth parameter.
+The time interval (seconds) between reading consecutive samples from the OpenHAB core.
 
-The purpose to have several archives is raised if a different granularity is needed while displaying data for different timespans.
-In the example below data for each minute are saved for the last 8 hours (granularity 1), looking at the last 24 hours a granularity of 10 (i.e. 10 readings are consolidated to one reading) is used and so forth.
-For the first archive (and maybe the only one) a steps-size of one should be used.
-This way a sample is taken after each step.
-  
-### Example
+It must be a positive integer value.
 
-So in the example shown below, we have 480 boxes, which each represent the value of one minute (Step is set to 60s, Granularity = 1).
-If more than one value is added to the database within (step x steps) seconds (and thus more than one value would be stored in one box), the "consolidation function" is used.
-openHAB uses AVERAGE as default for numeric values, so if you add 20 and 21 within one minute, 20.5 would be stored.
-480 minutes is 8 hours, so we have a 8h with the granularity of one minute.
+### `<consolidationFunction>` (Consolidation Function)
 
-The next archive has 144 boxes, which each represent the value of ten minutes (Step is set to 60s, Granularity = 10).
-1440 minutes is 24 hours, so we have a full day with the granularity of 10 minutes.
+Determines the type of data compression to be used when more than one sample is to be stored in a single "storage box".
+So if you use (say) the `AVERAGE` function, and two samples of `20.0` and `21.0` are to be stored, then the value `20.5` would be stored in the box.
 
-The same goes for following archives, for larger time spans, the stored values are less "exact". 
-However, usually you are not interested in the exact values for a selected minute some time ago.
+It must be one of the following strings:
 
-services/rrd4j.cfg:
+- **AVERAGE** the average of all the samples is stored in the box
+- **MINIMUM** the highest sample is stored in the box
+- **MAXIMUM** the lowest sample is stored in the box
+
+### `<xff>` (..)
+
+Nobody seems to know what this parameter is, but its recommended value is 0.5 :)
+
+### `<samplesPerBox>` (Samples Per Box)
+
+The number of consecutive data samples that will be consolidated to create a single entry ("storage box") in the database.
+If `<samplesPerBox>` is greater than 1 then the samples will be consolidated into the "storage box" by means of the `<consolidationFunction>` described above.
+The time span covered by a single "storage box" is therfore (`<sampleInterval>` x `<samplesPerBox>`) seconds.
+
+It must be a positive integer value.
+
+### `<boxCount>` (Box Count)
+
+The number of "storage boxes" in the archive.
+The time span covered by a full archive is therfore (`<sampleInterval>` x `<samplesPerBox>` x `<boxCount>`) seconds.
+
+It must be a positive integer value.
+
+### Multiple Possible Archives
+
+As already said, each datasource can have one or more archives.
+The purpose of having several archives is that it allows a different granularity of data storage over different timespans.
+
+In the example below..
+
+```
+ctr24h.def=COUNTER,900,0,U,60
+ctr24h.archives=AVERAGE,0.5,1,480:AVERAGE,0.5,10,144
+ctr24h.items=Item1,Item2
+```
+
+The `ctr24.def` parameter means that samples are taken at `60` seconds intervals.
+
+The first archive entry in the `ctr24.archives` parameter has `480` boxes each containing `1` sample (or to be exact the `AVERAGE` of `1` sample).
+So it covers `480 X 60` seconds of data (8 hours) at a granularity of one minute.
+As a general rule the first archive (and maybe the only one) should have `<samplesPerBox> = 1` so that each sample is stored in one box.
+
+And the second archive entry has `144` boxes each containing the `AVERAGE` of `10` samples.
+So it covers `144 X 10 X 60` seconds of data (24 hours) at a granularity of ten minutes.
+
+## Default Datasource
+
+The service always automatically creates an internal default datasource with the properties below.
+
+```
+defaultNumeric.def=GAUGE,60,U,U,60
+defaultNumeric.archives=AVERAGE,0.5,1,480:AVERAGE,0.5,4,360:AVERAGE,0.5,14,644:AVERAGE,0.5,60,720:AVERAGE,0.5,720,730:AVERAGE,0.5,10080,520
+```
+
+The default datasource type is GAUGE, the heartbeat is 60s, minimum and maximum values are unlimited, and the sample interval is 60s.
+
+The default archives are:
+
+| Archive | Boxes | Samples per Box | Period covered |
+|:---------:|:---------:|:--------:|:-------------:|
+| 1 | 480 | 1 | 8 hrs |
+| 2 | 360 | 4 | 24 hrs |
+| 3 | 644 | 14 | 6.26 days |
+| 4 | 720 | 60 | 30 days |
+| 5 | 730 | 720 | 365 days |
+| 6 | 520 | 10080 | 10 years |
+
+There is no `.items` parameter for the default datasource.
+Implicitly this means that any Item with an allocated strategy in the `rrd4j.persist` file will be persisted using the above-mentioned default settings -
+_**exception**:_ the Item is explicitly listed in the `.items` property value of a datasource in the `rrd4j.cfg` file.
+
+---
+
+## Examples
+
+### `rrd4j.cfg` file
 
 ```
 ctr24h.def=COUNTER,900,0,U,60
@@ -106,34 +197,8 @@ ctr7d.def=COUNTER,900,0,U,60
 ctr7d.archives=AVERAGE,0.5,1,480:AVERAGE,0.5,10,144:AVERAGE,0.5,60,672
 ctr7d.items=Item3,Item4
 ```
-In case no rrd4j.cfg is created the following default configuration will be used for all items persisted (i.e. all items with an allocated strategy in the rrd4j.persist file).
 
-Default rrd4j.cfg
-
-```
-defaultNumeric.def=GAUGE,60,U,U,60
-defaultNumeric.archives=AVERAGE,0.5,1,480:AVERAGE,0.5,4,360:AVERAGE,0.5,14,644:AVERAGE,0.5,60,720:AVERAGE,0.5,720,730:AVERAGE,0.5,10080,520
-```
-The Datasource type is GAUGE, the heartbeat is 60s, MIN and MAX are unlimited and the step size is 60s.
-The archives are:
-
-| Archive | Boxes | Granularity [min] | Period covered |
-|:---------:|:---------:|:--------:|:-------------:|
-| 1 | 480 | 1 | 8 hrs |
-| 2 | 360 | 4 | 24 hrs |
-| 3 | 644 | 14 | 6.26 days |
-| 4 | 720 | 60 | 30 days |
-| 5 | 730 | 720 | 365 days |
-| 6 | 520 | 10080 | 10 years |
-
-All item- and event-related configuration is done in the file `persistence/rrd4j.persist`, i.e. openHAB will persist items that are setup in this file with a strategy. 
-
-**IMPORTANT**
-
-The strategy `everyMinute` (60 seconds) **MUST** be used, otherwise no data will be persisted (stored).
-Other strategies can be used too.
-
-rrd4j.persist:
+### `rrd4j.persist` file:
 
 ```java
 Strategies {
@@ -147,8 +212,14 @@ Items {
 }
 ```
 
+**IMPORTANT:**
+The strategy `everyMinute` (60 seconds) **must** be used, otherwise no data will be persisted (stored).
+Other strategies can be used too.
+
+---
+
 ## Troubleshooting
 
-From time to time, you may find that if you change the item type of a persisted data, you may experience charting or other problems. To resolve this issue, remove the old `<item_name>`.rrd file in the `${openhab_home}/etc/rrd4j` folder or `/var/lib/openhab/persistence/rrd4j` folder for apt-get installed openHABs.
+From time to time, you may find that if you change the Item type of a persisted data point, you may experience charting or other problems. To resolve this issue, remove the old `<item_name>`.rrd file in the `${openhab_home}/etc/rrd4j` folder or `/var/lib/openhab/persistence/rrd4j` folder for apt-get installed openHABs.
 
-Restore of items after startup is taking some time. Rules are already started in parallel. Especially in rules that are started via "System started" trigger, it may happen that the restore is not completed resulting in defined items. In these cases the use of restored items has to be delayed by a couple of seconds. This delay has to be determined experimentally.
+Restoring Item values after startup takes some time. Rules may already have started to run in parallel. Especially in rules that are started via the "System started" trigger, it may happen that the restore has not yet completed resulting in non-defined Item values. In these cases the use of restored Item values should be delayed by a couple of seconds. This delay has to be determined experimentally.

--- a/bundles/persistence/org.openhab.persistence.rrd4j/README.md
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/README.md
@@ -25,11 +25,12 @@ The service starts by storing samples in the leftmost box in the drawer.
 Once the leftmost box is full, the service starts filling the next box to the right; and so on.
 Once the rightmost box in the drawer is full, the leftmost box is emptied, the content of all boxes is moved one box to the left, and new content is added to the rightmost box.
 
-So for example..
+An example is shown below.
+Whereby the values indicated in the example may vary as chosen by the user..
 
-- Samples are taken at intervals of (say) `60` seconds
-- They are consolidated by (say) the `AVERAGE` function, over (say) `10` samples, into boxes i.e. a box covers `10 X 60` seconds
-- The ful archive contains (say) `250` boxes i.e. the archive/drawer covers `60 X 10 X 250` seconds
+- Samples are taken at intervals of `60` seconds
+- They are consolidated by the `AVERAGE` function, over `10` samples, into boxes i.e. a box covers `10 X 60` seconds
+- The full archive contains `250` boxes i.e. the archive/drawer covers `60 X 10 X 250` seconds
 
 ## Configuration
 
@@ -108,13 +109,13 @@ It must be a positive integer value.
 ### `<consolidationFunction>` (Consolidation Function)
 
 Determines the type of data compression to be used when more than one sample is to be stored in a single "storage box".
-So if you use (say) the `AVERAGE` function, and two samples of `20.0` and `21.0` are to be stored, then the value `20.5` would be stored in the box.
+So if you use the `AVERAGE` function, and two samples of `20.0` and `21.0` are to be stored, then the value `20.5` would be stored in the box.
 
 It must be one of the following strings:
 
 - **AVERAGE** the average of all the samples is stored in the box
-- **MIN** the highest sample is stored in the box
-- **MAX** the lowest sample is stored in the box
+- **MIN** the lowest sample is stored in the box
+- **MAX** the highest sample is stored in the box
 - **LAST** the last sample is stored in the box
 - **FIRST** the first sample is stored in the box
 - **TOTAL** the sum of all samples is stored in the box

--- a/features/openhab-addons-external/src/main/resources/conf/rrd4j.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/rrd4j.cfg
@@ -7,4 +7,4 @@
 
 #<dsName>.def=[ABSOLUTE|COUNTER|DERIVE|GAUGE],<heartBeat>,[<minValue>|U],[<maxValue>|U],<sampleInterval>
 #<dsName>.archives=[AVERAGE|MIN|MAX|LAST|FIRST|TOTAL],<xff>,<samplesPerBox>,<boxCount>
-#<dsName>.items=<comma separated list of items for this defname>
+#<dsName>.items=<comma separated list of items for this dsName>

--- a/features/openhab-addons-external/src/main/resources/conf/rrd4j.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/rrd4j.cfg
@@ -5,6 +5,6 @@
 # default_numeric and default_other are internally defined defnames and are used as
 # defaults when no other defname applies
 
-#<defname>.def=[ABSOLUTE|COUNTER|DERIVE|GAUGE],<heartbeat>,[<min>|U],[<max>|U],<step>
-#<defname>.archives=[AVERAGE|MIN|MAX|LAST|FIRST|TOTAL],<xff>,<steps>,<rows>
-#<defname>.items=<comma separated list of items for this defname> 
+#<dsName>.def=[ABSOLUTE|COUNTER|DERIVE|GAUGE],<heartBeat>,[<minValue>|U],[<maxValue>|U],<sampleInterval>
+#<dsName>.archives=[AVERAGE|MIN|MAX|LAST|FIRST|TOTAL],<xff>,<samplesPerBox>,<boxCount>
+#<dsName>.items=<comma separated list of items for this defname>


### PR DESCRIPTION
When I tried to set up rrd4j persistence on my own system, I found the `rrd4j` `ReadMe.md` documentation in general very hard to understand, and in particular missing some specific information.

Very kindly @JueBag helped me to solve it -- thank you!

So, based on our common learning, this PR contains improvements and extensions to the `ReadMe.md` file (it also contains a small change in the `.cfg` sample file in which the parameter names have been changed to match the documentation).