### PR TITLE
Added link to relevant binding

### DIFF
--- a/bundles/action/org.openhab.action.mqtt/README.md
+++ b/bundles/action/org.openhab.action.mqtt/README.md
@@ -4,7 +4,7 @@ Publish a message to a topic on an MQTT broker.
 
 ## Prerequisites
 
-In addition to the MQTT Action service, the MQTT binding (1.x) must be installed and configured.  The action can reference the broker(s) that are configured for the MQTT binding.
+In addition to the MQTT Action service, the [MQTT binding (1.x)](https://www.openhab.org/addons/bindings/mqtt/) must be installed and configured.  The action can reference the broker(s) that are configured for the MQTT binding.
 
 ## Action
 


### PR DESCRIPTION
Added a link to this fully qualified address:  https://www.openhab.org/addons/bindings/mqtt/
A relative link may be preferable, but I was unable to test my guess at what the correct relative path would be from https://www.openhab.org/addons/actions/mqtt/